### PR TITLE
Make min-version check run before `ResolveAssemblyReferences` target

### DIFF
--- a/docs/guides/Create-UWP-Controls.md
+++ b/docs/guides/Create-UWP-Controls.md
@@ -110,7 +110,7 @@ Here is an example of what the targets file should look like:
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="TPMinVCheck" BeforeTargets="Build;ReBuild" Condition="'$(TargetPlatformMinVersion)' != ''">
+  <Target Name="TPMinVCheck" BeforeTargets="ResolveAssemblyReferences" Condition="'$(TargetPlatformMinVersion)' != ''">
     <PropertyGroup>
       <RequiredTPMinV>10.0.14393</RequiredTPMinV>
       <ActualTPMinV>$(TargetPlatformMinVersion)</ActualTPMinV>


### PR DESCRIPTION
When min version is 16299, other build errors occur before it gets to execute this target. When it resolves the assemblies, and these assemblies require 16299, it fails during the ResolveAssemblyReferences step, since it can't load the assemblies.
Moving the BeforeTargets from `Build;Rebuild` to `ResolveAssemblyReferences` avoids this issue.

Since the entire point of the check is to see whether the assembly reference can be used or not, it actually makes more sense to check it here, than during build/rebuild.