### PR TITLE
Clarify the new framework based environment variables for plugin discovery

### DIFF
--- a/docs/reference/extensibility/NuGet-Cross-Platform-Plugins.md
+++ b/docs/reference/extensibility/NuGet-Cross-Platform-Plugins.md
@@ -66,8 +66,10 @@ After 1 minute of inactivity a plugin is considered idle and is shut down.
 ## Plugin installation and discovery
 
 The plugins will be discovered via a convention based directory structure.
-CI/CD scenarios and power users can use an environment variable to override the behavior.
+CI/CD scenarios and power users can use environment variables to override the behavior. Note that `NUGET_NETFX_PLUGIN_PATHS` and `NUGET_NETCORE_PLUGIN_PATHS` are only available with 5.3+ version of the NuGet tooling and later.
 
+- `NUGET_NETFX_PLUGIN_PATHS` - defines the plugins that will be used by the .NET Framework based tooling (NuGet.exe/MSBuild.exe/Visual Studio). Takes precedence over `NUGET_PLUGIN_PATHS`. (NuGet version 5.3+ only)
+- `NUGET_NETCORE_PLUGIN_PATHS` - defines the plugins that will be used by the .NET Core based tooling (dotnet.exe). Takes precedence over `NUGET_PLUGIN_PATHS`. (NuGet version 5.3+ only)
 - `NUGET_PLUGIN_PATHS` - defines the plugins that will be used for that NuGet process, priority reserved. If this environment variable is set, it overrides the convention based discovery.
 -  User-location, the NuGet Home location in `%UserProfile%/.nuget/plugins`. This location cannot be overriden. A different root directory will be used for .NET Core and .NET Framework plugins.
 

--- a/docs/reference/extensibility/NuGet-Cross-Platform-Plugins.md
+++ b/docs/reference/extensibility/NuGet-Cross-Platform-Plugins.md
@@ -70,7 +70,7 @@ CI/CD scenarios and power users can use environment variables to override the be
 
 - `NUGET_NETFX_PLUGIN_PATHS` - defines the plugins that will be used by the .NET Framework based tooling (NuGet.exe/MSBuild.exe/Visual Studio). Takes precedence over `NUGET_PLUGIN_PATHS`. (NuGet version 5.3+ only)
 - `NUGET_NETCORE_PLUGIN_PATHS` - defines the plugins that will be used by the .NET Core based tooling (dotnet.exe). Takes precedence over `NUGET_PLUGIN_PATHS`. (NuGet version 5.3+ only)
-- `NUGET_PLUGIN_PATHS` - defines the plugins that will be used for that NuGet process, priority reserved. If this environment variable is set, it overrides the convention based discovery.
+- `NUGET_PLUGIN_PATHS` - defines the plugins that will be used for that NuGet process, priority reserved. If this environment variable is set, it overrides the convention based discovery. Ignored if either of the framework specific variables is specified.
 -  User-location, the NuGet Home location in `%UserProfile%/.nuget/plugins`. This location cannot be overriden. A different root directory will be used for .NET Core and .NET Framework plugins.
 
 | Framework | Root discovery location  |


### PR DESCRIPTION
Related to https://github.com/NuGet/Home/issues/8151 & https://github.com/NuGet/NuGet.Client/pull/2986. 

This should only be merged once the linked PR is completed and 5.3 has been released. 

The specs at https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin and https://github.com/NuGet/Home/wiki/NuGet-Package-Download-Plugin might need updated, although they contain the same information as the actual docs.