### PR TITLE
Fix incorrect indentation

### DIFF
--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -68,47 +68,53 @@ The following is a typical (but fictitious) `.nuspec` file, with comments descri
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
     <metadata>
-    <!-- The identifier that must be unique within the hosting gallery -->
-    <id>Contoso.Utility.UsefulStuff</id>
+        <!-- The identifier that must be unique within the hosting gallery -->
+        <id>Contoso.Utility.UsefulStuff</id>
 
-    <!-- The package version number that is used when resolving dependencies -->
-    <version>1.8.3-beta</version>
+        <!-- The package version number that is used when resolving dependencies -->
+        <version>1.8.3-beta</version>
 
-    <!-- Authors contain text that appears directly on the gallery -->
-    <authors>Dejana Tesic, Rajeev Dey</authors>
+        <!-- Authors contain text that appears directly on the gallery -->
+        <authors>Dejana Tesic, Rajeev Dey</authors>
 
-    <!-- Owners are typically nuget.org identities that allow gallery
-            users to easily find other packages by the same owners.  -->
-    <owners>dejanatc, rjdey</owners>
+        <!-- 
+            Owners are typically nuget.org identities that allow gallery
+            users to easily find other packages by the same owners.  
+        -->
+        <owners>dejanatc, rjdey</owners>
 
-    <!-- License and project URLs provide links for the gallery -->
-    <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
-    <projectUrl>http://github.com/contoso/UsefulStuff</projectUrl>
+         <!-- License and project URLs provide links for the gallery -->
+        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <projectUrl>http://github.com/contoso/UsefulStuff</projectUrl>
 
-    <!-- The icon is used in Visual Studio's package manager UI -->
-    <iconUrl>http://github.com/contoso/UsefulStuff/nuget_icon.png</iconUrl>
+        <!-- The icon is used in Visual Studio's package manager UI -->
+        <iconUrl>http://github.com/contoso/UsefulStuff/nuget_icon.png</iconUrl>
 
-    <!-- If true, this value prompts the user to accept the license when
-            installing the package. -->
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <!-- 
+            If true, this value prompts the user to accept the license when
+            installing the package. 
+        -->
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
-    <!-- Any details about this particular release -->
-    <releaseNotes>Bug fixes and performance improvements</releaseNotes>
+        <!-- Any details about this particular release -->
+        <releaseNotes>Bug fixes and performance improvements</releaseNotes>
 
-    <!-- The description can be used in package manager UI. Note that the
-            nuget.org gallery uses information you add in the portal. -->
-    <description>Core utility functions for web applications</description>
+        <!-- 
+            The description can be used in package manager UI. Note that the
+            nuget.org gallery uses information you add in the portal. 
+        -->
+        <description>Core utility functions for web applications</description>
 
-    <!-- Copyright information -->
-    <copyright>Copyright ©2016 Contoso Corporation</copyright>
+        <!-- Copyright information -->
+        <copyright>Copyright ©2016 Contoso Corporation</copyright>
 
-    <!-- Tags appear in the gallery and can be used for tag searches -->
-    <tags>web utility http json url parsing</tags>
+        <!-- Tags appear in the gallery and can be used for tag searches -->
+        <tags>web utility http json url parsing</tags>
 
-    <!-- Dependencies are automatically installed when the package is installed -->
-    <dependencies>
-        <dependency id="Newtonsoft.Json" version="9.0" />
-    </dependencies>
+        <!-- Dependencies are automatically installed when the package is installed -->
+        <dependencies>
+            <dependency id="Newtonsoft.Json" version="9.0" />
+        </dependencies>
     </metadata>
 
     <!-- A readme.txt to display when the package is installed -->


### PR DESCRIPTION
The `metadata` tag was on the same level as its children. That is confusing when skimming the code.