### PR TITLE
Link to the PackageIcon documentation

### DIFF
--- a/docs/create-packages/creating-a-package-dotnet-cli.md
+++ b/docs/create-packages/creating-a-package-dotnet-cli.md
@@ -117,6 +117,7 @@ You might also want to extend the capabilities of your package or otherwise supp
 
 - [Package versioning](../concepts/package-versioning.md)
 - [Support multiple target frameworks](../create-packages/multiple-target-frameworks-project-file.md)
+- [Add a package icon](../reference/nuspec.md#icon)
 - [Transformations of source and configuration files](../create-packages/source-and-config-file-transformations.md)
 - [Localization](../create-packages/creating-localized-packages.md)
 - [Pre-release versions](../create-packages/prerelease-packages.md)


### PR DESCRIPTION
It's really hard to find the documentation on how to create a package with an icon. We should consider adding a dedicated page for the new package icon feature... For example, googling for `PackageIcon nuget` results in:

![image](https://user-images.githubusercontent.com/737941/74115745-6f576500-4b65-11ea-8b71-05c014b753ff.png)
