### PR TITLE
Add missing supported MSBuild versions

### DIFF
--- a/docs/tools/cli-ref-pack.md
+++ b/docs/tools/cli-ref-pack.md
@@ -38,7 +38,7 @@ where `<nuspecPath>` and `<projectPath>` specify the `.nuspec` or project file, 
 | IncludeReferencedProjects | Indicates that the built package should include referenced projects either as dependencies or as part of the package. If a referenced project has a corresponding `.nuspec` file that has the same name as the project, then that referenced project is added as a dependency. Otherwise, the referenced project is added as part of the package. |
 | MinClientVersion | Set the *minClientVersion* attribute for the created package. This value will override the value of the existing *minClientVersion* attribute (if any) in the `.nuspec` file. |
 | MSBuildPath | *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`. |
-| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
+| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
 | NoDefaultExcludes | Prevents default exclusion of NuGet package files and files and folders starting with a dot, such as `.svn` and `.gitignore`. |
 | NoPackageAnalysis | Specifies that pack should not run package analysis after building the package. |
 | OutputDirectory | Specifies the folder in which the created package is stored. If no folder is specified, the current folder is used. |

--- a/docs/tools/cli-ref-restore.md
+++ b/docs/tools/cli-ref-restore.md
@@ -34,7 +34,7 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 | ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
 | Help | Displays help information for the command. |
 | MSBuildPath | *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`. |
-| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
+| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
 | NoCache | Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../consume-packages/managing-the-global-packages-and-cache-folders.md). |
 | NonInteractive | Suppresses prompts for user input or confirmations. |
 | OutputDirectory | Specifies the folder in which packages are installed. If no folder is specified, the current folder is used. Required when restoring with a `packages.config` file unless `PackagesDirectory` or `SolutionDirectory` is used.|

--- a/docs/tools/cli-ref-update.md
+++ b/docs/tools/cli-ref-update.md
@@ -37,7 +37,7 @@ where `<configPath>` identifies either a `packages.config` or solution file that
 | Help | Displays help information for the command. |
 | Id | Specifies a list of package IDs to update. |
 | MSBuildPath | *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`. |
-| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
+| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
 | NonInteractive | Suppresses prompts for user input or confirmations. |
 | PreRelease | Allows updating to prerelease versions. This flag is not required when updating prerelease packages that are already installed. |
 | RepositoryPath | Specifies the local folder where packages are installed. |


### PR DESCRIPTION
Looking at releases ( https://github.com/Microsoft/msbuild/releases ), following versions have a release/tag associated with it.
* 15.1
    * MSBuild 15.1.458
    * MSBuild 15.1.523
    * MSBuild 15.1.545
    * MSBuild 15.1.548
    * MSBuild 15.1.550
    * MSBuild 15.1.1012
* 15.3
    * MSBuild 15.3.117
    * MSBuild 15.3.118
    * MSBuild 15.3.255
    * MSBuild 15.3.388
    * MSBuild 15.3.402
    * MSBuild 15.3.407
    * MSBuild 15.3.409
* 15.4
    * MSBuild 15.4.8
* 15.5
    * MSBuild 15.5.180
* 15.6
    * MSBuild 15.6.82
* 15.7
    * MSBuild 15.7.177
    * MSBuild 15.7.179 
    * MSBuild 15.7.180
* 15.8
    * MSBuild 15.8.166
    * MSBuild 15.8.168
    * MSBuild 15.8.169
* MSBuild 15.9.20
    * 15.9

So supported version 15 versions should be
* 15.1
* 15.3
* 15.4
* 15.5
* 15.6
* 15.7
* 15.8
* 15.9

which I propose in this PR.

Relates to i.e. NuGet/Home#5170, NuGet/Home#4941