### PR TITLE
Replace NuGet.Client package with NuGet.Commands

### DIFF
--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -12,7 +12,7 @@ ms.topic: conceptual
 > [!Note]
 > Not to be confused with the [NuGet *Web* API](https://docs.microsoft.com/en-us/nuget/api/overview)
 
-The *NuGet Client SDK* refers to a group of .NET libraries centered around [NuGet.Client](https://www.nuget.org/packages/NuGet.Client), [Nuget.Packaging](https://www.nuget.org/packages/NuGet.Packaging), and [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol). These packages replace the earlier [NuGet.Core](https://www.nuget.org/packages/NuGet.Core/) library.
+The *NuGet Client SDK* refers to a group of .NET libraries centered around [NuGet.Commands](https://www.nuget.org/packages/NuGet.Commands), [Nuget.Packaging](https://www.nuget.org/packages/NuGet.Packaging), and [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol). These packages replace the earlier [NuGet.Core](https://www.nuget.org/packages/NuGet.Core/) library.
 
 We are working on having a stable surface area that we can document soon.
 


### PR DESCRIPTION
NuGet.Client is long gone. 
NuGet.Commands contains the most relevant code. 