### PR TITLE
API key usage regarding authenticating with package source

### DIFF
--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -22,7 +22,7 @@ nuget setapikey <key> -Source <url> [options]
 where `<source>` identifies the server and `<key>` is the key or password to save. If `<source>` is omitted, nuget.org is assumed.
 
 > [!NOTE]
-> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
 
 ## Options
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -22,7 +22,7 @@ nuget setapikey <key> -Source <url> [options]
 where `<source>` identifies the server and `<key>` is the key or password to save. If `<source>` is omitted, nuget.org is assumed.
 
 > [!NOTE]
-> Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> The API key is only used for pushing packages but not used for authenticating to a private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
 
 ## Options
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -22,7 +22,7 @@ nuget setapikey <key> -Source <url> [options]
 where `<source>` identifies the server and `<key>` is the key or password to save. If `<source>` is omitted, nuget.org is assumed.
 
 > [!NOTE]
-> The API key is only used for pushing packages but not used for authenticating to a private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> The API key is not used for authenticating to a private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
 
 ## Options
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -21,6 +21,9 @@ nuget setapikey <key> -Source <url> [options]
 
 where `<source>` identifies the server and `<key>` is the key or password to save. If `<source>` is omitted, nuget.org is assumed.
 
+> [!NOTE]
+> Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+
 ## Options
 
 | Option | Description |

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -22,7 +22,7 @@ nuget setapikey <key> -Source <url> [options]
 where `<source>` identifies the server and `<key>` is the key or password to save. If `<source>` is omitted, nuget.org is assumed.
 
 > [!NOTE]
-> The API key is not used for authenticating to a private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
 
 ## Options
 


### PR DESCRIPTION
The API key is only used for publishing and consuming packages but not for authenticating with the package source.