### PR TITLE
Pre-release version tip.

### DIFF
--- a/docs/Guides/Create-Cross-Platform-Packages.md
+++ b/docs/Guides/Create-Cross-Platform-Packages.md
@@ -148,6 +148,9 @@ nuget spec
         </metadata>
     </package>
     ```
+    
+> [!Tip]
+> You can suffix your package version with `-alpha`, `-beta` or `-rc` to mark your package as pre-release, check [Pre-release versions](../create-packages/prerelease-packages.md) for more information about pre-release versions.
 
 ### Add reference assemblies
 


### PR DESCRIPTION
I've added a tip on how to mark the package as pre-release right after the "Create and update the .nuspec file" section..