### PR TITLE
Adding context to nuget config command documentation

### DIFF
--- a/docs/Tools/cli-ref-config.md
+++ b/docs/Tools/cli-ref-config.md
@@ -18,7 +18,7 @@ ms.reviewer:
 
 **Applies to:** all &bullet; **Supported versions**: all
 
-Gets or sets NuGet configuration values in `%AppData%\NuGet\NuGet.Config` or the specified configuration file. For additional usage, see [Configuring NuGet Behavior](../consume-packages/configuring-nuget-behavior.md). For details on allowable key names, refer to the [NuGet config file reference](../Schema/nuget-config-file.md).
+Gets or sets NuGet configuration values in the user scope configuration file or a specified configuration file. The user scope configuration file is located at `%APPDATA%\NuGet\NuGet.Config` in Windows and at `~/.nuget/NuGet.Config` in Mac/Linux. For additional usage, see [Configuring NuGet Behavior](../consume-packages/configuring-nuget-behavior.md). For details on allowable key names, refer to the [NuGet config file reference](../Schema/nuget-config-file.md).
 
 ## Usage
 

--- a/docs/Tools/cli-ref-config.md
+++ b/docs/Tools/cli-ref-config.md
@@ -18,7 +18,7 @@ ms.reviewer:
 
 **Applies to:** all &bullet; **Supported versions**: all
 
-Gets or sets NuGet configuration values. For additional usage, see [Configuring NuGet Behavior](../consume-packages/configuring-nuget-behavior.md). For details on allowable key names, refer to the [NuGet config file reference](../Schema/nuget-config-file.md).
+Gets or sets NuGet configuration values in `%AppData%\NuGet\NuGet.Config` or the specified configuration file. For additional usage, see [Configuring NuGet Behavior](../consume-packages/configuring-nuget-behavior.md). For details on allowable key names, refer to the [NuGet config file reference](../Schema/nuget-config-file.md).
 
 ## Usage
 

--- a/docs/Tools/cli-ref-sources.md
+++ b/docs/Tools/cli-ref-sources.md
@@ -18,7 +18,8 @@ ms.reviewer:
 
 **Applies to:** package consumption, publishing &bullet; **Supported versions:** all
 
-Manages the list of sources located in `%AppData%\NuGet\NuGet.Config` or the specified configuration file.
+Manages the list of sources located in the user scope configuration file or a specified configuration file. The user scope configuration file is located at `%APPDATA%\NuGet\NuGet.Config` in Windows and at `~/.nuget/NuGet.Config` in Mac/Linux.
+
 
 Note that the source URL for nuget.org is `https://api.nuget.org/v3/index.json`.
 


### PR DESCRIPTION
This PR adds context in `nuget config` command about the exact config file that is affected, similar to the behavior outlined in the `nuget sources` command [doc](https://docs.microsoft.com/en-us/nuget/tools/cli-ref-sources).

cc: @anangaur @karann-msft @kraigb 