### PR TITLE
M19262: Repeated word and word missing

### DIFF
--- a/docs/reference/target-frameworks.md
+++ b/docs/reference/target-frameworks.md
@@ -125,7 +125,7 @@ The `dotnet` series of monikers should be used in NuGet 3.3 and earlier; the `ne
 ## Portable Class Libraries
 
 > [!Warning]
-> **PCLs are not recommended**. Although PCLs are supported, package authors should support netstandard instead. The .NET Platform Standard is an evolution of PCLs and represents binary portability across platforms using a single moniker that isn't tied to a static like like *portable-a+b+c* monikers.
+> **PCLs are not recommended**. Although PCLs are supported, package authors should support netstandard instead. The .NET Platform Standard is an evolution of PCLs and represents binary portability across platforms using a single moniker that isn't tied to a static library like *portable-a+b+c* monikers.
 
 To define a target framework that refers to multiple child-target-frameworks, the `portable` keyword use used to prefix the list of referenced frameworks. Avoid artificially including extra frameworks that are not directly compiled against because it can lead to unintended side-effects in those frameworks.
 


### PR DESCRIPTION
Hello, @kraigb, 

Translator has reported possible source content issue.  

Is there a word missing after static? Should it rather read 'static library'? 

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR, or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.