### PR TITLE
Fix incorrect description of the /tools folder

### DIFF
--- a/docs/Create-Packages/Creating-a-Package.md
+++ b/docs/Create-Packages/Creating-a-Package.md
@@ -191,7 +191,7 @@ The folder conventions are as follows:
 | runtimes | Architecture-specific assembly (`.dll`), symbol (`.pdb`), and native resource (`.pri`) files | Assemblies are added as references; other files are copied into project folders. See [Supporting multiple target frameworks](Supporting-Multiple-Target-Frameworks.md). |
 | content | Arbitrary files | Contents are copied to the project root. Think of the **content** folder as the root of the target application that ultimately consumes the package. To have the package add an image in the application's */images* folder, place it in the package's *content/images* folder. |
 | build | MSBuild `.targets` and `.props` files | Automatically inserted into the project file (NuGet 2.x) or `project.lock.json` (NuGet 3.x+). |
-| tools | Powershell scripts and programs accessible from the Package Manager Console | Contents are copied to the project folder, and the `tools` folder is added to the PATH environment variable. |
+| tools | Powershell scripts and programs accessible from the Package Manager Console | The `tools` folder is added to the `PATH` environment variable for the Package Manager Console only (Specifically, *not* to the `PATH` as set for MSBuild when building the project). |
 
 Because your folder structure can contain any number of assemblies for any number of target frameworks, this method is necessary when creating packages that support multiple frameworks 
 


### PR DESCRIPTION
The description of the `/tools` folder's usage is entirely incorrect. Visual Studio adds these package folders only to the PATH in the PM Console, but they are not added when building (which is pretty consistent with what they are used for, the PowerShell scripts that have access to the VS object model).

Double-checking.

PM console (VS 15.4.4)
```
PM> Write-Host $env:PATH
[..snip..]\TibMounter64;C:\projects\phemonoe\packages\Grpc.Tools.1.7.1\tools
```

Project file ("new" SDK-style .csproj file) with
```xml
  <Target Name="_test" BeforeTargets="Build">
    <Message Importance="high" Text="PATH=$(PATH)" />
  </Target>
```
prints
```
1>PATH=[...snip...]\TibMounter64
```
Double paranoid: Ctrl+F `Grpc` in the Output window confirms it's not there.

I have added the clarification because some NuGet packages are placing compilers into the `/tools` instead of `/build`, apparently on an invalid assumption that they would be "simply available" within the build scripts. So there is a confusion out there.

And there indeed no trace of these tool files "copied to the project folder," as the current documentation suggests (and not that there would be any reason to copy them).