### PR TITLE
Nuspect property 'Description' match with MSBuild property 'PackageDe…

### DIFF
--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -51,7 +51,7 @@ Note that the `Owners` and `Summary` properties from `.nuspec` are not supported
 | Authors | Authors | Username of the current user | |
 | Owners | N/A | Not present in NuSpec | |
 | Title | Title | The PackageId| |
-| Description | Description | "Package Description" | |
+| Description | PackageDescription | "Package Description" | |
 | Copyright | Copyright | empty | |
 | RequireLicenseAcceptance | PackageRequireLicenseAcceptance | false | |
 | LicenseUrl | PackageLicenseUrl | empty | |


### PR DESCRIPTION
…scription'

Using 'Description' property result in 'error CS0579'