### PR TITLE
Wrong argument used in example

### DIFF
--- a/docs/create-packages/Sign-a-Package.md
+++ b/docs/create-packages/Sign-a-Package.md
@@ -24,7 +24,7 @@ You can use self-issued certificates for testing purposes. However, packages sig
 
   ![Certificate Export Wizard](../reference/media/CertificateExportWizard.png)
 
-* You can also export the certificate using the [Export-Certificate PowerShell command](/powershell/module/pkiclient/export-certificate.md).
+* You can also export the certificate using the [Export-Certificate PowerShell command](/powershell/module/pkiclient/export-certificate).
 
 ## Sign the package
 
@@ -34,7 +34,7 @@ You can use self-issued certificates for testing purposes. However, packages sig
 Sign the package using [nuget sign](../tools/cli-ref-sign.md):
 
 ```cli
-nuget sign MyPackage.nupkg -CertificateFilePath <PathToTheCertificate> -Timestamper <TimestampServiceURL>
+nuget sign MyPackage.nupkg -CertificatePath <PathToTheCertificate> -Timestamper <TimestampServiceURL>
 ```
 
 * You can use a certificate available in the certificate store or use a certificate from a file. See CLI reference for [nuget sign](../tools/cli-ref-sign.md).


### PR DESCRIPTION
Fixing up the wrong argument used for CertificatePath and fixing another incorrect URI that is going to a 404 page