### PR TITLE
Fix WinMTR download link

### DIFF
--- a/docs/nuget-org/nuget-org-faq.md
+++ b/docs/nuget-org/nuget-org-faq.md
@@ -75,7 +75,7 @@ First, make sure you're using the latest versions of NuGet. If that version cont
 
 *To capture MTR:*
 
-- Download WinMTR from [http://winmtr.net/download/](http://winmtr.net/)
+- Download [WinMTR](https://sourceforge.net/projects/winmtr/files/WinMTR-v092.zip/download).
 - Enter `api.nuget.org` as the hostname and click **Start**.
 - Wait until the **Sent** column is >= 100.
 


### PR DESCRIPTION
The previous link has been broken for a couple of weeks now. A Blizzard (online video game company) [document links to SourceForge](https://us.battle.net/support/en/article/27780) so I think it is a reasonable alternative.