### PR TITLE
fix: typo in authors token

### DIFF
--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -142,7 +142,7 @@ With the exception of `$configuration$`, values in the project are used in prefe
 | --- | --- | ---
 | **$id$** | Project file | AssemblyName (title) from the project file |
 | **$version$** | AssemblyInfo | AssemblyInformationalVersion if present, otherwise AssemblyVersion |
-| **$author$** | AssemblyInfo | AssemblyCompany |
+| **$authors$** | AssemblyInfo | AssemblyCompany |
 | **$title$** | AssemblyInfo | AssemblyTitle |
 | **$description$** | AssemblyInfo | AssemblyDescription |
 | **$copyright$** | AssemblyInfo | AssemblyCopyright |


### PR DESCRIPTION
Based on issue #1072, I've corrected the docs in the appropriate place.