### PR TITLE
Mention dotnet cli as an install option

### DIFF
--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -9,7 +9,7 @@ ms.topic: quickstart
 
 # Quickstart: Install and use a package in Visual Studio (Windows only)
 
-NuGet packages contain reusable code that other developers make available to you for use in your projects. See [What is NuGet?](../What-is-NuGet.md) for background. Packages are installed into a Visual Studio project using the NuGet Package Manager or the Package Manager Console. This article demonstrates the process using the popular [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) package and a Windows Presentation Foundation (WPF) project. The same process applies to any other .NET or .NET Core project.
+NuGet packages contain reusable code that other developers make available to you for use in your projects. See [What is NuGet?](../What-is-NuGet.md) for background. Packages are installed into a Visual Studio project using the NuGet Package Manager or the Package Manager Console. You can also install nuget packages via the [dotnet command line](install-and-use-a-package-using-the-dotnet-cli.md). This article demonstrates the process using the popular [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) package and a Windows Presentation Foundation (WPF) project. The same process applies to any other .NET or .NET Core project.
 
 Once installed, refer to the package in code with `using <namespace>` where \<namespace\> is specific to the package you're using. Once the reference is made, you can call the package through its API.
 

--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -9,7 +9,7 @@ ms.topic: quickstart
 
 # Quickstart: Install and use a package in Visual Studio (Windows only)
 
-NuGet packages contain reusable code that other developers make available to you for use in your projects. See [What is NuGet?](../What-is-NuGet.md) for background. Packages are installed into a Visual Studio project using the NuGet Package Manager or the Package Manager Console. You can also install nuget packages via the [dotnet command line](install-and-use-a-package-using-the-dotnet-cli.md). This article demonstrates the process using the popular [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) package and a Windows Presentation Foundation (WPF) project. The same process applies to any other .NET or .NET Core project.
+NuGet packages contain reusable code that other developers make available to you for use in your projects. See [What is NuGet?](../What-is-NuGet.md) for background. Packages are installed into a Visual Studio project using the [dotnet command line](install-and-use-a-package-using-the-dotnet-cli.md), the NuGet Package Manager, or the Package Manager Console. This article demonstrates the process using the popular [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) package and a Windows Presentation Foundation (WPF) project. The same process applies to any other .NET or .NET Core project.
 
 Once installed, refer to the package in code with `using <namespace>` where \<namespace\> is specific to the package you're using. Once the reference is made, you can call the package through its API.
 

--- a/docs/quickstart/install-and-use-a-package-in-visual-studio.md
+++ b/docs/quickstart/install-and-use-a-package-in-visual-studio.md
@@ -9,7 +9,7 @@ ms.topic: quickstart
 
 # Quickstart: Install and use a package in Visual Studio (Windows only)
 
-NuGet packages contain reusable code that other developers make available to you for use in your projects. See [What is NuGet?](../What-is-NuGet.md) for background. Packages are installed into a Visual Studio project using the [dotnet command line](install-and-use-a-package-using-the-dotnet-cli.md), the NuGet Package Manager, or the Package Manager Console. This article demonstrates the process using the popular [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) package and a Windows Presentation Foundation (WPF) project. The same process applies to any other .NET or .NET Core project.
+NuGet packages contain reusable code that other developers make available to you for use in your projects. See [What is NuGet?](../What-is-NuGet.md) for background. Packages are installed into a Visual Studio project using the NuGet Package Manager, the [Package Manager Console](../consume-packages/install-use-packages-powershell), or the [dotnet CLI](install-and-use-a-package-using-the-dotnet-cli.md). This article demonstrates the process using the popular [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) package and a Windows Presentation Foundation (WPF) project. The same process applies to any other .NET or .NET Core project.
 
 Once installed, refer to the package in code with `using <namespace>` where \<namespace\> is specific to the package you're using. Once the reference is made, you can call the package through its API.
 


### PR DESCRIPTION
I received some internal feedback that installing with the dotnet cli wasn't discoverable from this page. (The article is in the same table of contents, but they didn't notice it.)

Would it be alright to add in a call out for the dotnet CLI? We could also add it as a link at the end instead as well. Essentially, the user was stumped when they were trying to install a nuget package from a terminal in a server scenario and hadn't done it outside Visual Studio before.