### PR TITLE
Fixing $authors$ to $author$

### DIFF
--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -190,7 +190,7 @@ With the exception of `$configuration$`, values in the project are used in prefe
 | --- | --- | ---
 | **$id$** | Project file | AssemblyName (title) from the project file |
 | **$version$** | AssemblyInfo | AssemblyInformationalVersion if present, otherwise AssemblyVersion |
-| **$authors$** | AssemblyInfo | AssemblyCompany |
+| **$author$** | AssemblyInfo | AssemblyCompany |
 | **$title$** | AssemblyInfo | AssemblyTitle |
 | **$description$** | AssemblyInfo | AssemblyDescription |
 | **$copyright$** | AssemblyInfo | AssemblyCopyright |


### PR DESCRIPTION
nuget pack for a csproj only works when `$author$` is used in the nuspec and the `[AssemblyCompany]` is populated.  `$authors$` does not work.  This resolves content feedback items https://github.com/NuGet/docs.microsoft.com-nuget/issues/1226 and should revert the changes made in https://github.com/NuGet/docs.microsoft.com-nuget/issues/1072