### PR TITLE
Add catalog and metadata vulnerability details

### DIFF
--- a/docs/api/_data/catalog-package-details.json
+++ b/docs/api/_data/catalog-package-details.json
@@ -72,5 +72,13 @@
     "V3",
     "Protocol",
     "Example"
+  ],
+  "vulnerabilities": [
+    {
+      "@id": "https://api.nuget.org/v3/catalog0/data/2015.02.01.11.18.40/windowsazure.storage.1.0.0.json#vulnerability/GitHub/999",
+      "@type": "Vulnerability",
+      "advisoryUrl": "https://github.com/advisories/ABCD-1234-5678-9012",
+      "severity": "2"
+    }
   ]
 }

--- a/docs/api/_data/package-registration-index.json
+++ b/docs/api/_data/package-registration-index.json
@@ -37,7 +37,13 @@
             "summary": "",
             "tags": [ "" ],
             "title": "",
-            "version": "3.0.0-beta"
+            "version": "3.0.0-beta",
+            "vulnerabilities": [
+              {
+                "advisoryUrl": "https://github.com/advisories/ABCD-1234-5678-9012",
+                "severity": "2"
+              }
+            ]
           },
           "packageContent": "https://api.nuget.org/v3-flatcontainer/nuget.server.core/3.0.0-beta/nuget.server.core.3.0.0-beta.nupkg",
           "registration": "https://api.nuget.org/v3/registration3/nuget.server.core/index.json"

--- a/docs/api/catalog-resource.md
+++ b/docs/api/catalog-resource.md
@@ -241,6 +241,7 @@ summary                 | string                     | no       |
 tags                    | array of strings           | no       |
 title                   | string                     | no       |
 verbatimVersion         | string                     | no       | The version string as it's originally found in the .nuspec
+vulnerabilities         | array of objects           | no       | The security vulnerabilities of the package
 
 The package `version` property is the full version string after normalization. This means that SemVer 2.0.0 build data can
 be included here.
@@ -262,6 +263,17 @@ The `published` timestamp is the time when the package was last listed.
 
 > [!Note]
 > On nuget.org, the `published` value is set to the year 1900 when the package is unlisted.
+
+#### Vulnerabilities
+
+An array of `vulnerability` objects. Each vulnerability has the following properties:
+
+Name         | Type   | Required | Notes
+------------ | ------ | -------- | -----
+advisoryUrl  | string | yes      | Location of security advisory for the package
+severity     | string | yes      | Severity of advisory: "0" = Low, "1" = Moderate, "2" = High, "3" = Critical
+
+If the `severity` property contains values other than those listed here, the severity of the advisory is to be treated as Low.
 
 #### Sample request
 

--- a/docs/api/registration-base-url-resource.md
+++ b/docs/api/registration-base-url-resource.md
@@ -181,6 +181,7 @@ summary                  | string                     | no       |
 tags                     | string or array of string  | no       | 
 title                    | string                     | no       | 
 version                  | string                     | yes      | The full version string after normalization
+vulnerabilities          | array of objects           | no       | The security vulnerabilities of the package
 
 The package `version` property is the full version string after normalization. This means that SemVer 2.0.0 build data
 can be included here.
@@ -251,6 +252,15 @@ Name         | Type   | Required | Notes
 ------------ | ------ | -------- | -----
 id           | string | yes      | The ID of the alternate package
 range        | object | no       | The allowed [version range](../concepts/package-versioning.md#version-ranges), or `*` if any version is allowed
+
+#### Vulnerabilities
+
+An array of `vulnerability` objects. Each vulnerability has the following properties:
+
+Name         | Type   | Required | Notes
+------------ | ------ | -------- | -----
+advisoryUrl  | string | yes      | Location of security advisory for the package
+severity     | string | yes      | Severity of advisory: "0" = Low, "1" = Moderate, "2" = High, "3" = Critical
 
 ### Sample request
 


### PR DESCRIPTION
Updates the docs to cover both the catalog and registration metadata inclusions for package vulnerabilities.