### PR TITLE
Update Package-Restore.md

### DIFF
--- a/docs/Consume-Packages/Package-Restore.md
+++ b/docs/Consume-Packages/Package-Restore.md
@@ -21,7 +21,7 @@ ms.reviewer:
 
 ---
 
-# Installing and reinstalling packages with package restore
+# Package Restore
 
 To promote a cleaner development environment and to reduce repository size, NuGet **Package Restore** installs all referenced packages before a project is built. This widely-used feature ensures that all dependencies are available in a project without requiring those packages to be stored in source control (see [Packages and Source Control](../consume-packages/packages-and-source-control.md) on how to configure your repository to exclude package binaries).
 

--- a/docs/Consume-Packages/Package-Restore.md
+++ b/docs/Consume-Packages/Package-Restore.md
@@ -69,7 +69,6 @@ From the command line or [Package Manager Console](../tools/Package-Manager-Cons
 | `nuget restore` | All versions of NuGet and all reference types. See [Command-line restore](#command-line-restore) below. | 
 | `dotnet restore` | Same as `nuget restore` for .NET Core projects. See [dotnet restore](https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-restore). |
 | `msbuild /t:restore` | Nuget 4.x+ and MSBuild 15.1+ with [package references in project files](../Consume-Packages/Package-References-in-Project-Files.md) only. `nuget restore` and `dotnet restore` both use this command for applicable projects. See [NuGet pack and restore as MSBuild targets- restore target](../schema/msbuild-targets.md#restore-target).|
-| `Update-Package -reinstall -ProjectName <project>` | Restores a project's packages from the Package Manager Console. See [Update-Package reference](../tools/ps-ref-update-package.md). | 
 
 Visual Studio itself also restores packages at different times:
 
@@ -80,17 +79,13 @@ Visual Studio itself also restores packages at different times:
 | Solution restore | When user right-clicks a solution and selects **Restore NuGet Packages**. |
 | Restore on project change | *(NuGet 4.x only)* When a .NET Core SDK-based project is used, including when project state changes. |
 
-See [Automatic restore in Visual Studio](#automatic-restore-in-visual-studio) below for more details.
-
 ## Enabling and disabling package restore
-
-Automatic restore and command-line restore is enabled by default with NuGet 2.7+. MSBuild-integrated restore and command-line restore is **not** enabled by default for NuGet 2.6 and earlier and must be enabled manually.
 
 Package restore is primarily enabled through **Tools > Options > NuGet Package Manager** in Visual Studio:
 
 ![Controlling package restore behaviors through NuGet Package Manager options](media/Restore-01-AutoRestoreOptions.png)
 
-- **Allow NuGet to download missing packages**: controls all forms of package restore by changing the `packageRestore/enabled` setting in the `%AppData%\NuGet\NuGet.Config` file as shown below. (For NuGet 2.6 or earlier, this setting can also be used in a project-specific `.nuget\Nuget.Config` file.)
+- **Allow NuGet to download missing packages**: controls all forms of package restore by changing the `packageRestore/enabled` setting in the `%AppData%\NuGet\NuGet.Config` file as shown below.
 
     ```xml
     <configuration>
@@ -122,8 +117,6 @@ Package restore is primarily enabled through **Tools > Options > NuGet Package M
 
 For reference, see the [NuGet config file - packageRestore section](../Schema/nuget-config-file.md#packagerestore-section).
 
-MSBuild-integrated restore with NuGet 2.6 and earlier is typically enabled by right-clicking a solution in Visual Studio and selecting **Enable NuGet Package Restore**. This sets up the necessary files and folders for this option to work, as explained under [MSBuild-integrated restore in Visual Studio](#msbuild-integrated-restore).
-
 In some cases, a developer or company might want to enable or disable package restore on a machine by default for all users. This can be done by adding the same settings above to the global NuGet configuration file located in `%ProgramData%\NuGet\Config[\{IDE}[\{Version}[\{SKU}]]]`. Individual users can then selectively enable restore as needed on a project level. See [Configuring NuGet Behavior](../consume-packages/configuring-nuget-behavior.md#how-settings-are-applied) for exact details on how NuGet prioritizes multiple config files.
 
 ## Constraining package versions with restore
@@ -152,8 +145,6 @@ In all cases, use the notation described in [Package versioning](../reference/pa
 
 ## Command-line restore
 
-For NuGet 2.6 and earlier, you use the [Install](../tools/cli-ref-install.md) command and point to the `packages.config` file that lists all the dependencies.
-
 For NuGet 2.7 and above, use the [Restore](../tools/cli-ref-restore.md) command to restore all packages in a solution (whether it uses `packages.config`, `project.json`, or package references in project files). For a given project folder such as `c:\proj\app`, the common variations below each restore the packages:
 
 ```
@@ -164,112 +155,19 @@ c:\proj\> nuget restore app
 
 For NuGet 4.0+ and MSBuild 15.1+, you can also use `MSBuild /t:restore` as described on [NuGet pack and restore as MSBuild targets](../schema/msbuild-targets.md).
 
-In the [Package Manager Console](../tools/Package-Manager-Console.md) you can use the [`Update-Package`](../tools/ps-ref-update-package.md) command:
+## Build-time restore in Visual Studio
 
-```ps
-# Restore packages for a project
-Update-Package -reinstall -ProjectName <project>
-
-# Restore packages for all projects in the solution
-Update-Package -reinstall
-```
-
-Note that the `-reinstall` argument is what specifically instructs `Update-Package` to restore packages to their currently installed versions rather than updating any of those versions.
-
-## Automatic restore in Visual Studio
-
-With NuGet 2.7 and later, Visual Studio automatically restores missing packages by default at the beginning of a build. This behavior can be changed by clearing **Tools > Options > [NuGet] Package Manager > General > Automatically check for missing packages during build in Visual Studio**.
-
-Automatic restore is also ignored if a `.nuget\NuGet.targets` file exists in a project, indicating that the project is configured for MSBuild-integrated restore. This can cause some errors as described below in [Automatic restore errors](#automatic-restore-errors). To update a project, see [Migrating to automatic restore](#migrating-to-automatic-restore).
+Visual Studio automatically restores missing packages by default at the beginning of a build. This behavior can be changed by clearing **Tools > Options > NuGet Package Manager > General > Automatically check for missing packages during build in Visual Studio**.
 
 When enabled, automatic restore works as follows:
 
-1. A `.nuget` folder is created in the solution containing a `Nuget.Config` file that contains only a single setting for `disableSourceControlIntegration` (as described in [Packages and source control](../consume-packages/packages-and-source-control.md) for Team Foundation Version Control).
 1. When a build begins, Visual Studio instructs NuGet to restore packages.
 1. NuGet recursively looks for all `packages.config` files in the solution, looks for `project.json`, or looks in the project file.
 1. For each packages listed in the reference files, NuGet checks if it already exists in the solution (the `packages` folder, `project.lock.json`, or `project.assets.json` depending on whether the project is using `packages.config`, `project.json`, or package references in project files).
-1. If the package is not found, NuGet attempts to retrieve the package from its cache first (see [Managing the NuGet cache](../consume-packages/managing-the-nuget-cache.md). If the package is not in the cache, NuGet attempts to download the package from the enabled sources as listed in **Tools > Options > [NuGet] Package Manager > Package Sources**, in the order that the sources appear. In this case, NuGet does not indicate a failure to find the package until all the sources have been checked, at which time it reports the failure only for the last source in the list. By implication such an error also means that the package wasn't present on any of the other sources either, even though errors were not shown for those sources individually.
+1. If the package is not found, NuGet attempts to retrieve the package from its cache first (see [Managing the NuGet cache](../consume-packages/managing-the-nuget-cache.md). If the package is not in the cache, NuGet attempts to download the package from the enabled sources as listed in **Tools > Options > NuGet Package Manager > Package Sources**, in the order that the sources appear. In this case, NuGet does not indicate a failure to find the package until all the sources have been checked, at which time it reports the failure only for the last source in the list. By implication such an error also means that the package wasn't present on any of the other sources either, even though errors were not shown for those sources individually.
 1. If the download is successful, NuGet caches the package and installs it into the solution (again, into either the `packages` folder, `project.lock.json`, or `project.assets.json`); otherwise NuGet fails and the build fails.
 
 During this process, you see a progress dialog with the option to cancel package restore.
-
-### Automatic restore errors
-
-If you're using NuGet 2.7 or later and have a solution that is still configured for MSBuild-integrated restore, you may have an older version of `nuget.exe` in the solution's `.nuget` folder. This will cause builds to fail with an error stating that you have not given consent to restore packages.
-
-To correct these errors, do one of the following:
-
-1. [Migrate the project to automatic restore](#migrating-to-automatic-restore).
-1. Update `nuget.exe` in the `.nuget` folder as follows
-
-    ```
-    cd .nuget
-    nuget update -self
-    ```
-
-1. Reset consent in your `%AppData%\NuGet\NuGet.Config` file by going to **Tools > Options > NuGet Package Manager > General** in Visual Studio, clear and re-select both **Package Restore** options, and click OK. This re-saves `NuGet.Config` with the proper consent settings for NuGet 2.6 and earlier.
-
-
-## MSBuild-integrated restore
-
-> [!Important]    
-> Although MS-Build integrated restore still works with NuGet 2.7 and later, we  recommended that you [migrate to automatic restore](#migrating-to-automatic-restore) instead because it's simpler and more robust.
-
-As noted before, MSBuild-integrated restore with NuGet 2.6 and earlier is typically enabled by right-clicking a solution in Visual Studio and selecting **Enable NuGet Package Restore**. This has the following effects:
-
-- NuGet creates a `.nuget` folder in the solution containing `nuget.exe`, `Nuget.Config`, and `NuGet.targets` files.
-- NuGet updates all projects in the solution to include a `<RestorePackages>true</RestorePackages>` flag and to import `NuGet.targets`. These cause MSBuild to invoke `nuget.exe` to restore packages before a build provided that the **Tools > Options > NuGet Package Manager > General > Allow NuGet to download missing packages** option is checked.
-
-Again, this option is **not** checked by default for NuGet 2.6 and earlier and must be manually set for package restore to work. For a custom build `.proj`, a pre build `<Exec>` action must also be added manually to restore packages.
-
-With MSBuild-integrated restore, packages that are downloaded by Visual Studio will be automatically added to Team Foundation Version Control by default when the project is connected to a repository. To change this behavior, see [Omitting packages with Team Foundation Version Control](../consume-packages/packages-and-source-control.md#omitting-packages-with-team-foundation-version-control).
-
-
-### Migrating to automatic restore
-
-Although the MSBuild-integrated restore approach works with NuGet 2.7 and later, it has several drawbacks:
-
-- It requires additional files within the solution folder.
-- It requires importing a `.targets` file into all projects in the solution, which can introduce issues when projects are shared among multiple solutions.
-- Projects will fail to load if `NuGet.targets` cannot be found.
-- Projects won't build successfully if any of the restored NuGet packages extend MSBuild through a targets/props file import.
-- Packages are automatically added to Team Foundation Version Control, when in use, unless specifically disabled.
-- It is not compatible with ASP.NET web site projects created in Visual Studio.
-
-To avoid all these issues, it's recommended to migrate any project using MSBuild-integrated restore to use the automatic restore capabilities of NuGet 2.7 and above.
-
-The process is as follows:
-
-1. Close Visual Studio to avoid file potential file locks and conflicts.
-1. If using Team Foundation Server (TFS):
-    1. Remove `nuget.exe` and `NuGet.targets` from the solution's `.nuget` folder and remove those files from the solution workspace.
-    1. Retain `Nuget.Config` with the `disableSourceControlIntegration` setting as explained in [Omitting packages with Team Foundation Version Control](../consume-packages/packages-and-source-control.md#omitting-packages-with-team-foundation-version-control).
-1. If not using TFS:
-    1. Remove the `.nuget` folder from the solution and the solution workspace.
-1. Edit each project file in the solution, remove the `<RestorePackages>` element, and remove any references to the `NuGet.targets` file. Those settings generally appear as follows:
-
-    ```xml
-    <RestorePackages>true</RestorePackages>
-    ...
-    <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
-    ...
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    </Target>
-    ```
-
-> [!Tip]    
-> Owen Johnson has created a [PowerShell migration script](https://github.com/owen2/AutomaticPackageRestoreMigrationScript) that can work in many cases, but is used at your own risk. Be sure to commit your project to source control or make a backup before using it.</div>
-
-To test the migration, do the following:
-
-1. Remove the `packages` folder from the solution.
-1. Open the solution in Visual Studio and start a build.
-1. Automatic restore should download and install each dependency package, without adding them to source control.
-
 
 ## Package Restore with Team Foundation Build
 
@@ -289,10 +187,4 @@ If you're using a previous version of build templates (such as in a project that
 
 For earlier version of TFS, you can simply include a build step to invoke [command-line restore](#command-line-restore) as described earlier.
 
-For more details see then [Walkthrough of Package Restore with Team Foundation Build](../consume-packages/team-foundation-build.md).
-
-### Command-line restore wrapped in MSBuild
-
-With existing build servers and MSBuild-based projects, you can also choose to wrap the command line in a regular MSBuild project. This minimizes changes on the server and also provides built-in support for aggregated logging and error reporting. This differs from the usual MSBuild-integrated restore as it runs before any other build process happens, instead of as part of those other processes.
-
-Note that for NuGet 4.0+ and MSBuild 15.1+, you can also use `MSBuild /t:restore` as described on [NuGet pack and restore as MSBuild targets](../schema/msbuild-targets.md).
+For more details see then [Walkthrough of Package Restore with Team Foundation Build](../consume-packages/team-foundation-build.md).    

--- a/docs/Release-Notes/Known-Issues.md
+++ b/docs/Release-Notes/Known-Issues.md
@@ -92,16 +92,6 @@ If the command fails, check to see if the file exists in that location.
 
 For more information about this error, see this [work item](https://nuget.codeplex.com/workitem/3609 "Work item 3609").
 
-## Package Restore Consent Errors with NuGet 2.7
-
-If you are using NuGet 2.7+, but you are working in a solution that had enabled package restore through the MSBuild-integrated approach, it's possible that package restore will still fail due to a lack of package restore consent. This happens when the version of `nuget.exe` in your solution's `.nuget` folder is version 2.6 or earlier, where package restore consent was still OFF by default.
-
-If you have upgraded to NuGet 2.7+ but your solution fails to build stating that you haven't given consent, you have a few options for proceeding:
-
-1. **Force save your NuGet settings with consent given.** To do this, open Visual Studio's options and under Package Manager, choose General. Uncheck and then re-check the boxes for consent and click OK. This forces your `%AppData%\NuGet\NuGet.Config` file to be saved with consent explicitly given, allowing NuGet 2.6 and earlier to see that you've given consent.
-1. **Update the version of `nuget.exe` in your `.nuget` folder.** To do this, run `nuget.exe update -self` from your `.nuget` folder, which will download the latest version of `nuget.exe` and replace the version in the `.nuget` folder. The latest version of `nuget.exe` will infer consent to be ON even when not explicitly saved in the `NuGet.Config` file.
-1. **Migrate to Automatic Package Restore.** For this approach, you would migrate from the MSBuild-integrated package restore to the Automatic Package Restore approach, following the [documented walkthrough](../consume-packages/package-restore.md#migrating-to-automatic-restore).
-
 ## Build failure after package update in VS 2012
 The problem: You are using VS 2012 RTM. When updating NuGet packages, you get this message:
 "One or more packages could not be completed uninstalled." and you are prompted to restart

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -24,10 +24,10 @@
 # Consume Packages
 ## [Overview and Workflow](Consume-Packages/Overview-and-Workflow.md)
 ## [Finding and Choosing Packages](Consume-Packages/Finding-and-Choosing-Packages.md)
-## [Reinstalling and Updating Packages](Consume-Packages/Reinstalling-and-Updating-Packages.md)
-## [Packages and Source Control](Consume-Packages/Packages-and-Source-Control.md)
 ## [Package Restore](Consume-Packages/Package-Restore.md)
 ### [Troubleshooting](Consume-Packages/Package-restore-troubleshooting.md)
+## [Reinstalling and Updating Packages](Consume-Packages/Reinstalling-and-Updating-Packages.md)
+## [Packages and Source Control](Consume-Packages/Packages-and-Source-Control.md)
 ## [Managing the NuGet Cache](Consume-Packages/Managing-the-NuGet-Cache.md)
 ## [Configuring NuGet Behavior](Consume-Packages/Configuring-NuGet-Behavior.md)
 ## [Dependency Resolution](Consume-Packages/Dependency-Resolution.md)

--- a/docs/Tools/Package-Manager-UI.md
+++ b/docs/Tools/Package-Manager-UI.md
@@ -53,11 +53,11 @@ In this topic:
 
 ## Finding and installing a package
 
-1. In **Solution Explorer**, right-click either **References**  or a project and select **Manage NuGet Packages...**. (In web site projects, right-click the **Bin** folder instead.)
+1. In **Solution Explorer**, right-click either **References**  or a project and select **Manage NuGet Packages...**.
 
     ![Manage NuGet Packages menu option](media/ManagePackagesUICommand.png)
 
-2. The **Browse** tab displays available packages by popularity. Search for a specific package using the search box on the top right. Select a package to display the package information on the right and to enable the **Install** button along with a version-selection drop-down.
+2. The **Browse** tab displays available packages by popularity. Search for a specific package using the search box on the top left. Select a package to display the package information on the right and to enable the **Install** button along with a version-selection drop-down.
 
     ![Manage NuGet Packages Dialog Browse tab](media/Search.png)
 
@@ -67,7 +67,7 @@ In this topic:
 
 ## Uninstalling a package
 
-1. In **Solution Explorer**, right-click either **References** or the desired project, and select **Manage NuGet Packages...**. (In web site projects, right-click the **Bin** folder instead.)
+1. In **Solution Explorer**, right-click either **References** or the desired project, and select **Manage NuGet Packages...**.
 2. Select the **Installed** tab.
 3. Select the package to uninstall and select **Uninstall**.
 
@@ -75,19 +75,18 @@ In this topic:
 
 ## Updating a package
 
-1. In **Solution Explorer**, right-click either **References** or the desired project, and select **Manage NuGet Packages...**. (In web site projects, right-click the **Bin** folder instead.)
+1. In **Solution Explorer**, right-click either **References** or the desired project, and select **Manage NuGet Packages...**.
 2. Select the **Updates** tab to see packages that have available updates.
 3. Select the package to update, select the desired version from the drop-down on the right, and select **Update**.
 
     ![Updating a package](media/UpdatePackages.png)
 
-4. <a name="implicit_reference"></a>For some packages, the **Update** button is disabled and the package a message appears saying that it's "Implicitly referenced by an SDK". (In some versions of Visual Studio the text may read only "AutoReferenced".) These conditions indicate that the package, such as Microsoft.NETCore.App, is part of a larger framework or SDK and should not be updated independently. (Such packages, of which Microsoft.NETStandard.Library is another example, are marked internally with `<IsImplicitlyDefined>True</IsImplicitlyDefined>`.) To update the package, you must update the SDK to which it belongs.
+4. <a name="implicit_reference"></a>For some packages, the **Update** button is disabled and a message appears saying that it's "Implicitly referenced by an SDK". (In some versions of Visual Studio the text may read only "AutoReferenced".) These conditions indicate that the package, such as Microsoft.NETCore.App, is part of a larger framework or SDK and should not be updated independently. (Such packages, of which Microsoft.NETStandard.Library is another example, are marked internally with `<IsImplicitlyDefined>True</IsImplicitlyDefined>`.) To update the package, you must update the SDK to which it belongs.
 
     ![Example package marked as Implicitly references or AutoReferenced](media/PackageManagerUIAutoReferenced.png)
 
 
 ## Managing packages for the solution
-*NuGet 1.4+*
 
 1. Select the **Tools > NuGet Package Manager > Manage NuGet Packages for Solution...** menu command, or right-click the solution and select **Manage NuGet Packages...**:
 


### PR DESCRIPTION
Ripped out parts based on meeting with Justin. The whole automatic restore and msbuild restore has been simplified. There is no more migration scenario. Several blog posts talk about how we (msft) have been giving the wrong guidance dating as far back as the 2014.

http://blog.davidebbo.com/2014/01/the-right-way-to-restore-nuget-packages.html

https://www.xavierdecoster.com/post/2014/03/06/migrate-away-from-msbuild-based-nuget-package-restore.html