### PR TITLE
Typo in config option

### DIFF
--- a/docs/consume-packages/Configuring-NuGet-Behavior.md
+++ b/docs/consume-packages/Configuring-NuGet-Behavior.md
@@ -93,7 +93,7 @@ nuget config -set repositoryPath= -configfile /home/my.Config
 
 ### Creating a new config file
 
-Copy the template below into the new file and then use `nuget config --configFile <filename>` to set values:
+Copy the template below into the new file and then use `nuget config -configFile <filename>` to set values:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
I didnt to get it to work with ` --configFile` when creating a new file, but it did work with `-configFile`. So maybe change that?