### PR TITLE
Fix deprecation documentation

### DIFF
--- a/docs/api/_data/package-registration-page.json
+++ b/docs/api/_data/package-registration-page.json
@@ -38,7 +38,7 @@
         "authors": "NuGet.org Team",
         "deprecation": {
           "reasons": [
-            "HasCriticalBugs"
+            "CriticalBugs"
           ],
           "message": "This package is unstable and broken!",
           "alternatePackage": {

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -249,7 +249,6 @@ Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----
 id           | string | yes      | The ID of the alternate package
 range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges-and-wildcards), or `*` if any version is allowed
-registration | string | no       | The URL to the registration index for this alternate package
 
 ### Sample request
 


### PR DESCRIPTION
Fixes two issues:

1. `HasCriticalBugs` should be `CriticalBugs`.
1. There is no `registration` property on the alternate package object.

Example deprecated package with `CriticalBugs` reason and an alternate package on DEV: https://apidev.nugettest.org/v3/registration5-gz-semver2/e2e.deprecated.200212.012137.9097008/index.json

For valid deprecation reasons, see: https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-deprecation

For the alternate package object shape, see this model: https://github.com/NuGet/NuGet.Services.Metadata/blob/ab34c77ca4248a52491c1d41cd3a8b2b70125300/src/NuGet.Protocol.Catalog/Models/AlternatePackage.cs