### PR TITLE
Update friendly name for netcore TFM

### DIFF
--- a/docs/Schema/Target-Frameworks.md
+++ b/docs/Schema/Target-Frameworks.md
@@ -57,7 +57,7 @@ The NuGet clients support the following frameworks. Equivalents are shown within
 |                |              |net46      |
 |                |              |net461     |
 |                |              |net462     |
-|.NET Core       | netcore      | netcore [netcore45]
+|Windows Store   | netcore      | netcore [netcore45]
 |                |              | netcore45 [win, win8]
 |                |              | netcore451 [win81]
 |                |              | netcore50


### PR DESCRIPTION
Use Windows Store instead of .NET Core for the friendly name of the netcore TFM to distinguish it from the netcoreapp TFM.

The table shows ".NET Core" as the friendly name for both the `netcore` and `netcoreapp` TFM families. This is confusing, especially since .NET Core is now its own separate framework. The `netcore` TFM is really for Windows Store apps, which is how it's documented in the [.NET Target Frameworks doc](https://docs.microsoft.com/en-us/dotnet/standard/frameworks). We should be consistent with the .NET Target Frameworks doc here.