### PR TITLE
Removing instruction for "dotnet run"

### DIFF
--- a/docs/quickstart/create-and-publish-a-package-using-the-dotnet-cli.md
+++ b/docs/quickstart/create-and-publish-a-package-using-the-dotnet-cli.md
@@ -29,8 +29,6 @@ You can use an existing .NET Class Library project for the code you want to pack
 
    This creates the new project.
 
-1. Use `dotnet run` to test that the app has been created properly.
-
 ## Add package metadata to the project file
 
 Every NuGet package needs a manifest that describes the package's contents and dependencies. In a final package, the manifest is a `.nuspec` file that is generated from the NuGet metadata properties that you include in the project file.


### PR DESCRIPTION
`dotnet run` won't work on a class lib. Currently, if someone were to follow the tutorial and execute `dotnet run` after creating the class lib, they'll get the following error:

```
Unable to run your project.
Ensure you have a runnable project type and ensure 'dotnet run' supports this project.
A runnable project should target a runnable TFM (for instance, netcoreapp2.0) and have OutputType 'Exe'.
The current OutputType is 'Library'.
```