### PR TITLE
Rename buildCrossTargeting to buildMultiTargeting

### DIFF
--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -352,7 +352,7 @@ Including MSBuild props and targets in a package was [introduced with NuGet 2.5]
 
 When NuGet installs a package with `\build` files, it adds MSBuild `<Import>` elements in the project file pointing to the `.targets` and `.props` files. (`.props` is added at the top of the project file; `.targets` is added at the bottom.) A separate conditional MSBuild `<Import>` element is added for each target framework.
 
-MSBuild `.props` and `.targets` files for cross-framework targeting can be placed in the `\buildCrossTargeting` folder. During package installation, NuGet adds the corresponding `<Import>` elements to the project file with the condition, that the target framework is not set (the MSBuild property `$(TargetFramework)` must be empty).
+MSBuild `.props` and `.targets` files for cross-framework targeting can be placed in the `\buildMultiTargeting` folder. During package installation, NuGet adds the corresponding `<Import>` elements to the project file with the condition, that the target framework is not set (the MSBuild property `$(TargetFramework)` must be empty).
 
 With NuGet 3.x, targets are not added to the project but are instead made available through the `project.lock.json`.
 


### PR DESCRIPTION
Rename `/buildCrossTargeting` to `/buildMultiTargeting`.
For the reference: https://github.com/NuGet/Home/issues/4098

Addresses #1412