### PR TITLE
Clarify native code docs

### DIFF
--- a/docs/create-packages/Native-Packages.md
+++ b/docs/create-packages/Native-Packages.md
@@ -9,7 +9,7 @@ ms.topic: conceptual
 
 # Creating native packages
 
-A native package contains native C++ code instead of managed code, allowing it to be used within C++ projects. (See [Native C++ Packages](../consume-packages/finding-and-choosing-packages.md#native-c-packages) in the Consume section.)
+A native package contains native binaries instead of managed assemblies, allowing it to be used within C++ (or similar) projects. (See [Native C++ Packages](../consume-packages/finding-and-choosing-packages.md#native-c-packages) in the Consume section.)
 
 To be consumable in a C++ project, a package must target the `native` framework. At present there are not any version numbers associated with this framework as NuGet treats all C++ projects the same.
 


### PR DESCRIPTION
Fixes discussion of native packages and clarifies that it is binaries, not source code in the packages

Per request of @starmessage in #925 

/cc @loic-sharma @zivkan @karann-msft @anangaur 