### PR TITLE
C55619: Moving space after asterisk in "*any *" as "*any* "

### DIFF
--- a/docs/create-packages/Prerelease-Packages.md
+++ b/docs/create-packages/Prerelease-Packages.md
@@ -59,7 +59,7 @@ In this convention, each version has three parts, `Major.Minor.Patch`, with the 
 - `Minor`: New features, but backwards compatible
 - `Patch`: Backwards compatible bug fixes only
 
-Pre-release versions are then denoted by appending a hyphen and a string after the patch number. Technically speaking, you can use *any *string after the hyphen and NuGet will treat the package as pre-release. NuGet then displays the full version number in the applicable UI, leaving consumers to interpret the meaning for themselves.
+Pre-release versions are then denoted by appending a hyphen and a string after the patch number. Technically speaking, you can use *any* string after the hyphen and NuGet will treat the package as pre-release. NuGet then displays the full version number in the applicable UI, leaving consumers to interpret the meaning for themselves.
 
 With this in mind, it's generally good to follow recognized naming conventions such as the following:
 


### PR DESCRIPTION
Hello @karann-msft,
Translator has reported possible source content issue.
Please review and merge the suggested proposed file change to avoid this error. If you make related fix in another PR, then share your PR number, so we can confirm and close this PR.
Many thanks in advance.