### PR TITLE
Drop preview from PackageReference migration doc

### DIFF
--- a/docs/reference/migrate-packages-config-to-package-reference.md
+++ b/docs/reference/migrate-packages-config-to-package-reference.md
@@ -10,7 +10,7 @@ ms.topic: conceptual
 
 # Migrate from packages.config to PackageReference
 
-Visual Studio 2017 Version 15.7 Preview 3 and later supports migrating a project from the [packages.config](./packages-config.md) management format to the [PackageReference](../consume-packages/Package-References-in-Project-Files.md) format.
+Visual Studio 2017 Version 15.7 and later supports migrating a project from the [packages.config](./packages-config.md) management format to the [PackageReference](../consume-packages/Package-References-in-Project-Files.md) format.
 
 ## Benefits of using PackageReference
 


### PR DESCRIPTION
Since 15.7 is released, there's not really a need to keep the `preview` in since it has already confused users.
See https://github.com/NuGet/Home/issues/6967

cc @kraigb 