### PR TITLE
Corrected XML Closing Tag - L20

### DIFF
--- a/docs/create-packages/includes/add-description.md
+++ b/docs/create-packages/includes/add-description.md
@@ -17,5 +17,5 @@ An example of a _description_ field is shown in the following XML text of the `.
       REST API Reference for Blob Service - https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api
     </Description>
   </PropertyGroup>
-</PropertyGroup>
+</Project>
 ```


### PR DESCRIPTION
In line 20, it should `</Project>`, instead of `</PropertyGroup>`.