### PR TITLE
Fixed quote on CLI pack page

### DIFF
--- a/docs/tools/cli-ref-pack.md
+++ b/docs/tools/cli-ref-pack.md
@@ -83,7 +83,7 @@ nuget pack foo.csproj -Properties Configuration=Release
 nuget pack foo.csproj -Build -Symbols -Properties owners=janedoe,xiaop;version="1.0.5"
 
 # Create a package from project foo.csproj, using MSBuild version 12 to build the project
-nuget pack foo.csproj -Build -Symbols -MSBuildVersion 12 -Properties owners=janedoe,xiaop;version="1.0.5
+nuget pack foo.csproj -Build -Symbols -MSBuildVersion 12 -Properties owners=janedoe,xiaop;version="1.0.5"
 
 nuget pack foo.nuspec -Version 2.1.0
 


### PR DESCRIPTION
Added a missing quote (closed quotes) to the "Create a package from project foo.csproj, using MSBuild version 12 to build the project" excample command.