### PR TITLE
add details of the endpoint uri for "int.nugettest.org"

### DIFF
--- a/docs/faqs/NuGet-FAQ.md
+++ b/docs/faqs/NuGet-FAQ.md
@@ -161,7 +161,7 @@ NuGet recommends all packages to be signed. A design principle of package signin
 
 Note that dependencies listed for your package are generated automatically from the package itself and cannot be edited.
 
-In addition, uploading packages to [int.nugettest.org](https://int.nugettest.org) is a great way to test and validate your package without making a package available in the public gallery.
+In addition, uploading packages to [int.nugettest.org](https://int.nugettest.org) is a great way to test and validate your package without making a package available in the public gallery. (EndPoint Uri is https://apiint.nugettest.org/v3/index.json)
 
 **Is it possible to reserve names for packages that will be published in future?**
 

--- a/docs/faqs/NuGet-FAQ.md
+++ b/docs/faqs/NuGet-FAQ.md
@@ -161,7 +161,7 @@ NuGet recommends all packages to be signed. A design principle of package signin
 
 Note that dependencies listed for your package are generated automatically from the package itself and cannot be edited.
 
-In addition, uploading packages to [int.nugettest.org](https://int.nugettest.org) is a great way to test and validate your package without making a package available in the public gallery. (EndPoint Uri is https://apiint.nugettest.org/v3/index.json)
+In addition, uploading packages to [int.nugettest.org](https://int.nugettest.org) is a great way to test and validate your package without making a package available in the public gallery. API Endpoint: https://apiint.nugettest.org/v3/index.json
 
 **Is it possible to reserve names for packages that will be published in future?**
 


### PR DESCRIPTION
found it hard to use nuget push against int w/o the endpoint uri.