### PR TITLE
sign command:  fix Options table

### DIFF
--- a/docs/tools/cli-ref-sign.md
+++ b/docs/tools/cli-ref-sign.md
@@ -41,9 +41,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 This option should be used when specifying the certificate via -CertificateSubjectName or -CertificateFingerprint options. |
 | CertificateStoreName | Specifies the name of the X.509 certificate store to use to search for the certificate. Defaults to "My", the X.509 certificate store for personal certificates.
 This option should be used when specifying the certificate via -CertificateSubjectName or -CertificateFingerprint options. |
-| CertificateSubjectName | Specifies the subject name of the certificate used to search a local certificate store for the certificate.
-The search is a case-insensitive string comparison using the supplied value, which will find all certificates with the subject name containing that string, regardless of other subject values.
-The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options. |
+| CertificateSubjectName | Specifies the subject name of the certificate used to search a local certificate store for the certificate.  The search is a case-insensitive string comparison using the supplied value, which will find all certificates with the subject name containing that string, regardless of other subject values.  The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options. |
 | ConfigFile | The NuGet configuration file to apply. If not specified, *%AppData%\NuGet\NuGet.Config* is used. |
 | ForceEnglishOutput | Forces nuget.exe to run using an invariant, English-based culture. |
 | HashAlgorithm | Hash algorithm to be used to sign the package. Defaults to SHA256. |


### PR DESCRIPTION
Scroll halfway down the Options section [here](https://docs.microsoft.com/en-us/nuget/tools/cli-ref-sign#options) and you'll see that the table was broken by some new lines.