### PR TITLE
Updated NuGet 4.3.0+ support of SemVer 2.0.0.

### DIFF
--- a/docs/create-packages/Prerelease-Packages.md
+++ b/docs/create-packages/Prerelease-Packages.md
@@ -75,7 +75,7 @@ With this in mind, it's generally good to follow recognized naming conventions s
 - `-rc`: Release candidate, typically a release that's potentially final (stable) unless significant bugs emerge.
 
 > [!Note]
-> NuGet does not support [SemVer-compatible (v2.0.0)](http://semver.org/spec/v2.0.0.html) prerelease numbers with dot notation, as in `1.0.1-build.23`. You can use a form like `1.0.1-build23` but this is always considered a pre-release version.
+> NuGet 4.3.0+ supports [SemVer-compatible (v2.0.0)](http://semver.org/spec/v2.0.0.html), which supports pre-release numbers with dot notation, as `in 1.0.1-build.23`. Dot notation is not supported with NuGet versions before 4.3.0. You can use a form like `1.0.1-build23` but this is always considered a pre-release version.
 
 Whatever suffixes you use, however, NuGet will give them precedence in reverse alphabetical order:
 

--- a/docs/create-packages/Prerelease-Packages.md
+++ b/docs/create-packages/Prerelease-Packages.md
@@ -75,7 +75,7 @@ With this in mind, it's generally good to follow recognized naming conventions s
 - `-rc`: Release candidate, typically a release that's potentially final (stable) unless significant bugs emerge.
 
 > [!Note]
-> NuGet 4.3.0+ supports [SemVer-compatible (v2.0.0)](http://semver.org/spec/v2.0.0.html), which supports pre-release numbers with dot notation, as `in 1.0.1-build.23`. Dot notation is not supported with NuGet versions before 4.3.0. You can use a form like `1.0.1-build23` but this is always considered a pre-release version.
+> NuGet 4.3.0+ supports [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html), which supports pre-release numbers with dot notation, as `in 1.0.1-build.23`. Dot notation is not supported with NuGet versions before 4.3.0. In earlier versions og NuGet, you could use a form like `1.0.1-build23` but this was always considered a pre-release version.
 
 Whatever suffixes you use, however, NuGet will give them precedence in reverse alphabetical order:
 


### PR DESCRIPTION
According to [NuGet documentation](https://docs.microsoft.com/en-us/nuget/reference/package-versioning#pre-release-versions), SemVer 2.0.0 is supported from version 4.3.0 onward. 
