### PR TITLE
Correct Nuget installation instructions

### DIFF
--- a/docs/Create-Packages/Creating-a-Package.md
+++ b/docs/Create-Packages/Creating-a-Package.md
@@ -23,7 +23,7 @@ ms.reviewer:
 ---
 # Creating NuGet packages
 
-No matter what your package does or what code it contains, you use `nuget.exe` to package that functionality into a component that can be shared with and used by any number of other developers. To install `nuget.exe`, see [Install NuGet CLI](../guides/Install-NuGet.md#nuget-cli). Note that Visual Studio does not automatically include `nuget.exe`.
+No matter what your package does or what code it contains, you use `nuget.exe` to package that functionality into a component that can be shared with and used by any number of other developers. To install `nuget.exe`, see [Install NuGet CLI](../guides/Install-NuGet.md#nuget-cli). Note that Visual Studio 2015 and below does not automatically include `nuget.exe`.
 
 Technically speaking, a NuGet package is just a ZIP file that's been renamed with the `.nupkg` extension and whose contents match certain conventions. This topic describes the detailed process of creating a package that meets those conventions. For a focused walkthrough, refer to [Create and Publish a Package Quickstart](../quickstart/create-and-publish-a-package.md).
 


### PR DESCRIPTION
The first paragraph in the title `Creating Nuget Packages` tells us how we need to download Nuget manually but that is not required if you have Visual Studio 2017 installed since it installs 4.x by default as mentioned on Nuget's download page: `https://www.nuget.org/downloads`