### PR TITLE
Simplify the "Package creation" intro

### DIFF
--- a/docs/create-packages/Overview-and-Workflow.md
+++ b/docs/create-packages/Overview-and-Workflow.md
@@ -16,9 +16,9 @@ A package can also serve to only pull in any number of other dependencies, witho
 > [!Note]
 > When you create a package for use by other developers, it's important to understand that they are taking a dependency on your work. As such, creating and publishing a package also implies a commitment to fixing bugs and making other updates, or at the very least making the package available as open source so others can help to maintain it.
 
-Whatever the case, creating a package begins with deciding which assemblies and other files to package. You then create a manifest file, referred to as a `.nuspec` file, to describe the package's contents along with its identifier, version number, copyright information, MSBuild props and targets, and much more.
+Whatever the case, creating a package begins with deciding what it should contain along with its identifier, version number, copyright information, etc...
 
-When you've prepared all the necessary files in the appropriate folders and have created the appropriate `.nuspec` file, you then use the `nuget pack` command (or the [MSBuild pack target](../reference/msbuild-targets.md)) to put everything together into a `.nupkg` file. You're then ready to deploy the package to whatever host makes it available to other developers.
+When you've prepared all the necessary content, you can use the "pack" comamnd to put everything together into a `.nupkg` file. You're then ready to deploy the package to whatever host makes it available to other developers.
 
 > [!Tip]
 > A NuGet package with the `.nupkg` extension is simply a ZIP file. To easily examine any package's contents, change the extension to `.zip` and expand its contents as usual. Just be sure to change the extension back to `.nupkg` before attempting to upload it to a host.

--- a/docs/create-packages/Overview-and-Workflow.md
+++ b/docs/create-packages/Overview-and-Workflow.md
@@ -16,9 +16,7 @@ A package can also serve to only pull in any number of other dependencies, witho
 > [!Note]
 > When you create a package for use by other developers, it's important to understand that they are taking a dependency on your work. As such, creating and publishing a package also implies a commitment to fixing bugs and making other updates, or at the very least making the package available as open source so others can help to maintain it.
 
-Whatever the case, creating a package begins with deciding what it should contain along with its identifier, version number, copyright information, etc...
-
-When you've prepared all the necessary content, you can use the "pack" command to put everything together into a `.nupkg` file. Then you're ready to deploy the package to whatever host makes it available to other developers.
+Whatever the case, creating a package begins with deciding its identifier, version number, license, copyright information, and any other necessary content. Once done, you can use the "pack" command to put everything together into a `.nupkg` file. This file can be published to a NuGet feed, like nuget.org.
 
 > [!Tip]
 > A NuGet package with the `.nupkg` extension is simply a ZIP file. To easily examine any package's contents, change the extension to `.zip` and expand its contents as usual. Just be sure to change the extension back to `.nupkg` before attempting to upload it to a host.

--- a/docs/create-packages/Overview-and-Workflow.md
+++ b/docs/create-packages/Overview-and-Workflow.md
@@ -18,7 +18,7 @@ A package can also serve to only pull in any number of other dependencies, witho
 
 Whatever the case, creating a package begins with deciding what it should contain along with its identifier, version number, copyright information, etc...
 
-When you've prepared all the necessary content, you can use the "pack" comamnd to put everything together into a `.nupkg` file. You're then ready to deploy the package to whatever host makes it available to other developers.
+When you've prepared all the necessary content, you can use the "pack" command to put everything together into a `.nupkg` file. Then you're ready to deploy the package to whatever host makes it available to other developers.
 
 > [!Tip]
 > A NuGet package with the `.nupkg` extension is simply a ZIP file. To easily examine any package's contents, change the extension to `.zip` and expand its contents as usual. Just be sure to change the extension back to `.nupkg` before attempting to upload it to a host.


### PR DESCRIPTION
Remove the bits that are specific to packing from a .nuspec using nuget.exe as this is no longer the "north star".