### PR TITLE
fix: Seems like there has been some misunderstanding

### DIFF
--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -59,7 +59,7 @@ To push packages to nuget.org you must use [nuget.exe v4.1.0 or above](https://w
     nuget setApiKey <your_API_key>
     ```
 
-    This command stores your API key in your NuGet configuration so that you need repeat this step again on the same computer.
+    This command stores your API key in your NuGet configuration so that you don't need to repeat this step again on the same computer.
 
 1. Push your package to NuGet Gallery using the following command:
 


### PR DESCRIPTION
I've changed `need to` => `don't need to` in line 62. I don't understand why someone would want to run `setApiKey` if it doesn't save it somewhere