### PR TITLE
Added NuGet Video "Install and Use a NuGet Package with Visual Studio"

### DIFF
--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -120,6 +120,12 @@ With the Newtonsoft.Json package in the project, you can call its `JsonConvert.S
 
     ![Output of the WPF app after selecting the button](media/QS_Use-07-AppEnd.png)
 
+## Related video
+
+> [!Video https://channel9.msdn.com/Series/NuGet-101/Install-and-Use-a-NuGet-Package-with-Visual-Studio-2-of-5/player]
+
+Find more NuGet videos on [Channel 9](https://channel9.msdn.com/Series/NuGet-101) and [YouTube](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oVLvfkFk8O9h6v2Dcdh2bh_).
+
 ## Next steps
 
 Congratulations on installing and using your first NuGet package!
@@ -135,9 +141,3 @@ To explore more that NuGet has to offer, select the links below.
 - [Overview and workflow of package consumption](../consume-packages/overview-and-workflow.md)
 - [Finding and choosing packages](../consume-packages/finding-and-choosing-packages.md)
 - [Package references in project files](../consume-packages/package-references-in-project-files.md)
-
-## Related video
-
-> [!Video https://channel9.msdn.com/Series/NuGet-101/Install-and-Use-a-NuGet-Package-with-Visual-Studio-2-of-5/player]
-
-Find more NuGet videos on [Channel 9](https://channel9.msdn.com/Series/NuGet-101) and [YouTube](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oVLvfkFk8O9h6v2Dcdh2bh_).

--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -138,6 +138,6 @@ To explore more that NuGet has to offer, select the links below.
 
 ## Related video
 
-> [!Video https://channel9.msdn.com/Series/NuGet-101/Install-and-Use-a-NuGet-Package-with-Visual-Studio-2-of-5]
+> [!Video https://channel9.msdn.com/Series/NuGet-101/Install-and-Use-a-NuGet-Package-with-Visual-Studio-2-of-5/player]
 
 Find more NuGet videos on [Channel 9](https://channel9.msdn.com/Series/NuGet-101) and [YouTube](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oVLvfkFk8O9h6v2Dcdh2bh_).

--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -138,6 +138,6 @@ To explore more that NuGet has to offer, select the links below.
 
 ## Related video
 
-> [!Video https://channel9.msdn.com/Series/NuGet-101/What-is-NuGet-2-of-5/player]
+> [!Video https://channel9.msdn.com/Series/NuGet-101/Install-and-Use-a-NuGet-Package-with-Visual-Studio-2-of-5]
 
 Find more NuGet videos on [Channel 9](https://channel9.msdn.com/Series/NuGet-101) and [YouTube](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oVLvfkFk8O9h6v2Dcdh2bh_).

--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -135,3 +135,9 @@ To explore more that NuGet has to offer, select the links below.
 - [Overview and workflow of package consumption](../consume-packages/overview-and-workflow.md)
 - [Finding and choosing packages](../consume-packages/finding-and-choosing-packages.md)
 - [Package references in project files](../consume-packages/package-references-in-project-files.md)
+
+## Related video
+
+> [!Video https://channel9.msdn.com/Series/NuGet-101/What-is-NuGet-2-of-5/player]
+
+Find more NuGet videos on [Channel 9](https://channel9.msdn.com/Series/NuGet-101) and [YouTube](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oVLvfkFk8O9h6v2Dcdh2bh_).


### PR DESCRIPTION
In the preview it doesn't show the video, but it seems to appear fine when published. This is the exact type/style of embedding used in other docs with videos such as:
https://github.com/MicrosoftDocs/xamarin-docs/blob/live/docs/essentials/includes/xamarin-show-essentials.md