### PR TITLE
Fixes 1793 (ApiKey is only used for pushing packages)

### DIFF
--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -61,6 +61,10 @@ To push packages to nuget.org you must use [nuget.exe v4.1.0 or above](https://w
 
     This command stores your API key in your NuGet configuration so that you don't need to repeat this step again on the same computer.
 
+    > [!NOTE]
+    > API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../reference/cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+    > API keys can be obtained from the individual NuGet servers. To create and manange APIKeys for nuget.org refer to [publish-api-key](../quickstart/includes/publish-api-key.md)
+
 1. Push your package to NuGet Gallery using the following command:
 
     ```cli

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -23,7 +23,7 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
 > [!NOTE]
 > API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
-> API keys can be obtained from the individual NuGet servers. To create and manange APIKeys for nuget.org refer to [publish-api-key](../../quickstart/includes/publish-api-key.md)
+> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [publish-api-key](../../quickstart/includes/publish-api-key.md)
 
 ## Options
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -19,10 +19,11 @@ Saves an API key for a given server URL into `NuGet.Config` so that it doesn't n
 nuget setapikey <key> -Source <url> [options]
 ```
 
-where `<source>` identifies the server and `<key>` is the key or password to save. If `<source>` is omitted, nuget.org is assumed.
+where `<source>` identifies the server and `<key>` is the key to save. If `<source>` is omitted, nuget.org is assumed. 
 
 > [!NOTE]
 > API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> API keys can be obtained from the individual NuGet servers. To create and manange APIKeys for nuget.org refer to [publish-api-key](../../quickstart/includes/publish-api-key.md)
 
 ## Options
 


### PR DESCRIPTION
https://github.com/NuGet/docs.microsoft.com-nuget/issues/1793