### PR TITLE
Update TOC.md

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -31,7 +31,6 @@
 ## Guides
 ### [Create UWP packages](guides/create-uwp-packages.md)
 ### [Creating UI controls as NuGet packages](guides/create-UI-controls.md)
-### [Create NET Standard/NET Framework packages with Visual Studio 2015](guides/create-net-standard-packages-vs2015.md)
 ### [Create packages for Xamarin with Visual Studio 2015](guides/create-packages-for-xamarin.md)
 # Host packages
 ## [Overview](hosting-packages/overview.md)


### PR DESCRIPTION
fixes #1124 

Remove the link to docs for creating .NET Standard packages in VS2015, since .NET Core tooling was only pre-release in VS2015. Using the dotnet CLI is recommended over VS2015, if VS2017 can't be used for some reason.