### PR TITLE
fix the meaning of compile and runtime assets in packageref

### DIFF
--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -92,7 +92,7 @@ Allowable values for these tags are as follows, with multiple values separated b
 
 | Value | Description |
 | --- | ---
-| compile | Contents of the `lib` folder and decides whether your project can compile against the assemblies within the folder |
+| compile | Contents of the `lib` folder and controls whether your project can compile against the assemblies within the folder |
 | runtime | Contents of the `lib` and `runtimes` folder and controls whether these assemblies will be copied out to the build output directory |
 | contentFiles | Contents of the `contentfiles` folder |
 | build | Props and targets in the `build` folder |

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -92,8 +92,8 @@ Allowable values for these tags are as follows, with multiple values separated b
 
 | Value | Description |
 | --- | ---
-| compile | Contents of the `lib` folder |
-| runtime | Contents of the `runtimes` folder |
+| compile | Contents of the `lib` folder and decides whether your project can compile against the assemblies within the folder |
+| runtime | Contents of the `lib` and `runtimes` folder and controls whether these assemblies will be copied out to the build output directory |
 | contentFiles | Contents of the `contentfiles` folder |
 | build | Props and targets in the `build` folder |
 | analyzers | .NET analyzers |


### PR DESCRIPTION
CC: @NuGet/nuget-client @jainaashish @rrelyea @kraigb 