### PR TITLE
Fixed typo in a sample

### DIFF
--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -319,7 +319,7 @@ Project file:
 ```xml
 <PropertyGroup>
     <RestoreIgnoreFailedSource>true</RestoreIgnoreFailedSource>
-<PropertyGroup>
+</PropertyGroup>
 ```
 
 ### Restore outputs


### PR DESCRIPTION
Properly closed a `<PropertyGroup>` tag.