### PR TITLE
Add missing attribute

### DIFF
--- a/docs/Schema/nuspec.md
+++ b/docs/Schema/nuspec.md
@@ -604,7 +604,7 @@ Empty folders can use `.` to opt out of providing content for certain combinatio
     <authors>Microsoft</authors>
     <dependencies>
         <dependency id="another-package" version="3.0.0" />
-        <dependency id="yet-another-package"/>
+        <dependency id="yet-another-package" version="1.0.0" />
     </dependencies>
     </metadata>
 </package>


### PR DESCRIPTION
The following line from the "A .nuspec with dependencies" example...
`<dependency id="yet-another-package"/>
`
appears to conflict with this from further up the page:

> The attributes for each <dependency> are as follows:...  version(Required) 


I therefore added a version attribute to that line in the example.