### PR TITLE
.csproj is not needed when reinstalling all packages for a specific proj

### DIFF
--- a/docs/Consume-Packages/Reinstalling-and-Updating-Packages.md
+++ b/docs/Consume-Packages/Reinstalling-and-Updating-Packages.md
@@ -49,7 +49,7 @@ Update-Package <package_name>
 To update all packages in a specific project, use the `-ProjectName` argument:
 
 ```ps
-Update-Package -ProjectName application-project.csproj
+Update-Package -ProjectName <application-project-name>
 ```
 
 Using `Update-Package` by itself, with no other arguments, will update all packages in all projects in the current folder. See the [Update-Package command](../Tools/ps-ref-update-package.md) reference for complete usage details.


### PR DESCRIPTION
I'm using VS 2017 + NuGet 4.0.0, not sure for what version is this true