### PR TITLE
fixed exclude files copy/paste error

### DIFF
--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -384,9 +384,9 @@ Each `<file>` element specifies the following attributes:
 **Excluding files**
 
     Source files:
-        \tools\*.bak
-        \tools\*.log
-        \tools\build\*.log
+        \tools\file.bak
+        \tools\file.log
+        \tools\build\file.log
 
     .nuspec entries:
         <file src="tools\*.*" target="tools" exclude="tools\*.bak" />

--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -384,9 +384,10 @@ Each `<file>` element specifies the following attributes:
 **Excluding files**
 
     Source files:
-        \tools\file.bak
-        \tools\file.log
-        \tools\build\file.log
+        \tools\fileA.bak
+        \tools\fileB.bak
+        \tools\fileA.log
+        \tools\build\fileB.log
 
     .nuspec entries:
         <file src="tools\*.*" target="tools" exclude="tools\*.bak" />


### PR DESCRIPTION
Source Files in the Exclude example were a pattern, not a discreet set of files. If I've misunderstood, let me know!