### PR TITLE
Fix for linux environment variable syntax

### DIFF
--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -300,7 +300,7 @@ You can use environment variables in `nuget.config` values (NuGet 3.4+) to apply
 
 For example, if the `HOME` environment variable on Windows is set to `c:\users\username`, then the value of `%HOME%\NuGetRepository` in the configuration file resolves to `c:\users\username\NuGetRepository`.
 
-Similarly, if `HOME` on Mac/Linux is set to `/home/myStuff`, then `%HOME%/NuGetRepository` in the configuration file resolves to `/home/myStuff/NuGetRepository`.
+Similarly, if `HOME` on Mac/Linux is set to `/home/myStuff`, then `$HOME/NuGetRepository` in the configuration file resolves to `/home/myStuff/NuGetRepository`.
 
 If an environment variable is not found, NuGet uses the literal value from the configuration file.
 


### PR DESCRIPTION
Fixed the syntax for `nuget.config` environment variables. It didn't match the example for it. There it says

> In this example, %PACKAGEHOME% is an environment variable. On Mac/Linux, use $PACKAGE_HOME/External as the value.

