### PR TITLE
Don't use ambiguous term "namespaces"

### DIFF
--- a/docs/api/search-query-service-resource.md
+++ b/docs/api/search-query-service-resource.md
@@ -107,7 +107,7 @@ totalDownloads | integer                    | no       | This value can be infer
 verified       | boolean                    | no       | A JSON boolean indicating whether the package is [verified](../reference/id-prefix-reservation.md)
 
 On nuget.org, a verified package is one which has a package ID matching a reserved ID prefix and owned by one of the
-reserved namespace's owners. For more information, see the
+reserved prefix's owners. For more information, see the
 [documentation about ID prefix reservation](../reference/id-prefix-reservation.md).
 
 The metadata contained in the search result object is taken from the latest package version. Each item in the

--- a/docs/reference/ID-Prefix-Reservation.md
+++ b/docs/reference/ID-Prefix-Reservation.md
@@ -60,7 +60,7 @@ When a package comes from a reserved prefix, you see the below visual indicators
 
 1. Review the acceptance [criteria for prefix ID reservation](#id-prefix-reservation-criteria).
 
-2. Determine the namespaces you want to reserve, in addition to any [advanced prefix reservation scenarios](#advanced-prefix-reservation-scenarios) you may require.
+2. Determine the prefixes you want to reserve, in addition to any [advanced prefix reservation scenarios](#advanced-prefix-reservation-scenarios) you may require.
 
 3. Send a mail to [account@nuget.org](mailto:account@nuget.org) with the owner display name on [nuget.org](https://www.nuget.org/), as well as any reserved prefixes you are requesting. If you are delegating prefix subsets to multiple owners, make sure you mention all owner display names and prefix subsets.
 


### PR DESCRIPTION
I was recently applying for an ID prefix reservation on nuget.org and following statement

> Determine the **namespaces** you want to reserve...

made me think that in addition to package ID prefix I can reserve .NET namespaces used in my code. That is obviously not true so I propose to replace "namespaces" with "prefixes".


