### PR TITLE
Targets file information isnt clear about filename

### DIFF
--- a/docs/guides/Create-UWP-Packages.md
+++ b/docs/guides/Create-UWP-Packages.md
@@ -152,7 +152,7 @@ Within your component, the core logic of the ImageEnhancer type is in native cod
 
 ### Adding .targets
 
-Next, C++ and JavaScript projects that might consume your NuGet package need a .targets file to identify the necessary assembly and winmd files. (C# and Visual Basic projects do this automatically.) Create this file by copying the text below into `ImageEnhancer.targets` and save it in the same folder as the `.nuspec` file:
+Next, C++ and JavaScript projects that might consume your NuGet package need a .targets file to identify the necessary assembly and winmd files. (C# and Visual Basic projects do this automatically.) Create this file by copying the text below into `ImageEnhancer.targets` and save it in the same folder as the `.nuspec` file. _Note_: This `.targets` file needs to be the same name as the package ID (e.g. the `<Id>` element in the `.nupspec` file):
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
The targets file needs to match the ID in the nuspec file, or it can't be imported due to an odd error message. This updates the document to make that clear.