### PR TITLE
Fix typo in "Analyzer NuGet formats"

### DIFF
--- a/docs/reference/analyzers-conventions.md
+++ b/docs/reference/analyzers-conventions.md
@@ -39,7 +39,7 @@ Also note that because this package has no platform-specific requirements, the `
 
 The use of the `analyzers` folder is similar to that used for [target frameworks](../create-packages/supporting-multiple-target-frameworks.md), except the specifiers in the path describe development host dependencies instead of build-time. The general format is as follows:
 
-    $/analyzers/{framework_name}{version}/{supported_architecture}/{supported_language}}/{analyzer_name}.dll
+    $/analyzers/{framework_name}{version}/{supported_architecture}/{supported_language}/{analyzer_name}.dll
 
 - **framework_name**: the *optional* API surface area of the .NET Framework that the contained DLLs need to run. `dotnet` is presently the only valid value because Roslyn is the only host that can run analyzers. If no target is specified, DLLs are assumed to apply to *all* targets.
 - **supported_language**: the language for which the DLL applies, one of `cs` (C#) and `vb` (Visual Basic), and `fs` (F#). The language indicates that the analyzer should be loaded only for a project using that language. If no language is specified then DLL is assumed to apply to *all* languages that support analyzers.


### PR DESCRIPTION
Fixed a tiny typo I noticed when reading the article.