### PR TITLE
add deprecation feature back into release notes

### DIFF
--- a/docs/release-notes/NuGet-5.3.md
+++ b/docs/release-notes/NuGet-5.3.md
@@ -23,6 +23,8 @@ NuGet distribution vehicles:
 
 * Improved security with SHA tracking and enforcement for Packages.Config - [#7281](https://github.com/NuGet/Home/issues/7281)
 
+* Enable server side deprecation of obsolete/legacy NuGet Packages [#2867](https://github.com/NuGet/Home/issues/2867)
+
 ### Issues fixed in this release
 
 **Bugs**

--- a/docs/release-notes/NuGet-5.3.md
+++ b/docs/release-notes/NuGet-5.3.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 
 * Improved security with SHA tracking and enforcement for Packages.Config - [#7281](https://github.com/NuGet/Home/issues/7281)
 
-* Enable server side deprecation of obsolete/legacy NuGet Packages [#2867](https://github.com/NuGet/Home/issues/2867)
+* Enable deprecation of obsolete/legacy NuGet Packages [#2867](https://github.com/NuGet/Home/issues/2867) | [Blog post](https://devblogs.microsoft.com/nuget/deprecating-packages-on-nuget-org/) | [Docs](https://docs.microsoft.com/en-us/nuget/nuget-org/deprecate-packages)
 
 ### Issues fixed in this release
 


### PR DESCRIPTION
when preview 3 shipped, i hand removed the link to the issue about server side deprecation.
when i updated RTM, and we had fixed all the bugs for deprecation...i should have added it back in.

now, i remembered...so adding it back.