### PR TITLE
Remove chmod from install docs.

### DIFF
--- a/docs/includes/install-cli.md
+++ b/docs/includes/install-cli.md
@@ -15,8 +15,6 @@ Behaviors may vary slightly by OS distribution.
     ```bash
     # Download the latest stable `nuget.exe` to `/usr/local/bin`
     sudo curl -o /usr/local/bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-    # Give the file permissions to execute
-    sudo chmod 755 /usr/local/bin/nuget.exe
     ```
 
 1. Create an alias by adding the following script to the appropriate file for your OS (typically `~/.bash_aliases` or `~/.bash_profile`):


### PR DESCRIPTION
chmod +x is not needed because nuget.exe is never executed directly because of the alias to use the mono executable.