### PR TITLE
Fix registration leaf's dependencyGroups documentation

### DIFF
--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -172,7 +172,7 @@ Name                     | Type                       | Required | Notes
 ------------------------ | -------------------------- | -------- | -----
 @id                      | string                     | yes      | The URL to document used to produce this object
 authors                  | string or array of strings | no       | 
-dependencyGroups         | array of objects           | no       | The URL to the package content (.nupkg)
+dependencyGroups         | array of objects           | no       | The dependencies of the package, grouped by target framework
 description              | string                     | no       | 
 iconUrl                  | string                     | no       | 
 id                       | string                     | yes      | The ID of the package


### PR DESCRIPTION
Fixes incorrect notes for the `dependencyGroups` property of registration leaf objects.

/cc @joelverhagen 