### PR TITLE
Clarify that only registration index has a predictable URL

### DIFF
--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -323,6 +323,9 @@ packageContent | string  | no       | The URL to the package content (.nupkg)
 published      | string  | no       | A string containing a ISO 8601 timestamp of when the package was published
 registration   | string  | no       | The URL to the registration index
 
+> [!Note]
+> On nuget.org, the `published` value is set to year 1900 when the package is unlisted.
+
 ### Sample request
 
     GET https://api.nuget.org/v3/registration3/nuget.versioning/4.3.0.json

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -85,7 +85,8 @@ other hand, if the server implementation immediately stores registration leaves 
 must perform more HTTP requests to get the information it needs.
 
 The heuristic that nuget.org uses is as follows: if there are 128 or more versions of a package, break the leaves
-into pages of size 64. If there are less than 128 versions, inline all leaves into the registration index.
+into pages of size 64. If there are less than 128 versions, inline all leaves into the registration index. Note that
+this means packages with 65 to 127 versions will have two pages in the index but both pages will be inlined.
 
     GET {@id}/{LOWER_ID}/index.json
 
@@ -160,7 +161,7 @@ The `catalogEntry` property in the registration leaf object has the following pr
 
 Name                     | Type                       | Required | Notes
 ------------------------ | -------------------------- | -------- | -----
-@id                      | string                     | yes      | The URL to document used to produce this object
+@id                      | string                     | yes      | The URL to the document used to produce this object
 authors                  | string or array of strings | no       | 
 dependencyGroups         | array of objects           | no       | The dependencies of the package, grouped by target framework
 deprecation              | object                     | no       | The deprecation associated with the package
@@ -188,6 +189,9 @@ framework. If the package has no dependencies, the `dependencyGroups` property i
 
 The value of the `licenseExpression` property complies with
 [NuGet license expression syntax](https://docs.microsoft.com/nuget/reference/nuspec#license).
+
+> [!Note]
+> On nuget.org, the `published` value is set to year 1900 when the package is unlisted.
 
 #### Package dependency group
 
@@ -261,7 +265,13 @@ fetch metadata about individual package versions.
 ## Registration page
 
 The registration page contains registration leaves. The URL to fetch a registration page is determined by the `@id`
-property in the [registration page object](#registration-page-object) mentioned above.
+property in the [registration page object](#registration-page-object) mentioned above. The URL is not meant to be
+predictable and should always be discovered by means of the index document.
+
+> [!Warning]
+> On nuget.org, the URL for the registration page document coincidentally contains the lower and upper bound of the 
+> page. However this assumption should never be made by a client since server implementations are free to change the
+> shape of the URL as long as the index document has a valid link.
 
 When the `items` array is not provided in the registration index, an HTTP GET request of the `@id` value will return a
 JSON document which has an object as its root. The object has the following properties:
@@ -294,7 +304,13 @@ version may not be available in this document. Package metadata should be fetche
 the registration index).
 
 The URL to fetch a registration leaf is obtained from the `@id` property of a registration leaf object in either a
-registration index or registration page.
+registration index or registration page. As with the page document. the URL is not meant to be predictable and should
+always be discovered by means of the registration page object.
+
+> [!Warning]
+> On nuget.org, the URL for the registration leaf document coincidentally contains the package version. However this
+> assumption should never be made by a client since server implementations are free to change the shape of the URL as
+> long as the parent document has a valid link. 
 
 The registration leaf is a JSON document with a root object with the following properties:
 
@@ -306,9 +322,6 @@ listed         | boolean | no       | Should be considered as listed if absent
 packageContent | string  | no       | The URL to the package content (.nupkg)
 published      | string  | no       | A string containing a ISO 8601 timestamp of when the package was published
 registration   | string  | no       | The URL to the registration index
-
-> [!Note]
-> On nuget.org, the `published` value is set to year 1900 when the package is unlisted.
 
 ### Sample request
 


### PR DESCRIPTION
By design, the page and leaf URL shapes are not predictable. This gives server implementors flexibility. For nuget.org, this means that we could include a random component in the page and leaf URLs to mitigate https://github.com/NuGet/NuGetGallery/issues/7134. This is an tool we've had in our back pocket from the beginning of time but after speaking to @loic-sharma offline this is confusing because the sample URL for registration leaf is so predictable.

If we ever have problems with consistency across multiple blobs in registration, we can just put a GUID in the page and leaf URLs and have an asynchronous process cleaning up the orphans blobs. This is a very powerful concept that we should not preclude by codifying a pattern that has been an implementation detail up until now.

We can't stop people from ignoring this warning but we can at least say a) official client does not do this and b) we have clearly documented not to do this. This will give us flexibility if we need it.

I chose to keep references to the registration leaf since all know implementations of V3 have this document so it's silly to act like it doesn't exist when clearly it does. If we want to mandate the leaf URL is predictable in this future we can, but we haven't assess the feasibility: what are all the popular implementations doing today and is it worth losing the flexibility.