### PR TITLE
Avoid defining `<PackageId>` in .targets

### DIFF
--- a/docs/Guides/Create-UWP-Controls.md
+++ b/docs/Guides/Create-UWP-Controls.md
@@ -134,9 +134,8 @@ Here is an example of what the targets file should look like:
     <PropertyGroup>
       <RequiredTPMinV>10.0.14393</RequiredTPMinV>
       <ActualTPMinV>$(TargetPlatformMinVersion)</ActualTPMinV>
-      <PackageId>ManagedPackage</PackageId>
     </PropertyGroup>
-    <Error Condition=" '$([System.Version]::Parse($(ActualTPMinV)).CompareTo($([System.Version]::Parse($(RequiredTPMinV)))))' == '-1' " 	   Text = "The $(PackageId) nuget package cannot be used in the $(MSBuildProjectName) project since the project's TargetPlatformMinVersion - $(ActualTPMinV) does not match the Minimum Version - $(RequiredTPMinV) supported by the package" />
+    <Error Condition=" '$([System.Version]::Parse($(ActualTPMinV)).CompareTo($([System.Version]::Parse($(RequiredTPMinV)))))' == '-1' " 	   Text = "The INSERT_PACKAGE_ID_HERE nuget package cannot be used in the $(MSBuildProjectName) project since the project's TargetPlatformMinVersion - $(ActualTPMinV) does not match the Minimum Version - $(RequiredTPMinV) supported by the package" />
   </Target>
 </Project>
 ```


### PR DESCRIPTION
Defining `<PackageId>` breaks the new .csproj format, because this example would override whatever package ID you define yourself in your project that might be referencing this package.
https://twitter.com/dotMorten/status/913855944890531840