### PR TITLE
Fixed the license path

### DIFF
--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -93,7 +93,7 @@ If you are using a license that hasn’t been assigned an SPDX identifier, or it
 <package>
   <metadata>
     ...
-    <license type="file">LICENSE.txt</license>
+    <license type="file">licenses/LICENSE.txt</license>
     ...
   </metadata>
   <files>


### PR DESCRIPTION
The example doesn't work because the embedded file a few lines down and the license file link (corrected here) doesn't match.