### PR TITLE
clean words.

### DIFF
--- a/docs/Consume-Packages/Configuring-NuGet-Behavior.md
+++ b/docs/Consume-Packages/Configuring-NuGet-Behavior.md
@@ -32,12 +32,12 @@ In this topic:
 - [How settings are applied](#how-settings-are-applied)
 - [NuGetDefaults.Config file](#nuget-defaults-file)
 
-## Config file locations and uses
+## NuGet.Config file locations and uses
 
 | Scope | NuGet.Config file location | Description |
 | --- | --- | --- |
-| Project | Project folder or any folder up to the drive root | In a project folder, settings apply only to that project. In parent folders that contain multiple projects subfolders, settings apply to all projects in those subfolders. |
-| User | Windows: %APPDATA%\NuGet\NuGet.Config<br/>Mac/Linux: ~/.nuget/NuGet.Config | Settings apply to all operations, but are overridden by any project-level settings. When using CLI commands, you can specify a different config file using the `-configFile` switch to ignore any settings in the default user-level file. |
+| Project | Current folder (aka Project folder) or any folder up to the drive root.| In a project folder, settings apply only to that project. In parent folders that contain multiple projects subfolders, settings apply to all projects in those subfolders. |
+| User | Windows: %APPDATA%\NuGet\NuGet.Config<br/>Mac/Linux: ~/.nuget/NuGet.Config | Settings apply to all operations, but are overridden by any project-level settings. |
 | Computer | Windows: %ProgramFiles(x86)%\NuGet\Config<br/>Mac/Linux: $XDG_DATA_HOME (typically ~/.local/share) | Settings apply to all operations on the computer, but are overriden by any user- or project-level settings. |
 
 Notes for earlier versions of NuGet:


### PR DESCRIPTION
a) It is puzzled for novice likes me to understand what a 'project' is.
b) In description column, deleting makes concept clean, clear, and easy for novice to understand. Same words are said in "Changing config settings" and "How settings are applied". Please do not stuff lots in introduction section.