### PR TITLE
Quick fix to provide more accurate SymbolSource information for now

### DIFF
--- a/docs/Create-Packages/Symbol-Packages.md
+++ b/docs/Create-Packages/Symbol-Packages.md
@@ -17,9 +17,9 @@ ms.reviewer:
 
 # Creating symbol packages
 
-In addition to building packages for nuget.org or other sources, NuGet also supports creating associated symbol packages and publishing them to the [SymbolSource repository](http://www.symbolsource.org/Public).
+In addition to building packages for nuget.org or other sources, NuGet also supports creating associated symbol packages and publishing them to the SymbolSource repository.
 
-Package consumers can then add `http://srv.symbolsource.org/pdb/Public` to their symbol sources in Visual Studio, which allows stepping into package code in the Visual Studio debugger. See [Specify symbol (.pdb) and source files in the Visual Studio debugger](/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger) for details on that process.
+Package consumers can then add `https://nuget.smbsrc.net` to their symbol sources in Visual Studio, which allows stepping into package code in the Visual Studio debugger. See [Specify symbol (.pdb) and source files in the Visual Studio debugger](/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger) for details on that process.
 
 ## Creating a symbol package
 
@@ -130,4 +130,4 @@ In this case, NuGet will publish `MyPackage.symbols.nupkg`, if present, to https
 
 ## See Also
 
-[Using SymbolSource](https://www.symbolsource.org/Public/Wiki/Using) (symbolsource.org)
+[Moving to the new SymbolSource engine](https://tripleemcoder.com/2015/10/04/moving-to-the-new-symbolsource-engine/) (symbolsource.org)


### PR DESCRIPTION
Docs referenced the old URL for symbols which routes through the dying service. Better to provide the URL to the new backend while we figure out the rest of the NuGet symbol story in the mean time.