### PR TITLE
Hosting-Packages: Link of text "NuGet Gallery Project" adjusted

### DIFF
--- a/docs/Hosting-Packages/Overview.md
+++ b/docs/Hosting-Packages/Overview.md
@@ -36,7 +36,7 @@ For all such purposes, NuGet supports setting up a private package source in the
 
 - Local feed: Packages are simply placed on a suitable network file share, ideally using `nuget init` and `nuget add` to create a hierarchical folder structure (NuGet 3.3+). For details, see [Local Feeds](../hosting-packages/local-feeds.md).
 - NuGet.Server: Packages are made available through a local server through HTTP. For details, see [NuGet.Server](../hosting-packages/NuGet-Server.md).
-- NuGet Gallery: Packages are hosted on an Internet server using the [NuGet Gallery Project](https://github.com/NuGet/NuGetGallery/wiki/Hosting-the-NuGet-Gallery-Locally-in-IIS) on GitHub. NuGet Gallery provides user management and additional features such as an extensive web UI that allows searching and exploring packages from within the browser, similar to nuget.org.
+- NuGet Gallery: Packages are hosted on an Internet server using the [NuGet Gallery Project](https://github.com/NuGet/NuGetGallery#build-and-run-the-gallery-in-arbitrary-number-easy-steps) on GitHub. NuGet Gallery provides user management and additional features such as an extensive web UI that allows searching and exploring packages from within the browser, similar to nuget.org.
 
 There are also several other NuGet hosting products that support remote private feeds, including the following:
 


### PR DESCRIPTION
File: Overview.md (Hosting-Packages)

Link of text "NuGet Gallery Project" adjusted according to the recommendation of the [previous linked nuget website](https://github.com/NuGet/NuGetGallery/wiki/Hosting-the-NuGet-Gallery-Locally-in-IIS).

Personally, I prefer the [new site](https://github.com/NuGet/NuGetGallery#build-and-run-the-gallery-in-arbitrary-number-easy-steps) instead of the [old one](https://github.com/NuGet/NuGetGallery/wiki/Hosting-the-NuGet-Gallery-Locally-in-IIS)

### Reason for the new link
* Better structured page
* More links to other helpful websites

They will improve the documentation in the [backlog item #3462](https://github.com/NuGet/NuGetGallery/issues/3462)