### PR TITLE
Add missing `targetFramework` property

### DIFF
--- a/docs/api/_data/catalog-package-details.json
+++ b/docs/api/_data/catalog-package-details.json
@@ -56,7 +56,8 @@
           "id": "WebApi.All",
           "range": "[0.5.0, )"
         }
-      ]
+      ],
+      "targetFramework": ".NETFramework4.6"
     }
   ],
   "tags": [


### PR DESCRIPTION
The catalog leafs' `dependencyGroup`s have a `targetFramework` property. For example, see: https://api.nuget.org/v3/catalog0/data/2019.01.30.23.20.42/newtonsoft.json.12.0.1.json