### PR TITLE
Environment variables format typo

### DIFF
--- a/docs/consume-packages/Configuring-NuGet-Behavior.md
+++ b/docs/consume-packages/Configuring-NuGet-Behavior.md
@@ -68,7 +68,7 @@ nuget config -set repositoryPath=/home/packages -configfile $XDG_DATA_HOME/NuGet
 ```
 
 > [!Note]
-> In NuGet 3.4 and later you can use environment variables in any value, as in `repositoryPath=%PACKAGEHOME%` (Windows) and `repositoryPath=%PACKAGEHOME` (Mac/Linux).
+> In NuGet 3.4 and later you can use environment variables in any value, as in `repositoryPath=%PACKAGEHOME%` (Windows) and `repositoryPath=$PACKAGEHOME` (Mac/Linux).
 
 ### Removing a value
 


### PR DESCRIPTION
Environment variables format is $VAR_NAME ON Mac/Linux