### PR TITLE
Change global cache to global packages folder

### DIFF
--- a/docs/Consume-Packages/Managing-the-NuGet-Cache.md
+++ b/docs/Consume-Packages/Managing-the-NuGet-Cache.md
@@ -42,7 +42,7 @@ Typical output is as follows:
 
     http-cache: C:\Users\user\AppData\Local\NuGet\v3-cache   #NuGet 3.x+ cache
     packages-cache: C:\Users\user\AppData\Local\NuGet\Cache  #NuGet 2.x cache
-    global-packages: C:\Users\user\.nuget\packages\          #Global cache
+    global-packages: C:\Users\user\.nuget\packages\          #Global packages folder
     temp: C:\Users\user\AppData\Local\Temp\NuGetScratch      #Temp folder
 
 If you encounter package installation problems or otherwise want to ensure that you're installing packages from a remote gallery, use the `locals -clear` option:
@@ -50,7 +50,7 @@ If you encounter package installation problems or otherwise want to ensure that 
 ```
 nuget locals http-cache -clear        #Clear the 3.x+ cache
 nuget locals packages-cache -clear    #Clear the 2.x cache
-nuget locals global-packages -clear   #Clear the global cache
+nuget locals global-packages -clear   #Clear the global packages folder
 nuget locals temp -clear              #Clear the temporary cache
 nuget locals all -clear               #Clear all caches
 ```


### PR DESCRIPTION
The global packages folder is not a global packages cache.
It's actually the install location for transitive project systems. 

It's basically treated as a source when restoring. 

More info the discussion here:
https://twitter.com/emgarten/status/887793207689400320 /cc @emgarten 
Please correct me if something's not clear enough. 
&
https://twitter.com/DamianEdwards/status/887799949114580993

We should probably have some documentation for the "global packages folder" specifically...what it is and how it behaves. 
//cc @kraigb @anangaur @rrelyea 

EDIT:
I've created an issue to add more info about the global packages folder
https://github.com/NuGet/docs.microsoft.com-nuget/issues/406