### PR TITLE
Added example packing a release build

### DIFF
--- a/docs/Tools/cli-ref-pack.md
+++ b/docs/Tools/cli-ref-pack.md
@@ -55,7 +55,7 @@ where `<nuspecPath>` and `<projectPath>` specify the `.nuspec` or project file, 
 | NoDefaultExcludes | Prevents default exclusion of NuGet package files and files and folders starting with a dot, such as `.svn` and `.gitignore`. |
 | NoPackageAnalysis | Specifies that pack should not run package analysis after building the package. |
 | OutputDirectory | Specifies the folder in which the created package is stored. If no folder is specified, the current folder is used. |
-| Properties | Specifies a list of token=value pairs, separated by semicolons, where each occurrence of `$token$` in the `.nuspec` file will be replaced with the given value. Values can be strings in quotation marks. |
+| Properties | Specifies a list of token=value pairs, separated by semicolons, where each occurrence of `$token$` in the `.nuspec` file will be replaced with the given value. Values can be strings in quotation marks. Note that for the "Configuration" property, the default is "Debug". To change to a Release configuration, use `-Properties Configuration=Release`. |
 | Suffix | *(3.4.4+)* Appends a suffix to the internally generated version number, typically used for appending build or other pre-release identifiers. For example, using `-suffix nightly` will create a package with a version number like `1.2.3-nightly`. Suffixes must start with a letter to avoid warnings, errors, and potential incompatibilities with different versions of NuGet and the NuGet Package Manager. |
 | Symbols | Specifies that the package contains sources and symbols. When used with a `.nuspec` file, this creates a regular NuGet package file and the corresponding symbols package. |
 | Tool | Specifies that the output files of the project should be placed in the `tool` folder. |

--- a/docs/Tools/cli-ref-pack.md
+++ b/docs/Tools/cli-ref-pack.md
@@ -92,6 +92,8 @@ nuget pack foo.nuspec
 
 nuget pack foo.csproj
 
+nuget pack foo.csproj -Properties Configuration=Release
+
 nuget pack foo.csproj -Build -Symbols -Properties owners=janedoe,xiaop;version="1.0.5"
 
 # create a package from project foo.csproj, using MSBuild version 12 to build the project


### PR DESCRIPTION
Added an example showing how to use the pack command to use a Release build instead of the default Debug build. It would also be helpful to be told somewhere in the text that Debug is the default, but I'm not sure where that should go.