### PR TITLE
Clarify the `alternatePackage` object format

### DIFF
--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -225,7 +225,7 @@ Name             | Type             | Required | Notes
 ---------------- | ---------------- | -------- | -----
 reasons          | array of strings | yes      | The reasons why the package was deprecated
 message          | string           | no       | The additional details about this deprecation
-alternatePackage | object           | no       | The package dependency that should be used instead
+alternatePackage | object           | no       | The [package dependency](#package-dependency) that should be used instead
 
 The `reasons` property must contain at least one string and should only contains strings from the following table:
 

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -225,7 +225,7 @@ Name             | Type             | Required | Notes
 ---------------- | ---------------- | -------- | -----
 reasons          | array of strings | yes      | The reasons why the package was deprecated
 message          | string           | no       | The additional details about this deprecation
-alternatePackage | object           | no       | The [package dependency](#package-dependency) that should be used instead
+alternatePackage | object           | no       | The alternate package that should be used instead
 
 The `reasons` property must contain at least one string and should only contains strings from the following table:
 
@@ -234,6 +234,14 @@ Reason       | Description
 Legacy       | The package is no longer maintained
 CriticalBugs | The package has bugs which make it unsuitable for usage
 Other        | The package is deprecated due to a reason not on this list
+
+The `alternatePackage` property has the following properties:
+
+Name         | Type   | Required | Notes
+------------ | ------ | -------- | -----
+id           | string | yes      | The ID of the package dependency
+range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards), or `*` if all versions are allowed
+registration | string | no       | The URL to the registration index for this dependency
 
 If the `reasons` property contains strings that are not from the known set, they should be ignored. The strings are case-insensitive, so `legacy` should be treated the same as `Legacy`. There is no ordering restriction on the array, so the strings can arranged in any arbitrary order. Additionally, if the property contains only strings that are not from the known set, it should be treated as if it only contained the "Other" string.
 

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -242,7 +242,7 @@ The `alternatePackage` property has the following properties:
 Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----
 id           | string | yes      | The ID of the alternate package
-range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards), or `*` if all versions are allowed
+range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards), or `*` if any version is allowed
 registration | string | no       | The URL to the registration index for this alternate package
 
 ### Sample request

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -211,7 +211,7 @@ Each package dependency has the following properties:
 Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----
 id           | string | yes      | The ID of the package dependency
-range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards) of the dependency 
+range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards) of the dependency
 registration | string | no       | The URL to the registration index for this dependency
 
 If the `range` property is excluded or an empty string, the client should default to the version range `(, )`. That is,

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -237,7 +237,9 @@ Other        | The package is deprecated due to a reason not on this list
 
 If the `reasons` property contains strings that are not from the known set, they should be ignored. The strings are case-insensitive, so `legacy` should be treated the same as `Legacy`. There is no ordering restriction on the array, so the strings can arranged in any arbitrary order. Additionally, if the property contains only strings that are not from the known set, it should be treated as if it only contained the "Other" string.
 
-The `alternatePackage` property has the following properties:
+#### Alternate package
+
+The alternate package object has the following properties:
 
 Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -211,11 +211,11 @@ Each package dependency has the following properties:
 Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----
 id           | string | yes      | The ID of the package dependency
-range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards) of the dependency
+range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards) of the dependency 
 registration | string | no       | The URL to the registration index for this dependency
 
 If the `range` property is excluded or an empty string, the client should default to the version range `(, )`. That is,
-any version of the dependency is allowed.
+any version of the dependency is allowed. The value of `*` is not allowed for the `range` property.
 
 #### Package deprecation
 
@@ -235,15 +235,15 @@ Legacy       | The package is no longer maintained
 CriticalBugs | The package has bugs which make it unsuitable for usage
 Other        | The package is deprecated due to a reason not on this list
 
+If the `reasons` property contains strings that are not from the known set, they should be ignored. The strings are case-insensitive, so `legacy` should be treated the same as `Legacy`. There is no ordering restriction on the array, so the strings can arranged in any arbitrary order. Additionally, if the property contains only strings that are not from the known set, it should be treated as if it only contained the "Other" string.
+
 The `alternatePackage` property has the following properties:
 
 Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----
-id           | string | yes      | The ID of the package dependency
+id           | string | yes      | The ID of the alternate package
 range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards), or `*` if all versions are allowed
-registration | string | no       | The URL to the registration index for this dependency
-
-If the `reasons` property contains strings that are not from the known set, they should be ignored. The strings are case-insensitive, so `legacy` should be treated the same as `Legacy`. There is no ordering restriction on the array, so the strings can arranged in any arbitrary order. Additionally, if the property contains only strings that are not from the known set, it should be treated as if it only contained the "Other" string.
+registration | string | no       | The URL to the registration index for this alternate package
 
 ### Sample request
 


### PR DESCRIPTION
This is the section that was updated: https://review.docs.microsoft.com/en-us/nuget/api/registration-base-url-resource?branch=pr-en-us-1766#package-deprecation