### PR TITLE
add missing redirect

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -81,6 +81,11 @@
             "redirect_document_id": false
         },
         {
+            "source_path": "docs/Schema/packages-config.md",
+            "redirect_url": "/nuget/reference/packages-config",
+            "redirect_document_id": false
+        },
+        {
             "source_path": "docs/Schema/target-frameworks.md",
             "redirect_url": "/nuget/reference/target-frameworks",
             "redirect_document_id": false


### PR DESCRIPTION
Customer reported that an answer on SO would result in a 404 for the URL https://docs.microsoft.com/en-us/nuget/reference/packages-config

I've noticed that the file was renamed in this commit https://github.com/NuGet/docs.microsoft.com-nuget/commit/5cfa9b9f891af4505eb894f50699fe6ac9f0f82f#diff-d99b07c5c17aff7907086006735dce3a but the article was not redirected so fixing that

FYI @dasMulli @GuardRex