### PR TITLE
Document the tools.json endpoint

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -176,6 +176,7 @@
 ## [Catalog](api/catalog-resource.md)
 ## [Rate limits](api/rate-limits.md)
 ## [nuget.org protocols](api/nuget-protocols.md)
+## [tools.json](api/tools-json.md)
 # Visual Studio extensibility
 ## [NuGet API in Visual Studio](visual-studio-extensibility/nuget-api-in-visual-studio.md)
 ## [Project system support](visual-studio-extensibility/project-system-support.md)

--- a/docs/api/_data/tools-json.json
+++ b/docs/api/_data/tools-json.json
@@ -1,0 +1,34 @@
+{
+    "nuget.exe": [
+        {
+            "version": "4.8.0-preview3",
+            "url": "https://dist.nuget.org/win-x86-commandline/v4.8.0-preview3/nuget.exe",
+            "stage": "EarlyAccessPreview",
+            "uploaded": "2018-07-06T23:00:00.0000000Z"
+        },
+        {
+            "version": "4.7.1",
+            "url": "https://dist.nuget.org/win-x86-commandline/v4.7.1/nuget.exe",
+            "stage": "ReleasedAndBlessed",
+            "uploaded": "2018-08-10T23:00:00.0000000Z"
+        },
+        {
+            "version": "4.6.1",
+            "url": "https://dist.nuget.org/win-x86-commandline/v4.6.1/nuget.exe",
+            "stage": "Released",
+            "uploaded": "2018-03-22T23:00:00.0000000Z"
+        },
+        {
+            "version": "3.5.0",
+            "url": "https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe",
+            "stage": "ReleasedAndBlessed",
+            "uploaded": "2016-12-19T15:30:00.0000000-08:00"
+        },
+        {
+            "version": "2.8.6",
+            "url": "https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe",
+            "stage": "ReleasedAndBlessed",
+            "uploaded": "2015-09-01T12:30:00.0000000-07:00"
+        }
+    ]
+}

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -19,6 +19,8 @@ This API is used by the NuGet client in Visual Studio, nuget.exe, and the .NET C
 
 Note in some cases, nuget.org has additional requirements that are not enforced by other package sources. These differences are documented by the [nuget.org Protocols](nuget-protocols.md).
 
+For a simple enumeration and download of available nuget.exe versions, see the [tools.json](tools-json.md) endpoint.
+
 ## Service index
 
 The entry point for the API is a JSON document in a well known location. This document is called the **service index**. The location of the service index for nuget.org is `https://api.nuget.org/v3/index.json`.

--- a/docs/api/tools-json.md
+++ b/docs/api/tools-json.md
@@ -1,0 +1,80 @@
+---
+title: tools.json for discovering nuget.exe versions
+description: The endpoint for 
+author: jver
+ms.author: jver
+manager: skofman
+ms.date: 08/16/2018
+ms.topic: conceptual
+ms.reviewer: kraigb
+---
+
+# tools.json for discovering nuget.exe versions
+
+Today, there are a few ways to get the latest version of nuget.exe on your machine in a scriptable fashion. For example,
+you can download and extract the [`NuGet.CommandLine`](https://www.nuget.org/packages/NuGet.CommandLine/) package from
+nuget.org. This has some complexity since it either requires that you already have nuget.exe (for `nuget.exe install`)
+or you have to unzip the .nupkg using a basic unzip tool and find the binary inside.
+
+If you already have nuget.exe, you can also use `nuget.exe update -self`, however this also requires having an existing
+copy of nuget.exe. This approach also updates you to the latest version. It does not allow the use of a specific
+version.
+
+The `tools.json` endpoint is available to both solve the bootstrapping problem and to give control of the version of
+nuget.exe that you download. This can be used in CI/CD environments or in custom scripts to discover and download any
+released version of nuget.exe.
+
+The `tools.json` endpoint can be fetched using an unauthenticated HTTP request (e.g. `Invoke-WebRequest` in PowerShell
+or `wget`). It can be parsed using a JSON deserializer and subsequent nuget.exe download URLs can also be fetched using
+unauthenticated HTTP requests.
+
+The endpoint can be fetched using the `GET` method:
+
+	GET https://dist.nuget.org/tools.json
+
+The [JSON schema](http://json-schema.org/) for the endpoint is available here:
+
+	GET https://dist.nuget.org/tools.schema.json
+
+## Response
+
+The response is a JSON document containing all of the available versions of nuget.exe.
+
+The root JSON object has the following property:
+
+Name      | Type             | Required
+--------- | ---------------- | --------
+nuget.exe | array of objects | yes
+
+Each object in the `nuget.exe` array has the following properties:
+
+Name     | Type   | Required | Notes
+-------- | ------ | -------- | -----
+version  | string | yes      | A SemVer 2.0.0 string
+url      | string | yes      | An absolute URL for downloading this version of nuget.exe
+stage    | string | yes      | An enum string
+uploaded | string | yes      | An approximate timestamp of when the version was made available
+
+The items in the array will be sorted in descending, SemVer 2.0.0 order. This guarantee is meant to ease the burden on
+a client looking for the latest version. 
+
+The `stage` property indicates how vettect this version of the tool is. 
+
+Stage              | Meaning
+------------------ | ------
+EarlyAccessPreview | Not yet visible on the [download web page](https://www.nuget.org/downloads) and should be validated by partners
+Released           | Available on the download site but is not yet recommended for wide-spread consumption
+ReleasedAndBlessed | Available on the download site and is recommended for consumption
+
+One simple approach for having the latest, recommended version is to take the first version in the list that has the
+`stage` value of `ReleasedAndBlessed`.
+
+The `NuGet.CommandLine` package on nuget.org is typically only updated with `ReleasedAndBlessed` versions.
+
+### Sample request
+
+    GET https://dist.nuget.org/tools.json
+
+### Sample response
+
+[!code-JSON [tools-json.json](./_data/tools-json.json)]


### PR DESCRIPTION
This is used internally (VSTS) and has been mentioned to a couple customers over email and GitHub issue.

I went ahead and documented it as a simplified way of fetching the latest versions of nuget.exe with just `wget` and a JSON parser (few requirements, ideal for custom scripts).

Preview:
https://review.docs.microsoft.com/en-us/nuget/api/tools-json?branch=jver-toolsjson