### PR TITLE
Added description for buildCrossTargeting

### DIFF
--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -349,7 +349,9 @@ Then in the `.nuspec` file, be sure to refer to these files in the `<files>` nod
 
 Including MSBuild props and targets in a package was [introduced with NuGet 2.5](../release-notes/NuGet-2.5.md#automatic-import-of-msbuild-targets-and-props-files), therefore it is recommended to add the `minClientVersion="2.5"` attribute to the `metadata` element, to indicate the minimum NuGet client version required to consume the package.
 
-When NuGet installs a package with `\build` files, it adds an MSBuild `<Import>` elements in the project file pointing to the `.targets` and `.props` files. (`.props` is added at the top of the project file; `.targets` is added at the bottom.)
+When NuGet installs a package with `\build` files, it adds MSBuild `<Import>` elements in the project file pointing to the `.targets` and `.props` files. (`.props` is added at the top of the project file; `.targets` is added at the bottom.) A separate conditional MSBuild `<Import>` element is added for each target framework.
+
+MSBuild `.props` and `.targets` files for cross-framework targeting can be placed in the `\buildCrossTargeting` folder. During package installation, NuGet adds the corresponding `<Import>` elements to the project file with the condition, that the target framework is not set (the MSBuild property `$(TargetFramework)` must be empty).
 
 With NuGet 3.x, targets are not added to the project but are instead made available through the `project.lock.json`.
 


### PR DESCRIPTION
 Added description on how to add MSBuild props and targets files for the case that `$(TargetFramework)` is empty and the `\buildCrossTargeting` package folder must be used instead.
To clarify the difference, the description for generated imports from files in the `\build` package folder was extended with the information, that a separate import is added for each target framework.