### PR TITLE
Document NuGet.Protocol

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -39,7 +39,7 @@
     {
       "path_to_root": "nuget-samples",
       "url": "https://github.com/NuGet/Samples",
-      "branch": "master",
+      "branch": "nuget-protocol-samples",
       "branch_mapping": {}
     }
   ],

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -35,6 +35,12 @@
       "url": "https://github.com/Microsoft/templates.docs.msft.pdf",
       "branch": "master",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "nuget-samples",
+      "url": "https://github.com/NuGet/Samples",
+      "branch": "master",
+      "branch_mapping": {}
     }
   ],
   "branch_target_mapping": {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -39,7 +39,7 @@
     {
       "path_to_root": "nuget-samples",
       "url": "https://github.com/NuGet/Samples",
-      "branch": "nuget-protocol-samples",
+      "branch": "master",
       "branch_mapping": {}
     }
   ],

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -37,7 +37,7 @@
       "branch_mapping": {}
     },
     {
-      "path_to_root": "nuget-samples",
+      "path_to_root": "_samples",
       "url": "https://github.com/NuGet/Samples",
       "branch": "nuget-protocol-samples",
       "branch_mapping": {}

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -37,7 +37,7 @@
       "branch_mapping": {}
     },
     {
-      "path_to_root": "_samples",
+      "path_to_root": "nuget-samples",
       "url": "https://github.com/NuGet/Samples",
       "branch": "nuget-protocol-samples",
       "branch_mapping": {}

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -14,10 +14,10 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Used to interact with HTTP and file-based NuGet feeds
 * [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Used to interact with NuGet packages. `NuGet.Protocol` depends on this package
 
+You can find the source code for these packages on the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
+
 > [!Note]
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
-
-You can find the source code for these packages on the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
 
 ## Getting started
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -30,9 +30,9 @@ You can find these examples on the [NuGet.Protocol.Samples](TODO) project on Git
 
 Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):
 
-[!code-csharp[ListPackageVersions](~/_samples/NuGetProtocolSamples/Program.cs?name=ListPackageVersions)]
+[!code-csharp[ListPackageVersions](~/nuget-samples/NuGetProtocolSamples/Program.cs?name=ListPackageVersions)]
 
-[!code-csharp[DownloadPackage](~/_samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
+[!code-csharp[DownloadPackage](~/nuget-samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
 
 ```csharp
 ILogger logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -26,8 +26,6 @@ dotnet add NuGet.Protocol
 
 You can find these examples on the [NuGet.Protocol.Samples](TODO) project on GitHub.
 
-:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="tEST":::
-
 ### List package versions
 
 Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -9,14 +9,50 @@ ms.topic: conceptual
 
 # NuGet Client SDK
 
-The *NuGet Client SDK* refers to a group of NuGet packages centered around [NuGet.Commands](https://www.nuget.org/packages/NuGet.Commands), [NuGet.Packaging](https://www.nuget.org/packages/NuGet.Packaging), and [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol). These packages replace the earlier [NuGet.Core](https://www.nuget.org/packages/NuGet.Core/) library.
+The *NuGet Client SDK* refers to a group of NuGet packages centered around [NuGet.Commands](https://www.nuget.org/packages/NuGet.Commands), [NuGet.Packaging](https://www.nuget.org/packages/NuGet.Packaging), and [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol). These packages replace the legacy [NuGet.Core](https://www.nuget.org/packages/NuGet.Core/) library. You can find the source code for these packages on GitHub in the project [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client).
 
 > [!Note]
 >  For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
 
-## Source code
+## Getting started
 
-The source code is published on GitHub in the project [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client).
+### Install the package
+
+```
+dotnet add NuGet.Protocol
+```
+
+## Examples
+
+### List package versions
+
+```csharp
+var foo = "bar";
+```
+
+### Download a package
+
+```csharp
+var foo = "bar";
+```
+
+### Get package metadata 
+
+```csharp
+var foo = "bar";
+```
+
+### Get package downloads
+
+```csharp
+var foo = "bar";
+```
+
+### Search packages
+
+```csharp
+var foo = "bar";
+```
 
 ## Third-party documentation
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -46,7 +46,7 @@ var foo = "bar";
 
 ### Search packages
 
-Search for "json" packages:
+Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
 
 ```csharp
 var logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -14,7 +14,7 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Used to interact with HTTP and file-based NuGet feeds
 * [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Used to interact with NuGet packages. `NuGet.Protocol` depends on this package
 
-You can find the source code for these packages on the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
+You can find the source code for these packages in the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
 
 > [!Note]
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -9,7 +9,10 @@ ms.topic: conceptual
 
 # NuGet Client SDK
 
-The *NuGet Client SDK* refers to a group of NuGet packages centered around the [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol) and [NuGet.Packaging](https://www.nuget.org/packages/NuGet.Packaging) packages from the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
+The *NuGet Client SDK* refers to a group of NuGet packages:
+
+* [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Used to interact with HTTP and file-based NuGet feeds
+* [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Used to interact with NuGet packages. `NuGet.Protocol` depends on this package
 
 > [!Note]
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
@@ -24,7 +27,7 @@ dotnet add NuGet.Protocol
 
 ## Examples
 
-You can find these examples on the [NuGet.Protocol.Samples](TODO) project on GitHub.
+You can find these examples on the [NuGet.Protocol.Samples](https://github.com/NuGet/Samples/tree/master/NuGetProtocolSamples) project on GitHub.
 
 ### List package versions
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -24,7 +24,7 @@ You can find the source code for these packages on the [NuGet/NuGet.Client](http
 ### Install the package
 
 ```ps1
-dotnet add NuGet.Protocol
+dotnet add package NuGet.Protocol
 ```
 
 ## Examples

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -49,7 +49,7 @@ Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package M
 Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
 
 [!code-csharp[SearchPackages](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=SearchPackages)]
-
+ 
 ## Third-party documentation
 
 You can find examples and documentation for some of the API in the following blog series by Dave Glick, published 2016:

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -27,7 +27,9 @@ dotnet add NuGet.Protocol
 ### List package versions
 
 ```csharp
-var foo = "bar";
+Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+
+
 ```
 
 ### Download a package
@@ -42,16 +44,30 @@ var foo = "bar";
 var foo = "bar";
 ```
 
-### Get package downloads
-
-```csharp
-var foo = "bar";
-```
-
 ### Search packages
 
+Search for "json" packages:
+
 ```csharp
-var foo = "bar";
+var logger = NullLogger.Instance;
+var cancellationToken = CancellationToken.None;
+
+var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+var search = await repository.GetResourceAsync<PackageSearchResource>();
+var searchFilter = new SearchFilter(includePrerelease: true);
+
+var results = await search.SearchAsync(
+    "json",
+    searchFilter,
+    skip: 0,
+    take: 20,
+    logger,
+    cancellationToken);
+
+foreach (var result in results)
+{
+    Console.WriteLine($"Found package {result.Identity.Id} {result.Identity.Version}");
+}
 ```
 
 ## Third-party documentation

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -30,7 +30,7 @@ You can find these examples on the [NuGet.Protocol.Samples](TODO) project on Git
 
 Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):
 
-:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="ListPackageVersions":::
+:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="ListPackageVersions":::
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -56,7 +56,7 @@ foreach (NuGetVersion version in versions)
 
 Download Newtonsoft.Json v12.0.1 using the [NuGet V3 Package Content API](../api/package-base-address-resource.md):
 
-:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="DownloadPackage":::
+:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="DownloadPackage":::
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -91,7 +91,7 @@ Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
 
 Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package Metadata API](../api/registration-base-url-resource.md):
 
-:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="GetPackageMetadata":::
+:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="GetPackageMetadata":::
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -122,7 +122,7 @@ foreach (IPackageSearchMetadata package in packages)
 
 Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
 
-:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="SearchPackages":::
+:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="SearchPackages":::
 
 ```csharp
 var logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -49,7 +49,7 @@ Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package M
 Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
 
 [!code-csharp[SearchPackages](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=SearchPackages)]
- 
+
 ## Third-party documentation
 
 You can find examples and documentation for some of the API in the following blog series by Dave Glick, published 2016:

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -30,9 +30,9 @@ You can find these examples on the [NuGet.Protocol.Samples](TODO) project on Git
 
 Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):
 
-[!code-csharp[ListPackageVersions](~/nuget-samples/NuGetProtocolSamples/Program.cs?name=ListPackageVersions)]
+[!code-csharp[ListPackageVersions](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=ListPackageVersions)]
 
-[!code-csharp[DownloadPackage](~/nuget-samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
+[!code-csharp[DownloadPackage](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
 
 ```csharp
 ILogger logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -26,9 +26,13 @@ dotnet add NuGet.Protocol
 
 You can find these examples on the [NuGet.Protocol.Samples](TODO) project on GitHub.
 
+:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="tEST":::
+
 ### List package versions
 
 Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):
+
+:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="ListPackageVersions":::
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -53,6 +57,8 @@ foreach (NuGetVersion version in versions)
 ### Download a package
 
 Download Newtonsoft.Json v12.0.1 using the [NuGet V3 Package Content API](../api/package-base-address-resource.md):
+
+:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="DownloadPackage":::
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -87,6 +93,8 @@ Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
 
 Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package Metadata API](../api/registration-base-url-resource.md):
 
+:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="GetPackageMetadata":::
+
 ```csharp
 ILogger logger = NullLogger.Instance;
 CancellationToken cancellationToken = CancellationToken.None;
@@ -115,6 +123,8 @@ foreach (IPackageSearchMetadata package in packages)
 ### Search packages
 
 Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
+
+:::code language="csharp" source="~/nuget-samples/NuGetProtocolSamples/Program.cs" id="SearchPackages":::
 
 ```csharp
 var logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -9,7 +9,7 @@ ms.topic: conceptual
 
 # NuGet Client SDK
 
-The *NuGet Client SDK* refers to a group of NuGet packages centered around the [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol) and the [NuGet.Packaging](https://www.nuget.org/packages/NuGet.Packaging) packages from the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
+The *NuGet Client SDK* refers to a group of NuGet packages centered around the [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol) and [NuGet.Packaging](https://www.nuget.org/packages/NuGet.Packaging) packages from the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
 
 > [!Note]
 >  For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -28,6 +28,8 @@ You can find these examples on the [NuGet.Protocol.Samples](TODO) project on Git
 
 ### List package versions
 
+Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):
+
 ```csharp
 ILogger logger = NullLogger.Instance;
 CancellationToken cancellationToken = CancellationToken.None;
@@ -49,6 +51,8 @@ foreach (NuGetVersion version in versions)
 ```
 
 ### Download a package
+
+Download Newtonsoft.Json v12.0.1 using the [NuGet V3 Package Content API](../api/package-base-address-resource.md):
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -80,6 +84,8 @@ Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
 ```
 
 ### Get package metadata 
+
+Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package Metadata API](../api/registration-base-url-resource.md):
 
 ```csharp
 ILogger logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -30,7 +30,9 @@ You can find these examples on the [NuGet.Protocol.Samples](TODO) project on Git
 
 Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](../api/package-base-address-resource.md#enumerate-package-versions):
 
-:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="ListPackageVersions":::
+[!code-csharp[ListPackageVersions](~/_samples/NuGetProtocolSamples/Program.cs?name=ListPackageVersions)]
+
+[!code-csharp[DownloadPackage](~/_samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -55,8 +57,6 @@ foreach (NuGetVersion version in versions)
 ### Download a package
 
 Download Newtonsoft.Json v12.0.1 using the [NuGet V3 Package Content API](../api/package-base-address-resource.md):
-
-:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="DownloadPackage":::
 
 ```csharp
 ILogger logger = NullLogger.Instance;
@@ -91,8 +91,6 @@ Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
 
 Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package Metadata API](../api/registration-base-url-resource.md):
 
-:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="GetPackageMetadata":::
-
 ```csharp
 ILogger logger = NullLogger.Instance;
 CancellationToken cancellationToken = CancellationToken.None;
@@ -121,8 +119,6 @@ foreach (IPackageSearchMetadata package in packages)
 ### Search packages
 
 Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
-
-:::code language="csharp" source="~/_samples/NuGetProtocolSamples/Program.cs" id="SearchPackages":::
 
 ```csharp
 var logger = NullLogger.Instance;

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -17,6 +17,8 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 > [!Note]
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
 
+You can find the source code for these packages on the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
+
 ## Getting started
 
 ### Install the package

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -12,13 +12,13 @@ ms.topic: conceptual
 The *NuGet Client SDK* refers to a group of NuGet packages centered around the [NuGet.Protocol](https://www.nuget.org/packages/NuGet.Protocol) and [NuGet.Packaging](https://www.nuget.org/packages/NuGet.Packaging) packages from the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
 
 > [!Note]
->  For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
+> For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
 
 ## Getting started
 
 ### Install the package
 
-```
+```ps1
 dotnet add NuGet.Protocol
 ```
 
@@ -32,115 +32,23 @@ Find all versions of Newtonsoft.Json using the [NuGet V3 Package Content API](..
 
 [!code-csharp[ListPackageVersions](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=ListPackageVersions)]
 
-[!code-csharp[DownloadPackage](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
-
-```csharp
-ILogger logger = NullLogger.Instance;
-CancellationToken cancellationToken = CancellationToken.None;
-
-SourceCacheContext cache = new SourceCacheContext();
-SourceRepository repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
-FindPackageByIdResource resource = await repository.GetResourceAsync<FindPackageByIdResource>();
-
-IEnumerable<NuGetVersion> versions = await resource.GetAllVersionsAsync(
-    "Newtonsoft.Json",
-    cache,
-    logger,
-    cancellationToken);
-
-foreach (NuGetVersion version in versions)
-{
-    Console.WriteLine($"Found version {version}");
-}
-```
-
 ### Download a package
 
 Download Newtonsoft.Json v12.0.1 using the [NuGet V3 Package Content API](../api/package-base-address-resource.md):
 
-```csharp
-ILogger logger = NullLogger.Instance;
-CancellationToken cancellationToken = CancellationToken.None;
+[!code-csharp[DownloadPackage](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=DownloadPackage)]
 
-SourceCacheContext cache = new SourceCacheContext();
-SourceRepository repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
-FindPackageByIdResource resource = await repository.GetResourceAsync<FindPackageByIdResource>();
-
-string packageId = "Newtonsoft.Json";
-NuGetVersion packageVersion = new NuGetVersion("12.0.1");
-using MemoryStream packageStream = new MemoryStream();
-
-await resource.CopyNupkgToStreamAsync(
-    packageId,
-    packageVersion,
-    packageStream,
-    cache,
-    logger,
-    cancellationToken);
-
-Console.WriteLine($"Downloaded package {packageId} {packageVersion}");
-
-using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
-NuspecReader nuspecReader = await packageReader.GetNuspecReaderAsync(cancellationToken);
-
-Console.WriteLine($"Tags: {nuspecReader.GetTags()}");
-Console.WriteLine($"Description: {nuspecReader.GetDescription()}");
-```
-
-### Get package metadata 
+### Get package metadata
 
 Get the metadata for the "Newtonsoft.Json" package using the [NuGet V3 Package Metadata API](../api/registration-base-url-resource.md):
 
-```csharp
-ILogger logger = NullLogger.Instance;
-CancellationToken cancellationToken = CancellationToken.None;
-
-SourceCacheContext cache = new SourceCacheContext();
-SourceRepository repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
-PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>();
-
-IEnumerable<IPackageSearchMetadata> packages = await resource.GetMetadataAsync(
-    "Newtonsoft.Json",
-    includePrerelease: true,
-    includeUnlisted: false,
-    cache,
-    logger,
-    cancellationToken);
-
-foreach (IPackageSearchMetadata package in packages)
-{
-    Console.WriteLine($"Version: {package.Identity.Version}");
-    Console.WriteLine($"Listed: {package.IsListed}");
-    Console.WriteLine($"Tags: {package.Tags}");
-    Console.WriteLine($"Description: {package.Description}");
-}
-```
+[!code-csharp[GetPackageMetadata](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=GetPackageMetadata)]
 
 ### Search packages
 
 Search for "json" packages using the [NuGet V3 Search API](../api/search-query-service-resource.md):
 
-```csharp
-var logger = NullLogger.Instance;
-var cancellationToken = CancellationToken.None;
-
-var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
-var search = await repository.GetResourceAsync<PackageSearchResource>();
-var searchFilter = new SearchFilter(includePrerelease: true);
-
-var results = await search.SearchAsync(
-    "json",
-    searchFilter,
-    skip: 0,
-    take: 20,
-    logger,
-    cancellationToken);
-
-foreach (var result in results)
-{
-    Console.WriteLine($"Found package {result.Identity.Id} {result.Identity.Version}");
-}
-```
+[!code-csharp[SearchPackages](~/../nuget-samples/NuGetProtocolSamples/Program.cs?name=SearchPackages)]
 
 ## Third-party documentation
 


### PR DESCRIPTION
This adds basic examples for the [NuGet.Protocol package](https://www.nuget.org/packages/NuGet.Protocol/). The code samples are added by https://github.com/NuGet/Samples/pull/38, that change will need to be merged before this one.