### PR TITLE
Update Dependency-Resolution.md

### DIFF
--- a/docs/consume-packages/Dependency-Resolution.md
+++ b/docs/consume-packages/Dependency-Resolution.md
@@ -19,11 +19,11 @@ When multiple packages have the same dependency, then the same package ID can ap
 
 When installing packages into projects using the PackageReference format, NuGet adds references to a flat package graph in the appropriate file and resolves conflicts ahead of time. This process is referred to as *transitive restore*. Reinstalling or restoring packages is then a process of downloading the packages listed in the graph, resulting in faster and more predictable builds. You can also take advantage of wildcard (floating) versions, such as 2.8.\*, avoiding expensive and error prone calls to `nuget update` on the client machines and build servers.
 
-When the NuGet restore process runs prior to a build, it resolves dependencies first in memory, then writes the resulting graph to a file called `project.assets.json`. 
+When the NuGet restore process runs prior to a build, it resolves dependencies first in memory, then writes the resulting graph to a file called `project.assets.json`. It also writes the resolved dependencies to a lock file named `packages.lock.json`, if the [lock file functionality is enabled](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#locking-dependencies).
 The assets file is located at `MSBuildProjectExtensionsPath`, which defaults to the project's 'obj' folder. 
 MSBuild then reads this file and translates it into a set of folders where potential references can be found, and then adds them to the project tree in memory.
 
-The lock file is temporary and should not be added to source control. It's listed by default in both `.gitignore` and `.tfignore`. See [Packages and source control](packages-and-source-control.md).
+The `project.assets.json` file is temporary and should not be added to source control. It's listed by default in both `.gitignore` and `.tfignore`. See [Packages and source control](packages-and-source-control.md).
 
 ### Dependency resolution rules
 


### PR DESCRIPTION
It called `project.assets.json` as the lock file which I thought may confuse users, now that we have lock file feature.