### PR TITLE
Documentation error re env vars on Mac/Linux

### DIFF
--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -300,7 +300,7 @@ You can use environment variables in `nuget.config` values (NuGet 3.4+) to apply
 
 For example, if the `HOME` environment variable on Windows is set to `c:\users\username`, then the value of `%HOME%\NuGetRepository` in the configuration file resolves to `c:\users\username\NuGetRepository`.
 
-Similarly, if `HOME` on Mac/Linux is set to `/home/myStuff`, then `$HOME/NuGetRepository` in the configuration file resolves to `/home/myStuff/NuGetRepository`.
+Note that you have to use Windows-style environment variables (starts and ends with %) even on Mac/Linux. Having `$HOME/NuGetRepository` in a configuration file will not resolve. On Mac/Linux the value of `%HOME%\NuGetRepository` will resolve to `/home/myStuff/NuGetRepository`.
 
 If an environment variable is not found, NuGet uses the literal value from the configuration file.
 


### PR DESCRIPTION
Existing documentation states outright that Unix-style environment variables ($HOME) will be expanded if used in NuGet.Config. This is wrong. Only Windows style variables (%HOME%) are expanded.