### PR TITLE
Add Sleet to hosting-packages doc

### DIFF
--- a/docs/hosting-packages/Overview.md
+++ b/docs/hosting-packages/Overview.md
@@ -27,6 +27,7 @@ There are also several other NuGet hosting products that support remote private 
 - [NuGet Server (Open Source)](http://nuget-server.net), an open-source implementation similar to Inedo's NuGet Server
 - [LiGet](https://github.com/ai-traders/liget), an open-source implementation of NuGet V2 server that runs on kestrel in docker
 - [BaGet](https://github.com/loic-sharma/BaGet), an open-source implementation of NuGet V3 server built on ASP.NET Core
+- [Sleet](https://github.com/emgarten/sleet), an open-source NuGet V3 static feed generator
 - [Artifactory](https://www.jfrog.com/artifactory/) from JFrog.
 - [Nexus](http://www.sonatype.org/nexus/) from Sonatype.
 - [TeamCity](https://www.jetbrains.com/teamcity/) from JetBrains.


### PR DESCRIPTION
This change adds Sleet to hosting-packages doc. It is a static feed generator that creates NuGet v3 feeds which can be hosted on a web server, azure storage, or amazon s3.

The approach of Sleet is different from other feeds in the list, I think users exploring their options on this page would find it useful.