### PR TITLE
Fix `PackageVersion` link

### DIFF
--- a/docs/create-packages/Prerelease-Packages.md
+++ b/docs/create-packages/Prerelease-Packages.md
@@ -19,7 +19,7 @@ To support the software release lifecycle, NuGet 1.6 and later allows for the di
 
 You can specify such versions using one of the following ways:
 
-- **If your project uses [`PackageReference`](../consume-packages/package-references-in-project-files.md)**: include the semantic version suffix in the `.csproj` file's [`PackageVersion`](/dotnet/core/tools/csproj.md#packageversion) element:
+- **If your project uses [`PackageReference`](../consume-packages/package-references-in-project-files.md)**: include the semantic version suffix in the `.csproj` file's [`PackageVersion`](/dotnet/core/tools/csproj#packageversion) element:
 
     ```xml
     <PropertyGroup>


### PR DESCRIPTION
Including the `.md` extension for an absolute link seems to be unsupported, the `.md` stays in the resulting html link, causing it to be invalid.

Fixes #2023