### PR TITLE
Fix formatting of list.

### DIFF
--- a/docs/Consume-Packages/Package-Restore.md
+++ b/docs/Consume-Packages/Package-Restore.md
@@ -191,10 +191,10 @@ The process is as follows:
 
 1. Close Visual Studio to avoid file potential file locks and conflicts.
 1. If using TFS:
-    a. Remove `nuget.exe` and `nuget.targets` from the solution's `.nuget` folder and remove those files from the solution workspace.
-    a. Retain `nuget.config` with the `disableSourceControlIntegration` setting as explained in [Omitting packages with Team Foundation Version Control](../consume-packages/packages-and-source-control.md#omitting-packages-with-team-foundation-version-control).
+    1. Remove `nuget.exe` and `nuget.targets` from the solution's `.nuget` folder and remove those files from the solution workspace.
+    1. Retain `nuget.config` with the `disableSourceControlIntegration` setting as explained in [Omitting packages with Team Foundation Version Control](../consume-packages/packages-and-source-control.md#omitting-packages-with-team-foundation-version-control).
 1. If not using TFS:
-    a. Remove the `.nuget` folder from the solution and the solution workspace.
+    1. Remove the `.nuget` folder from the solution and the solution workspace.
 1. Edit each project file in the solution, remove the `&lt;RestorePackages&gt;` element, and remove any references to the `nuget.targets` file. Those settings generally appear as follows:
 
     ```xml


### PR DESCRIPTION
In the "Migrating to automatic restore" section, there is a list within an list. It does not render properly on Github or [on the website](https://docs.microsoft.com/en-us/nuget/consume-packages/package-restore#migrating-to-automatic-restore).

It is like this in the source:
```
1. point 1
    a. subpoint a
```

However in HTML, it is rendered as:
```html
<li>point1 a. subpoint a</li>
```

My fix is to switch the sub list to a numbered list. I think that lettered lists might not be supported by Markdown, since CommonMark [does not have them yet](https://talk.commonmark.org/t/letter-ordered-lists/173/17). And [GitHub Flavored Markdown](https://github.github.com/gfm/#list-items) is based on CommonMark, so that at least explains why it does not render nicely on GitHub.