### PR TITLE
Update msbuild-targets.md

### DIFF
--- a/docs/Schema/msbuild-targets.md
+++ b/docs/Schema/msbuild-targets.md
@@ -50,7 +50,7 @@ Because `pack` and `restore` are  MSBuild targets, you can access them to enhanc
 ```xml
 <Target Name="CopyPackage" AfterTargets="Pack">
     <Copy
-        SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg"
+        SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg"
         DestinationFolder="\\myshare\packageshare\"
         />
 </Target>


### PR DESCRIPTION
Added two dots to the path for the .nupkg file.
$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg
This is because $(OutputPath) for a .Net Standard class library is set in the .csproj file by default to bin\Release\netstandard1.6\\
(Note the trailing backslash char also, no need to add an extra backslash, just the two dots.)
Therefore, you need to navigate up one level to get to bin\Release\\*.nupkg