### PR TITLE
Write guide about how to use the catalog to query for all packages

### DIFF
--- a/docs/API/catalog-resource.md
+++ b/docs/API/catalog-resource.md
@@ -32,6 +32,9 @@ The **catalog** is a resource that records all package operations on a package s
 > [!Note]
 > Because the catalog is not used by the official NuGet client, not all package sources implement the catalog.
 
+> [!Note]
+> Currently, the nuget.org catalog is not available in China. For more details, see [NuGet/NuGetGallery#4949](https://github.com/NuGet/NuGetGallery/issues/4949).
+
 ## Versioning
 
 The following `@type` value is used:

--- a/docs/Guides/api/query-for-all-published-packages.md
+++ b/docs/Guides/api/query-for-all-published-packages.md
@@ -63,11 +63,11 @@ Otherwise, follow the guide below to build a reliable catalog reader.
 
 ## Initialize a cursor
 
-The first piece of a reliable catalog reader is implementing a cursor. For full details about the design of a catalog
-cursor, see the [catalog reference document](../../api/catalog-resource.md#cursor). In short, cursor is just a point
-in time up to which you have processed events in the catalog. Events in the catalog represent package publishes and
-other package changes. If you care about all packages ever published to NuGet (since the beginning of time), you would
-initialize your cursor to a "minimum value" timestamp (e.g. `DateTime.MinValue` in .NET). If you care only about
+The first step in building a reliable catalog reader is implementing a cursor. For full details about the design of a
+catalog cursor, see the [catalog reference document](../../api/catalog-resource.md#cursor). In short, cursor is a
+point in time up to which you have processed events in the catalog. Events in the catalog represent package publishes
+and other package changes. If you care about all packages ever published to NuGet (since the beginning of time), you
+would initialize your cursor to a "minimum value" timestamp (e.g. `DateTime.MinValue` in .NET). If you care only about
 packages published starting now, you would use the current timestamp as your initial cursor value.
 
 For this guide, we'll initialize our cursor to a timestamp one hour ago. For now, just save that timestamp in memory.
@@ -78,7 +78,7 @@ DateTime cursor = DateTime.UtcNow.AddHours(-1);
 
 ## Determine catalog index URL
 
-The location of every resource (endpoint) in the NuGet API should be should be discovered using the
+The location of every resource (endpoint) in the NuGet API should be discovered using the
 [service index](../../api/service-index.md). Since this guide focuses on nuget.org, we'll be using nuget.org's service
 index.
 

--- a/docs/Guides/api/query-for-all-published-packages.md
+++ b/docs/Guides/api/query-for-all-published-packages.md
@@ -1,0 +1,207 @@
+---
+# required metadata 
+
+title: Query for all packages published to nuget.org | Microsoft Docs
+author:
+- joelverhagen
+- kraigb
+ms.author:
+- joelverhagen
+- kraigb
+manager: skofman
+ms.date: 11/2/2017
+ms.topic: get-started-article
+ms.prod: nuget
+ms.technology: null
+ms.assetid: 5d017cd4-3d75-4341-ba90-3c57be093b7d
+
+# optional metadata
+
+description: Using the NuGet API, you can query for all packages published to nuget.org and stay up-to-date over time.
+keywords: NuGet API enumerate all packages, NuGet API replicate packages, latest packages published to nuget.org
+ms.reviewer:
+- karann
+- unniravindranathan
+
+---
+
+# Query for all packages published to nuget.org
+
+One common query pattern on the legacy OData V2 API was enumerating all packages published to nuget.org, ordered by when
+the package was published. Scenarios requiring this kind of query against nuget.org vary widely:
+
+- Replicating nuget.org entirely
+- Detecting when packages have new versions released
+- Finding packages that depend on your package
+
+The legacy way of doing this typically depended on sorting the OData package entity by a timestamp and paging across
+the massive result set using `skip` and `top` (page size) parameters. Unfortunately, this approach has some drawbacks:
+
+- Possibility of missing packages, since the queries are being made on data that is often changing order
+- Slow query response time, since the queries are not optimized (the most optimized queries are ones that support a
+  mainline scenario for the official NuGet client)
+- Use of deprecated and undocumented API, meaning the support of such queries in the future is not guaranteed
+- Inability to replay history in the exact order that it transpired
+
+For this reason, the following guide can be followed to address the aforementioned scenarios in a more reliable and
+future-proof way.
+
+## Overview
+
+At the center of this guide is resource in the [NuGet API](../../api/overview.md) called the **catalog**. The catalog
+is an append-only API that allows the caller to see a full history of packages added to, modified, and deleted from
+nuget.org. If you are interested in all or even a subset of packages published to nuget.org, the catalog is a great way
+to stay up-to-date with the set of currently available packages as time goes on.
+
+This guide is intended to be a high-level walk-through but if you are interested in the fine-grain details of the
+catalog, see its [API reference document](../../api/catalog-resource.md).
+
+The following steps can be implemented in any programming language of your choice. If you want a full running sample,
+take a look at the [C# sample](#c-sample-code) mentioned below.
+
+Otherwise, follow the guide below to build a reliable catalog reader.
+
+## Initialize a cursor
+
+The first piece of a reliable catalog reader is implementing a cursor. For full details about the design of a catalog
+cursor, see the [catalog reference document](../../api/catalog-resource.md#cursor). In short, cursor is just a point
+in time up to which you have processed events in the catalog. Events in the catalog represent package publishes and
+other package changes. If you care about all packages ever published to NuGet (since the beginning of time), you would
+initialize your cursor to a "minimum value" timestamp (e.g. `DateTime.MinValue` in .NET). If you care only about
+packages published starting now, you would use the current timestamp as your initial cursor value.
+
+For this guide, we'll initialize our cursor to a timestamp one hour ago. For now, just save that timestamp in memory.
+
+```cs
+DateTime cursor = DateTime.UtcNow.AddHours(-1);
+```
+
+## Determine catalog index URL
+
+The location of every resource (endpoint) in the NuGet API should be should be discovered using the
+[service index](../../api/service-index.md). Since this guide focuses on nuget.org, we'll be using nuget.org's service
+index.
+
+```
+GET https://api.nuget.org/v3/index.json
+```
+
+The service document is JSON document containing all of the resources on nuget.org. Look for the resource having the
+`@type` property value of `Catalog/3.0.0`. The associated `@id` property value is the URL to the catalog index itself.
+
+## Find new catalog leaves
+
+Using the `@id` property value found in the previous step, download the catalog index:
+
+```
+GET https://api.nuget.org/v3/catalog0/index.json
+```
+
+Deserialize the [catalog index](../../api/catalog-resource.md#catalog-index). Filter out all
+[catalog page objects](../../api/catalog-resource.md#catalog-page-object-in-the-index) with `commitTimeStamp` less than
+or equal to your current cursor value.
+
+For each remaining catalog page, download the full document using the `@id` property.
+
+```
+GET https://api.nuget.org/v3/catalog0/page2926.json
+```
+
+Deserialize the [catalog page](../../api/catalog-resource.md#catalog-page). Filter out all
+[catalog leaf objects](../../api/catalog-resource.md#catalog-item-object-in-a-page) with `commitTimeStamp` less than
+or equal to your current cursor value.
+
+After you have downloaded all of the catalog pages not filtered out, you will have a set of catalog leaf objects
+representing packages that have been published, unlisted, listed, or deleted in the time between your cursor timestamp
+and now.
+
+## Process catalog leaves
+
+At this point, you can perform any custom processing you'd like on the catalog items. If all you need is the ID and
+version of the package, you can inspect the `nuget:id` and `nuget:version` properties on the catalog item objects found
+in the pages. Make sure to look at the `@type` property to know if the catalog item concerns an existing package or a
+deleted package.
+
+If you are interested in the metadata about the package (such at the description, dependencies, .nupkg size, etc), you
+can fetch the [catalog leaf document](../../api/catalog-resource.md#catalog-leaf) using the `@id` property.
+
+```
+GET https://api.nuget.org/v3/catalog0/data/2015.02.01.11.18.40/windowsazure.storage.1.0.0.json
+```
+
+This document has all of the metadata included in the
+[package metadata resource](../../api/registration-base-url-resource.md), and more!
+
+This step is where you implement your custom logic. The other steps in this guide are implemented in pretty much the
+same way not matter what you are doing with the catalog leaves.
+
+### Downloading the .nupkg
+
+If you are interested in downloading the .nupkg's for packages found in the catalog, you can use the
+[package content resource](../../api/package-base-address-resource.md). However, note that there is a short delay
+between when a package is found in catalog and when it is available in the package content resource. Therefore, if
+you encounter `404 Not Found` when attempting to download a .nupkg for a package that you found in the catalog, simply
+retry a short time later. Fixing this delay is tracked by GitHub issue
+[NuGet/NuGetGallery#3455](https://github.com/NuGet/NuGetGallery/issues/3455).
+
+## Move the cursor forward
+
+Once you have successfully processed the catalog items, you need to determine the new cursor value to save. To do this,
+find the maximum (latest chronologically) `commitTimeStamp` of all catalog items that you processed. This is your new
+cursor value. Save it to some persistent store, like a database, file system, or blob storage. When you want to get more
+catalog items, simply start from the [first step](#initialize-a-cursor) by initializing your cursor value from this
+persistent store.
+
+If your application throws an exception or faults, don't move the cursor forward. Moving the cursor forward has the
+meaning that you never again need to process catalog items before your cursor.
+
+If, for some reason, you have a bug in how you process catalog leaves, you can simply move your cursor backward in time
+and allow your code to reprocess the old catalog items.
+
+## C# sample code
+
+Since the catalog is a set of JSON documents, it can be interacted with using any programming language that has
+an HTTP client and JSON deserializer.
+
+For improved understanding and convenience, we have made a small sample available written in C# to demonstrate how to
+read from the catalog. The solution file requires Visual Studio 2017. The project is `netcoreapp2.0` depends on the
+[NuGet.Protocol 4.4.0](https://www.nuget.org/packages/NuGet.Protocol/4.4.0) (for resolving the service index) and
+[Newtonsoft.Json 9.0.1](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1) (for JSON deserialization).
+
+Simply clone the [NuGet/Samples](https://github.com/NuGet/Samples) repository on GitHub, restore, build, and run the
+project file under the `CatalogReaderExample` directory. 
+
+```
+git clone https://github.com/NuGet/Samples.git
+```
+
+The main logic of the code is visible in the
+[`Program.cs`](https://github.com/NuGet/Samples/blob/master/CatalogReaderExample/CatalogReaderExample/Program.cs)
+file.
+
+### Sample output
+
+```
+No cursor found. Defaulting to 11/2/2017 9:41:28 PM.
+Fetched catalog index https://api.nuget.org/v3/catalog0/index.json.
+Fetched catalog page https://api.nuget.org/v3/catalog0/page2935.json.
+Processing 69 catalog leaves.
+11/2/2017 9:32:35 PM: DotVVM.Compiler.Light 1.1.7 (type is nuget:PackageDetails)
+11/2/2017 9:32:35 PM: Momentum.Pm.Api 5.12.181-beta (type is nuget:PackageDetails)
+11/2/2017 9:32:44 PM: Momentum.Pm.PortalApi 5.12.181-beta (type is nuget:PackageDetails)
+11/2/2017 9:35:14 PM: Genesys.Extensions.Standard 3.17.11.40 (type is nuget:PackageDetails)
+11/2/2017 9:35:14 PM: Genesys.Extensions.Core 3.17.11.40 (type is nuget:PackageDetails)
+11/2/2017 9:35:14 PM: Halforbit.DataStores.FileStores.Serialization.Bond 1.0.4 (type is nuget:PackageDetails)
+11/2/2017 9:35:14 PM: Halforbit.DataStores.FileStores.AmazonS3 1.0.4 (type is nuget:PackageDetails)
+11/2/2017 9:35:14 PM: Halforbit.DataStores.DocumentStores.DocumentDb 1.0.6 (type is nuget:PackageDetails)
+11/2/2017 9:35:14 PM: Halforbit.DataStores.FileStores.BlobStorage 1.0.5 (type is nuget:PackageDetails)
+...
+11/2/2017 10:23:54 PM: Cake.GitPackager 0.1.2 (type is nuget:PackageDetails)
+11/2/2017 10:23:54 PM: UtilPack.NuGet 2.0.0 (type is nuget:PackageDetails)
+11/2/2017 10:23:54 PM: UtilPack.NuGet.AssemblyLoading 2.0.0 (type is nuget:PackageDetails)
+11/2/2017 10:26:26 PM: UtilPack.NuGet.Deployment 2.0.0 (type is nuget:PackageDetails)
+11/2/2017 10:26:26 PM: UtilPack.NuGet.Common.MSBuild 2.0.0 (type is nuget:PackageDetails)
+11/2/2017 10:26:36 PM: InstaClient 1.0.2 (type is nuget:PackageDetails)
+11/2/2017 10:26:36 PM: SecureStrConvertor.VARUN_RUSIYA 1.0.0.5 (type is nuget:PackageDetails)
+Writing cursor value: 11/2/2017 10:26:36 PM.
+```

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -9,6 +9,8 @@
 ## [Create Cross-Platform Packages](Guides/Create-Cross-Platform-Packages.md)
 ## [Create NET Standard Packages (Visual Studio 2017)](Guides/Create-NET-Standard-Packages-VS2017.md)
 ## [Create NET Standard Packages (Visual Studio 2015)](Guides/Create-NET-Standard-Packages-VS2015.md)
+## API
+### [Query for all packages](Guides/api/query-for-all-published-packages.md)
 # Create Packages
 ## [Overview and Workflow](Create-Packages/Overview-and-Workflow.md)
 ## [Creating a Package](Create-Packages/Creating-a-Package.md)

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -4,13 +4,12 @@
 ## [Use a Package](Quickstart/Use-a-Package.md)
 # Guides
 ## [Install NuGet client tools](Guides/Install-NuGet.md)
+## [Create NET Standard Packages (Visual Studio 2017)](Guides/Create-NET-Standard-Packages-VS2017.md)
+## [Create NET Standard Packages (Visual Studio 2015)](Guides/Create-NET-Standard-Packages-VS2015.md)
 ## [Create UWP Packages](Guides/Create-UWP-Packages.md)
 ## [Creating UWP Controls as NuGet Packages](Guides/Create-UWP-Controls.md)
 ## [Create Cross-Platform Packages](Guides/Create-Cross-Platform-Packages.md)
-## [Create NET Standard Packages (Visual Studio 2017)](Guides/Create-NET-Standard-Packages-VS2017.md)
-## [Create NET Standard Packages (Visual Studio 2015)](Guides/Create-NET-Standard-Packages-VS2015.md)
-## API
-### [Query for all packages](Guides/api/query-for-all-published-packages.md)
+## [Query for all packages using the API](Guides/api/query-for-all-published-packages.md)
 # Create Packages
 ## [Overview and Workflow](Create-Packages/Overview-and-Workflow.md)
 ## [Creating a Package](Create-Packages/Creating-a-Package.md)


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/4914.

I picked this scenario by looking at the highest cost (sum total duration) V2 queries done today (top 7):

1. Find reverse dependencies
1. Get most recently updated packages
1. `GetUpdates()`
1. Page over all latest stable
1. `Search()`
1. Substrings on metadata fields
1. Page over all packages

![image](https://user-images.githubusercontent.com/94054/32394550-ba17eed2-c09a-11e7-8eff-131730d3ae15.png)

Items 1, 2, 6, 7 are all easily solved using the catalog. Reverse dependencies may one day have 1st class support. So I thought a generic guide on how to use the catalog was the best first guide to write for the NuGet V3 API.

Review URL:
https://review.docs.microsoft.com/en-us/nuget/guides/api/query-for-all-published-packages?branch=jver-v2-v3-guides

/cc @emgarten @xavierdecoster @ryuyu @scottbommarito