### PR TITLE
Update error messages to remove "Please" to match

### DIFF
--- a/docs/reference/errors-and-warnings/NU3001.md
+++ b/docs/reference/errors-and-warnings/NU3001.md
@@ -14,7 +14,7 @@ f1_keywords:
 
 ## Scenario 1
 
-<pre>Invalid password was provided for the certificate file 'certificate.pfx'. Please provide a valid password using the '-CertificatePassword' option.</pre>
+<pre>Invalid password was provided for the certificate file 'certificate.pfx'. Provide a valid password using the '-CertificatePassword' option.</pre>
 
 ### Issue
 
@@ -29,7 +29,7 @@ If you are using a password protected certificate file to sign a NuGet package, 
 
 ## Scenario 2
 
-<pre>Certificate file 'certificate.pfx' not found. For a list of accepted ways to provide a certificate, please visit https://docs.nuget.org/docs/reference/command-line-reference.</pre>
+<pre>Certificate file 'certificate.pfx' not found. For a list of accepted ways to provide a certificate, visit https://docs.nuget.org/docs/reference/command-line-reference.</pre>
 
 ### Issue
 
@@ -44,7 +44,7 @@ Please ensure that any certificate file being used to sign a NuGet package exist
 
 ## Scenario 3
 
-<pre>Certificate file 'random_file.txt' is invalid. For a list of accepted ways to provide a certificate, please visit https://docs.nuget.org/docs/reference/command-line-reference.</pre>
+<pre>Certificate file 'random_file.txt' is invalid. For a list of accepted ways to provide a certificate, visit https://docs.nuget.org/docs/reference/command-line-reference.</pre>
 
 ### Issue
 
@@ -74,7 +74,7 @@ Please pass the '-CertificateFingerprint' option with the hash of the desired ce
 
 ## Scenario 5
 
-<pre>No certificates were found that meet all the given criteria. For a list of accepted ways to provide a certificate, please visit https://docs.nuget.org/docs/reference/command-line-reference.</pre>
+<pre>No certificates were found that meet all the given criteria. For a list of accepted ways to provide a certificate, visit https://docs.nuget.org/docs/reference/command-line-reference.</pre>
 
 ### Issue
 
@@ -109,7 +109,7 @@ Currently, due to framework limitations, NuGet sign command does not support CNG
 
 ## Scenario 7
 
-<pre>The package already contains a signature. Please remove the existing signature before adding a new signature.</pre>
+<pre>The package already contains a signature. Remove the existing signature before adding a new signature.</pre>
 
 ### Issue
 


### PR DESCRIPTION
Changed some error strings to remove Please, per guidelines.
Updating docs to use string without "please" too.
(from feedback https://github.com/NuGet/NuGet.Client/pull/3206#discussion_r375568267)