### PR TITLE
Fix the NuGet Description MSBuild property name

### DIFF
--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -50,7 +50,7 @@ Note that the `Owners` and `Summary` properties from `.nuspec` are not supported
 | Authors | Authors | Username of the current user | |
 | Owners | N/A | Not present in NuSpec | |
 | Title | Title | The PackageId| |
-| Description | Description | "Package Description" | |
+| Description | PackageDescription | "Package Description" | |
 | Copyright | Copyright | empty | |
 | RequireLicenseAcceptance | PackageRequireLicenseAcceptance | false | |
 | license | PackageLicenseExpression | empty | Corresponds to `<license type="expression">` |


### PR DESCRIPTION
It's `PackageDescription`, not `Description'.