### PR TITLE
L132141: Escaping lt and gt characters

### DIFF
--- a/docs/consume-packages/installing-signed-packages.md
+++ b/docs/consume-packages/installing-signed-packages.md
@@ -90,7 +90,7 @@ In some situations you may want to enable verification using certificates that d
 
 ### Sync repository certificates
 
-Package repositories should announce the certificates they use in their [service index](../api/service-index.md). Eventually the repository will update these certificates, e.g. when the certificate expires. When that happens, clients with specific policies will require an update to the configuration to include the newly added certificate. You can easily upgrade the trusted signers associated to a repository by using the `nuget.exe` [trusted-signers sync command](../reference/cli-reference/cli-ref-trusted-signers.md#nuget-trusted-signers-sync--name-).
+Package repositories should announce the certificates they use in their [service index](../api/service-index.md). Eventually the repository will update these certificates, e.g. when the certificate expires. When that happens, clients with specific policies will require an update to the configuration to include the newly added certificate. You can easily upgrade the trusted signers associated to a repository by using the `nuget.exe` [trusted-signers sync command](../reference/cli-reference/cli-ref-trusted-signers.md#nuget-trusted-signers-sync--name-name
 
 ### Schema reference
 

--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -97,11 +97,11 @@ _Note_: If a trusted signer with the given name already exists, the certificate 
 | FingerprintAlgorithm | Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to `SHA256`. Values supported are `SHA256`, `SHA384` and `SHA512` |
 | AllowUntrustedRoot | Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. |
 
-## nuget trusted-signers remove -Name <name>
+## nuget trusted-signers remove -Name \<name\>
 
 Removes any trusted signers that match the given name.
 
-## nuget trusted-signers sync -Name <name>
+## nuget trusted-signers sync -Name \<name\>
 
 Requests the latest list of certificates used in a currently trusted repository to update the the existing certificate list in the trusted signer.
 


### PR DESCRIPTION
Content team has reported possible source content issue. 
Description: un-escaped element <name> at the end, is causing issues in the loc versions of the files.