### PR TITLE
Avoid a 301 to a preview article & fix minor typo

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,7 @@ The NuGet API is a set of HTTP endpoints that can be used to download packages, 
 and perform most other operations available in the official NuGet clients.
 
 This API is used by the NuGet client in Visual Studio, nuget.exe, and the .NET CLI to perform NuGet operations such as
-[`dotnet restore`](/dotnet/articles/core/preview3/tools/dotnet-restore), search in the Visual Studio UI, and [`nuget.exe push`](../tools/cli-ref-push.md).
+[`dotnet restore`](/dotnet/core/tools/dotnet-restore?tabs=netcore2x), search in the Visual Studio UI, and [`nuget.exe push`](../tools/cli-ref-push.md).
 
 Note in some cases, nuget.org has additional requirements that are not enforced by other package sources. These differences are documented by the [nuget.org Protocols](nuget-protocols.md).
 
@@ -34,7 +34,7 @@ For more information about the service index, see [its API reference](service-in
 
 ## Versioning
 
-The API is version 3 of NuGet's HTTP protocol. This protocol is sometimes referred to as "the V3 API." These reference
+The API is version 3 of NuGet's HTTP protocol. This protocol is sometimes referred to as "the V3 API". These reference
 documents will refer to this version of the protocol simply as "the API."
 
 The service index schema version is indicated by the `version` property in the service index. The API mandates that


### PR DESCRIPTION
Changed the link to the direct article (which points to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?tabs=netcore2x) without the "preview3/..." redirect.