### PR TITLE
Update service index API docs to specify 3.0.0 instead of 3.0.0-beta.1

### DIFF
--- a/docs/api/_data/service-index.json
+++ b/docs/api/_data/service-index.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "resources": [
     {
       "@id": "https://api.nuget.org/v3-flatcontainer/",

--- a/docs/api/service-index.md
+++ b/docs/api/service-index.md
@@ -33,7 +33,8 @@ The `version` value is a SemVer 2.0.0 parseable version string which indicates t
 
 Each resource in the service index is versioned independently from the service index schema version.
 
-The current schema version is `3.0.0-beta.1`.
+The current schema version is `3.0.0`. The `3.0.0` version is functionally equivalent to the older `3.0.0-beta.1`
+version but should be preferred as it more clearly communicates the stable, defined schema.
 
 ## HTTP methods
 


### PR DESCRIPTION
Related to https://github.com/NuGet/NuGetGallery/issues/5403

@kraigb, I'll let you know when I want this merged. I'd like to align it somewhat with the actual service deployment.