### PR TITLE
Update requirements build targets

### DIFF
--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -345,7 +345,7 @@ Then in the `.nuspec` file, be sure to refer to these files in the `<files>` nod
 </package>
 ```
 
-Including MSBuild props and targets in a package is a feature that was only [introduced with the release of NuGet 2.5](../release-notes/nuget-2.5#automatic-import-of-msbuild-targets-and-props-files), therefore it is recommended to add the `minClientVersion="2.5"` attribute to the `metadata` element, to indicate the minimum NuGet client version required to consume the package.
+Including MSBuild props and targets in a package is a feature that was only [introduced with the release of NuGet 2.5](../release-notes/NuGet-2.5.md#automatic-import-of-msbuild-targets-and-props-files), therefore it is recommended to add the `minClientVersion="2.5"` attribute to the `metadata` element, to indicate the minimum NuGet client version required to consume the package.
 
 When NuGet 2.5+ installs a package with `\build` files, it adds an MSBuild `<Import>` elements in the project file pointing to the `.targets` and `.props` files. (`.props` is added at the top of the project file; `.targets` is added at the bottom.)
 

--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -170,7 +170,7 @@ The folder conventions are as follows:
 | lib/{tfm} | Assembly (`.dll`), documentation (`.xml`), and symbol (`.pdb`) files for the given Target Framework Moniker (TFM) | Assemblies are added as references; `.xml` and `.pdb` copied into project folders. See [Supporting multiple target frameworks](supporting-multiple-target-frameworks.md) for creating framework target-specific sub-folders. |
 | runtimes | Architecture-specific assembly (`.dll`), symbol (`.pdb`), and native resource (`.pri`) files | Assemblies are added as references; other files are copied into project folders. See [Supporting multiple target frameworks](supporting-multiple-target-frameworks.md). |
 | content | Arbitrary files | Contents are copied to the project root. Think of the **content** folder as the root of the target application that ultimately consumes the package. To have the package add an image in the application's */images* folder, place it in the package's *content/images* folder. |
-| build | MSBuild `.targets` and `.props` files | Automatically inserted into the project file (NuGet 2.x) or `project.lock.json` (NuGet 3.x+). |
+| build | MSBuild `.targets` and `.props` files | Automatically inserted into the project file (NuGet 2.5+) or `project.lock.json` (NuGet 3.x+). |
 | tools | Powershell scripts and programs accessible from the Package Manager Console | The `tools` folder is added to the `PATH` environment variable for the Package Manager Console only (Specifically, *not* to the `PATH` as set for MSBuild when building the project). |
 
 Because your folder structure can contain any number of assemblies for any number of target frameworks, this method is necessary when creating packages that support multiple frameworks 

--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -332,7 +332,7 @@ Then in the `.nuspec` file, be sure to refer to these files in the `<files>` nod
 ```xml
 <?xml version="1.0"?>
 <package >
-    <metadata>
+    <metadata minClientVersion="2.5">
     <!-- ... -->
     </metadata>
     <files>

--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -345,7 +345,9 @@ Then in the `.nuspec` file, be sure to refer to these files in the `<files>` nod
 </package>
 ```
 
-When NuGet 2.x installs a package with `\build` files, it adds an MSBuild `<Import>` elements in the project file pointing to the `.targets` and `.props` files. (`.props` is added at the top of the project file; `.targets` is added at the bottom.)
+Including MSBuild props and targets in a package is a feature that was only [introduced with the release of NuGet 2.5](../release-notes/nuget-2.5#automatic-import-of-msbuild-targets-and-props-files), therefore it is recommended to add the `minClientVersion="2.5"` attribute to the `metadata` element, to indicate the minimum NuGet client version required to consume the package.
+
+When NuGet 2.5+ installs a package with `\build` files, it adds an MSBuild `<Import>` elements in the project file pointing to the `.targets` and `.props` files. (`.props` is added at the top of the project file; `.targets` is added at the bottom.)
 
 With NuGet 3.x, targets are not added to the project but are instead made available through the `project.lock.json`.
 


### PR DESCRIPTION
Add documentation that NuGet 2.5 or later is required for including MSBuild props and targets in a package, as per the [release notes](https://docs.microsoft.com/en-us/nuget//release-notes/nuget-2.5#automatic-import-of-msbuild-targets-and-props-files).

---

https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package