### PR TITLE
Removing note as the package has been unlisted

### DIFF
--- a/docs/Schema/nuspec.md
+++ b/docs/Schema/nuspec.md
@@ -45,9 +45,6 @@ In this topic:
 
 The current `nuspec.xsd` schema file can be found in the [NuGet GitHub repository](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd).
 
-> [!NOTE]
-> On nuget.org you can find a NuGet.Manifest.Schema 2.0.4 package. However, the schema files contained within it are older versions applicable to NuGet 2.0 and earlier. The most up-to-date schema file is best obtained from the GitHub repository.
-
 Within this schema, a `.nuspec` file has the following general form:
 
     <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Not sure if we should still call out the package, as users can't find it anymore unless already installed. The package has been unlisted.