### PR TITLE
Specify `nuget restore -Source` args must be urls

### DIFF
--- a/docs/Tools/nuget-exe-CLI-Reference.md
+++ b/docs/Tools/nuget-exe-CLI-Reference.md
@@ -598,7 +598,7 @@ where `<projectPath>` specifies the location of a solution, a `packages.config` 
 | Recursive | *(4.0+)* Restores all references projects for UWP and .NET Core projects. Does not apply to projects using `packages.config`. |
 | RequireConsent | Verifies that restoring packages is enabled before downloading and installing the packages. For details, see [Package Restore](../consume-packages/package-restore.md). |
 | SolutionDirectory | Specifies the solution folder. Not valid when restoring packages for a solution. |
-| Source | Specifies list of package sources to use for the restore. |
+| Source | Specifies list of package sources (as URLS) to use for the restore. |
 | Verbosity |>Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed (2.5+)*. |
 
 ### Remarks


### PR DESCRIPTION
I spent a good deal of time being confused about this [1].
This should be updated once #5849 [2] is closed.

[1] https://github.com/NuGet/Home/issues/6024
[2] https://github.com/NuGet/Home/issues/5849