### PR TITLE
CLI command Options formatted, with missing values and short-forms

### DIFF
--- a/docs/consume-packages/install-use-packages-dotnet-cli.md
+++ b/docs/consume-packages/install-use-packages-dotnet-cli.md
@@ -52,13 +52,13 @@ This article shows you basic usage for a few of the most common dotnet CLI comma
 If the version is not specified, NuGet installs the latest version of the package. You can also use the [dotnet add package](/dotnet/core/tools/dotnet-add-package?tabs=netcore2x) command to install a specific version of a Nuget package:
 
 ```dotnetcli
-dotnet add package <PACKAGE_NAME> -v <VERSION>
+dotnet add package <PACKAGE_NAME> --version <VERSION>
 ```
 
 For example, to add version 12.0.1 of the `Newtonsoft.Json` package, use this command:
 
 ```dotnetcli
-dotnet add package Newtonsoft.Json -v 12.0.1
+dotnet add package Newtonsoft.Json --version 12.0.1
 ```
 
 ## List package references

--- a/docs/quickstart/includes/publish-dotnet.md
+++ b/docs/quickstart/includes/publish-dotnet.md
@@ -3,7 +3,7 @@
 1. Run the following command, specifying your package name (unique package ID) and replacing the key value with your API key:
 
     ```dotnetcli
-    dotnet nuget push AppLogger.1.0.0.nupkg -k qz2jga8pl3dvn2akksyquwcs9ygggg4exypy3bhxy6w6x6 -s https://api.nuget.org/v3/index.json
+    dotnet nuget push AppLogger.1.0.0.nupkg --api-key qz2jga8pl3dvn2akksyquwcs9ygggg4exypy3bhxy6w6x6 --source https://api.nuget.org/v3/index.json
     ```
 
 1. dotnet displays the results of the publishing process:

--- a/docs/reference/cli-reference/cli-ref-add.md
+++ b/docs/reference/cli-reference/cli-ref-add.md
@@ -34,14 +34,31 @@ where `<packagePath>` is the pathname to the package to add, and `<sourcePath>` 
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| Expand | Adds all the files in the package to the package source. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-e|-Expand`**
+
+  Adds all the files in the package to the package source.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-add.md
+++ b/docs/reference/cli-reference/cli-ref-add.md
@@ -34,7 +34,7 @@ where `<packagePath>` is the pathname to the package to add, and `<sourcePath>` 
 
 ## Options
 
-- **`-ConfigFile`**
+- **`-c|-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 

--- a/docs/reference/cli-reference/cli-ref-add.md
+++ b/docs/reference/cli-reference/cli-ref-add.md
@@ -13,12 +13,14 @@ ms.topic: reference
 
 Adds a specified package to a non-HTTP package source (a folder or UNC path) in a hierarchical layout, wherein folders are created for the package ID and version number. For example:
 
-    \\myserver\packages
-      └─<packageID>
-        └─<version>
-          ├─<packageID>.<version>.nupkg
-          ├─<packageID>.<version>.nupkg.sha512
-          └─<packageID>.nuspec
+```
+\\myserver\packages
+  └─<packageID>
+    └─<version>
+      ├─<packageID>.<version>.nupkg
+      ├─<packageID>.<version>.nupkg.sha512
+      └─<packageID>.nuspec
+```
 
 When restoring or updating against the package source, hierarchical layout provides significantly better performance.
 

--- a/docs/reference/cli-reference/cli-ref-add.md
+++ b/docs/reference/cli-reference/cli-ref-add.md
@@ -59,10 +59,9 @@ Forces nuget.exe to run using an invariant, English-based culture.
 
    Specifies the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported.
 
-- **`-v|-Verbosity <LEVEL>`**
+- **`-v|-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
-
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-add.md
+++ b/docs/reference/cli-reference/cli-ref-add.md
@@ -55,6 +55,10 @@ Forces nuget.exe to run using an invariant, English-based culture.
 
   Suppresses prompts for user input or confirmations.
 
+- **`-s|-src|-Source`**
+
+   Specifies the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported.
+
 - **`-v|-Verbosity <LEVEL>`**
 
   Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.

--- a/docs/reference/cli-reference/cli-ref-add.md
+++ b/docs/reference/cli-reference/cli-ref-add.md
@@ -36,32 +36,32 @@ where `<packagePath>` is the pathname to the package to add, and `<sourcePath>` 
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-e|-Expand`**
+- **`-Expand`**
 
   Adds all the files in the package to the package source.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-s|-src|-Source`**
+- **`-src|-Source`**
 
    Specifies the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-config.md
+++ b/docs/reference/cli-reference/cli-ref-config.md
@@ -33,29 +33,29 @@ In NuGet 3.4+, `<value>` can use [environment variables](cli-ref-environment-var
 
   Returns the config value as a path, ignored when `-Set` is used.
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-s|-Set`**
+- **`-Set`**
 
   One on more key-value pairs to be set in config.
 
-- **`-v|-Verbosity <LEVEL>`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-config.md
+++ b/docs/reference/cli-reference/cli-ref-config.md
@@ -40,7 +40,6 @@ In NuGet 3.4+, `<value>` can use [environment variables](cli-ref-environment-var
 - **`-f|-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
-Forces nuget.exe to run using an invariant, English-based culture.
 
 - **`-?|-h|-help`**
 

--- a/docs/reference/cli-reference/cli-ref-config.md
+++ b/docs/reference/cli-reference/cli-ref-config.md
@@ -33,7 +33,7 @@ In NuGet 3.4+, `<value>` can use [environment variables](cli-ref-environment-var
 
   Returns the config value as a path, ignored when `-Set` is used.
 
-- **`-ConfigFile`**
+- **`-c|-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 

--- a/docs/reference/cli-reference/cli-ref-config.md
+++ b/docs/reference/cli-reference/cli-ref-config.md
@@ -28,14 +28,35 @@ In NuGet 3.4+, `<value>` can use [environment variables](cli-ref-environment-var
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| AsPath | Returns the config value as a path, ignored when `-Set` is used. |
-| ConfigFile | The NuGet configuration file to modify. If not specified, the default file is used -`%AppData%\NuGet\NuGet.Config` (Windows) or `~/.config/NuGet/NuGet.Config`  (Mac/Linux) or `~/.nuget/NuGet/NuGet.Config` (varies by OS distribution).|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+
+- **`-a|AsPath`**
+
+  Returns the config value as a path, ignored when `-Set` is used.
+
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-s|-Set`**
+
+  One on more key-value pairs to be set in config.
+
+- **`-v|-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-config.md
+++ b/docs/reference/cli-reference/cli-ref-config.md
@@ -29,7 +29,7 @@ In NuGet 3.4+, `<value>` can use [environment variables](cli-ref-environment-var
 ## Options
 
 
-- **`-a|AsPath`**
+- **`AsPath`**
 
   Returns the config value as a path, ignored when `-Set` is used.
 

--- a/docs/reference/cli-reference/cli-ref-delete.md
+++ b/docs/reference/cli-reference/cli-ref-delete.md
@@ -27,7 +27,7 @@ where `<packageID>` and `<packageVersion>` identify the exact package to delete 
 
   The API key for the target repository. If not present, the one specified in the config file is used.
 
-- **`-ConfigFile`**
+- **`-c|-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 

--- a/docs/reference/cli-reference/cli-ref-delete.md
+++ b/docs/reference/cli-reference/cli-ref-delete.md
@@ -23,7 +23,7 @@ where `<packageID>` and `<packageVersion>` identify the exact package to delete 
 
 ## Options
 
-- **`-a|-ApiKey`**
+- **`-ApiKey`**
 
   The API key for the target repository. If not present, the one specified in the config file is used.
 

--- a/docs/reference/cli-reference/cli-ref-delete.md
+++ b/docs/reference/cli-reference/cli-ref-delete.md
@@ -27,15 +27,15 @@ where `<packageID>` and `<packageVersion>` identify the exact package to delete 
 
   The API key for the target repository. If not present, the one specified in the config file is used.
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
@@ -50,11 +50,11 @@ where `<packageID>` and `<packageVersion>` identify the exact package to delete 
  - **`-NoServiceEndpoint`**
    Does not append "api/v2/packages" to the source URL.
 
-- **`-s|-src|-Source`**
+- **`-src|-Source`**
 
   Specifies the server URL. The URL for nuget.org is `https://api.nuget.org/v3/index.json`. For private feeds, substitute the host name, for example, *%hostname%/api/v3*.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-delete.md
+++ b/docs/reference/cli-reference/cli-ref-delete.md
@@ -23,15 +23,40 @@ where `<packageID>` and `<packageVersion>` identify the exact package to delete 
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ApiKey | The API key for the target repository. If not present, the one specified in the config file is used. |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Source | Specifies the server URL. The URL for nuget.org is `https://api.nuget.org/v3/index.json`. For private feeds, substitute the host name, for example, *%hostname%/api/v3*. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-a|-ApiKey`**
+
+  The API key for the target repository. If not present, the one specified in the config file is used.
+
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+ - **`-np|-NoPrompt`**
+
+   Do not prompt when deleting.
+
+ - **`-NoServiceEndpoint`**
+   Does not append "api/v2/packages" to the source URL.
+
+- **`-s|-src|-Source`**
+
+  Specifies the server URL. The URL for nuget.org is `https://api.nuget.org/v3/index.json`. For private feeds, substitute the host name, for example, *%hostname%/api/v3*.
+
+- **`-v|-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-delete.md
+++ b/docs/reference/cli-reference/cli-ref-delete.md
@@ -54,9 +54,9 @@ where `<packageID>` and `<packageVersion>` identify the exact package to delete 
 
   Specifies the server URL. The URL for nuget.org is `https://api.nuget.org/v3/index.json`. For private feeds, substitute the host name, for example, *%hostname%/api/v3*.
 
-- **`-v|-Verbosity <LEVEL>`**
+- **`-v|-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-help.md
+++ b/docs/reference/cli-reference/cli-ref-help.md
@@ -27,15 +27,33 @@ where [command] identifies a specific command for which to display help.
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| All | Print detailed help for all available commands; ignored if a specific command is given. |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the help command itself. |
-| Markdown | Print detailed help in markdown format when used with `-All`. Ignored otherwise. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-All`**
+
+  Print detailed help for all available commands; ignored if a specific command is given.
+
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-help`**
+
+  Displays help information for the command.
+
+- **`-Markdown`**
+
+  Print detailed help in markdown format when used with `-All`. Ignored otherwise.
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-init.md
+++ b/docs/reference/cli-reference/cli-ref-init.md
@@ -25,27 +25,27 @@ where `<source>` is the folder containing packages and `<destination>` is the lo
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-e|-Expand`**
+- **`-Expand`**
 
   Adds all files in each package that's added to the package source; same as `-Expand` with the `add` command.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-init.md
+++ b/docs/reference/cli-reference/cli-ref-init.md
@@ -25,14 +25,29 @@ where `<source>` is the folder containing packages and `<destination>` is the lo
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Expand | Adds all files in each package that's added to the package source; same as `-Expand` with the `add` command. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-e|-Expand`**
+
+  Adds all files in each package that's added to the package source; same as `-Expand` with the `add` command.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-init.md
+++ b/docs/reference/cli-reference/cli-ref-init.md
@@ -45,9 +45,9 @@ where `<source>` is the folder containing packages and `<destination>` is the lo
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity <LEVEL>`**
+- **`-v|-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-install.md
+++ b/docs/reference/cli-reference/cli-ref-install.md
@@ -34,7 +34,7 @@ where `<packageID>` names the package to install (using the latest version), or 
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
@@ -66,7 +66,7 @@ where `<packageID>` names the package to install (using the latest version), or 
 
   *(4.4+)* Target framework used for selecting dependencies. Defaults to 'Any' if not specified.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
@@ -102,7 +102,7 @@ where `<packageID>` names the package to install (using the latest version), or 
 
    Specifies the list of package sources (as URLs) to use. If omitted, the command uses the sources provided in configuration files, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md).
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-install.md
+++ b/docs/reference/cli-reference/cli-ref-install.md
@@ -34,26 +34,81 @@ where `<packageID>` names the package to install (using the latest version), or 
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| DependencyVersion | *(4.4+)* The version of the dependency packages to use, which can be one of the following:<br/><ul><li>*Lowest* (default): the lowest version</li><li>*HighestPatch*: the version with the lowest major, lowest minor, highest patch</li><li>*HighestMinor*: the version with the lowest major, highest minor, highest patch</li><li>*Highest*: the highest version</li><li>*Ignore*: No dependency packages will be used</li></ul> |
-| DisableParallelProcessing | Disables installing multiple packages in parallel. |
-| ExcludeVersion | Installs the package to a folder named with only the package name and not the version number. |
-| FallbackSource | *(3.2+)* A list of package sources to use as fallbacks in case the package isn't found in the primary or default source. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Framework | *(4.4+)* Target framework used for selecting dependencies. Defaults to 'Any' if not specified. |
-| Help | Displays help information for the command. |
-| NoCache | Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../../consume-packages/managing-the-global-packages-and-cache-folders.md). |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| OutputDirectory | Specifies the folder in which packages are installed. If no folder is specified, the current folder is used. |
-| PackageSaveMode | Specifies the types of files to save after package installation: one of `nuspec`, `nupkg`, or `nuspec;nupkg`. |
-| PreRelease | Allows prerelease packages to be installed. This flag is not required when restoring packages with `packages.config`. |
-| RequireConsent | Verifies that restoring packages is enabled before downloading and installing the packages. For details, see [Package Restore](../../consume-packages/package-restore.md). |
-| SolutionDirectory | Specifies root folder of the solution for which to restore packages. |
-| Source | Specifies the list of package sources (as URLs) to use. If omitted, the command uses the sources provided in configuration files, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md). |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
-| Version | Specifies the version of the package to install. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-DependencyVersion`**
+
+  *(4.4+)* The version of the dependency packages to use, which can be one of the following:<br/><ul><li>*Lowest* (default): the lowest version</li><li>*HighestPatch*: the version with the lowest major, lowest minor, highest patch</li><li>*HighestMinor*: the version with the lowest major, highest minor, highest patch</li><li>*Highest*: the highest version</li><li>*Ignore*: No dependency packages will be used</li></ul>
+
+- **`-DirectDownload`**
+
+  Download directly without populating any caches with metadata or binaries.
+
+- **`-DisableParallelProcessing`**
+
+  Disables installing multiple packages in parallel.
+
+- **`-x|-ExcludeVersion`**
+
+  Installs the package to a folder named with only the package name and not the version number.
+
+- **`-FallbackSource`**
+
+  *(3.2+)* A list of package sources to use as fallbacks in case the package isn't found in the primary or default source.
+
+- **`-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-Framework`**
+
+  *(4.4+)* Target framework used for selecting dependencies. Defaults to 'Any' if not specified.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-NoCache`**
+
+  Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../../consume-packages/managing-the-global-packages-and-cache-folders.md).
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-OutputDirectory`**
+
+  Specifies the folder in which packages are installed. If no folder is specified, the current folder is used.
+
+- **`-PackageSaveMode`**
+
+  Specifies the types of files to save after package installation: one of `nuspec`, `nupkg`, or `nuspec;nupkg`.
+
+- **`-PreRelease`**
+
+  Allows prerelease packages to be installed. This flag is not required when restoring packages with `packages.config`.
+
+- **`-RequireConsent`**
+
+  Verifies that restoring packages is enabled before downloading and installing the packages. For details, see [Package Restore](../../consume-packages/package-restore.md).
+
+- **`-SolutionDirectory`**
+
+  Specifies root folder of the solution for which to restore packages.
+
+- **`-Source`**
+
+   Specifies the list of package sources (as URLs) to use. If omitted, the command uses the sources provided in configuration files, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md).
+
+- **`-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+
+- **`-Version`**
+
+  Specifies the version of the package to install.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-install.md
+++ b/docs/reference/cli-reference/cli-ref-install.md
@@ -102,9 +102,9 @@ where `<packageID>` names the package to install (using the latest version), or 
 
    Specifies the list of package sources (as URLs) to use. If omitted, the command uses the sources provided in configuration files, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md).
 
-- **`-Verbosity <LEVEL>`**
+- **`-v|-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 - **`-Version`**
 

--- a/docs/reference/cli-reference/cli-ref-list.md
+++ b/docs/reference/cli-reference/cli-ref-list.md
@@ -55,9 +55,9 @@ where the optional search terms will filter the displayed list. Search terms are
 
   Specifies a list of packages sources to search.
 
-- **`-v|-Verbosity <LEVEL>`**
+- **`-v|-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-list.md
+++ b/docs/reference/cli-reference/cli-ref-list.md
@@ -23,17 +23,41 @@ where the optional search terms will filter the displayed list. Search terms are
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| AllVersions | List all versions of a package. By default, only the latest package version is displayed. |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| IncludeDelisted | *(3.2+)* Display unlisted packages. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| PreRelease | Includes prerelease packages in the list. |
-| Source | Specifies a list of packages sources to search. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-a|-AllVersions`**
+
+  List all versions of a package. By default, only the latest package version is displayed.
+
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-i|-IncludeDelisted`**
+
+  *(3.2+)* Display unlisted packages.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-p|-PreRelease`**
+
+  Includes prerelease packages in the list.
+
+- **`-s|-Source`**
+
+  Specifies a list of packages sources to search.
+
+- **`-v|-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-list.md
+++ b/docs/reference/cli-reference/cli-ref-list.md
@@ -23,39 +23,39 @@ where the optional search terms will filter the displayed list. Search terms are
 
 ## Options
 
-- **`-a|-AllVersions`**
+- **`-AllVersions`**
 
   List all versions of a package. By default, only the latest package version is displayed.
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-i|-IncludeDelisted`**
+- **`-IncludeDelisted`**
 
   *(3.2+)* Display unlisted packages.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-p|-PreRelease`**
+- **`-PreRelease`**
 
   Includes prerelease packages in the list.
 
-- **`-s|-Source`**
+- **`-Source`**
 
   Specifies a list of packages sources to search.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-locals.md
+++ b/docs/reference/cli-reference/cli-ref-locals.md
@@ -47,9 +47,9 @@ where `<folder>` is one of `all`, `http-cache`, `packages-cache` *(3.5 and earli
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity <LEVEL>`**
+- **`-v|-Verbosity [normal|quiet|detailed]`**
 
-  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-locals.md
+++ b/docs/reference/cli-reference/cli-ref-locals.md
@@ -31,23 +31,23 @@ where `<folder>` is one of `all`, `http-cache`, `packages-cache` *(3.5 and earli
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-l|-List`**
+- **`-List`**
 
   Lists the location of the specified folder, or the locations of all folders when used with *all*.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-locals.md
+++ b/docs/reference/cli-reference/cli-ref-locals.md
@@ -23,15 +23,33 @@ where `<folder>` is one of `all`, `http-cache`, `packages-cache` *(3.5 and earli
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| Clear | Clears the specified folder. |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| List | Lists the location of the specified folder, or the locations of all folders when used with *all*. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-Clear`**
+
+  Clears the specified folder.
+
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-l|-List`**
+
+  Lists the location of the specified folder, or the locations of all folders when used with *all*.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity <LEVEL>`**
+
+  Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-mirror.md
+++ b/docs/reference/cli-reference/cli-ref-mirror.md
@@ -30,16 +30,37 @@ If your target repository is on `https://machine/repo` that's running [NuGet.Ser
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ApiKey | The API key for the target repository. If not present,  the one specified in the config file is used (`%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux)). |
-| Help | Displays help information for the command. |
-| NoCache | Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../../consume-packages/managing-the-global-packages-and-cache-folders.md). |
-| Noop | Logs what would be done but does not perform the actions; assumes success for push operations. |
-| PreRelease | Includes prerelease packages in the mirroring operation. |
-| Source | A list of package sources to mirror. If no sources are specified, the ones defined in the config file (see ApiKey above) are used, defaulting to nuget.org if none are specified. |
-| Timeout | Specifies the timeout, in seconds, for pushing to a server. The default is 300 seconds (5 minutes). |
-| Version | The version of the package to install. If not specified, the latest version is mirrored. |
+- **`-ApiKey`**
+
+  The API key for the target repository. If not present,  the one specified in the config file is used (`%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux)).
+
+- **`-Help`**
+
+  Displays help information for the command.
+
+- **`-NoCache`**
+
+  Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../../consume-packages/managing-the-global-packages-and-cache-folders.md).
+
+- **`-Noop`**
+
+  Logs what would be done but does not perform the actions; assumes success for push operations.
+
+- **`-PreRelease`**
+
+  Includes prerelease packages in the mirroring operation.
+
+- **`-Source`**
+
+  A list of package sources to mirror. If no sources are specified, the ones defined in the config file (see ApiKey above) are used, defaulting to nuget.org if none are specified.
+
+- **`-Timeout`**
+
+  Specifies the timeout, in seconds, for pushing to a server. The default is 300 seconds (5 minutes).
+
+- **`-Version`**
+
+  The version of the package to install. If not specified, the latest version is mirrored.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-pack.md
+++ b/docs/reference/cli-reference/cli-ref-pack.md
@@ -26,29 +26,109 @@ nuget pack <nuspecPath | projectPath> [options] [-Properties ...]
 where `<nuspecPath>` and `<projectPath>` specify the `.nuspec` or project file, respectively.
 
 ## Options
+- **`-BasePath`**
 
-| Option | Description |
-| --- | --- |
-| BasePath | Sets the base path of the files defined in the [.nuspec](../nuspec.md) file. |
-| Build | Specifies that the project should be built before building the package. |
-| Exclude | Specifies one or more wildcard patterns to exclude when creating a package. To specify more than one pattern, repeat the -Exclude flag. See example below. |
-| ExcludeEmptyDirectories | Prevents inclusion of empty directories when building the package. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| ConfigFile | Specify the configuration file for the pack command. |
-| Help | Displays help information for the command. |
-| IncludeReferencedProjects | Indicates that the built package should include referenced projects either as dependencies or as part of the package. If a referenced project has a corresponding `.nuspec` file that has the same name as the project, then that referenced project is added as a dependency. Otherwise, the referenced project is added as part of the package. |
-| MinClientVersion | Set the *minClientVersion* attribute for the created package. This value will override the value of the existing *minClientVersion* attribute (if any) in the `.nuspec` file. |
-| MSBuildPath | *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`. |
-| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
-| NoDefaultExcludes | Prevents default exclusion of NuGet package files and files and folders starting with a dot, such as `.svn` and `.gitignore`. |
-| NoPackageAnalysis | Specifies that pack should not run package analysis after building the package. |
-| OutputDirectory | Specifies the folder in which the created package is stored. If no folder is specified, the current folder is used. |
-| Properties | Should appear last on the command line after other options. Specifies a list of properties that override values in the project file; see [Common MSBuild Project Properties](/visualstudio/msbuild/common-msbuild-project-properties) for property names. The Properties argument here is a list of token=value pairs, separated by semicolons, where each occurrence of `$token$` in the `.nuspec` file will be replaced with the given value. Values can be strings in quotation marks. Note that for the "Configuration" property, the default is "Debug". To change to a Release configuration, use `-Properties Configuration=Release`. **In general**, Properties should be the same that were used during the corresponding project build, in order to avoid potentially strange behavior. |
-| Suffix | *(3.4.4+)* Appends a suffix to the internally generated version number, typically used for appending build or other pre-release identifiers. For example, using `-suffix nightly` will create a package with a version number like `1.2.3-nightly`. Suffixes must start with a letter to avoid warnings, errors, and potential incompatibilities with different versions of NuGet and the NuGet Package Manager. |
-| Symbols | Specifies that the package contains sources and symbols. When used with a `.nuspec` file, this creates a regular NuGet package file and the corresponding symbols package. By default it creates a [legacy symbol package](../../create-packages/Symbol-Packages.md). The new recommended format for symbol packages is .snupkg. See [Creating symbol packages (.snupkg)](../../create-packages/Symbol-Packages-snupkg.md). |
-| Tool | Specifies that the output files of the project should be placed in the `tool` folder. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
-| Version | Overrides the version number from the `.nuspec` file. |
+   Sets the base path of the files defined in the [.nuspec](../nuspec.md) file.
+
+- **`-Build`**
+
+  Specifies that the project should be built before building the package.
+
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-Exclude`**
+
+  Specifies one or more wildcard patterns to exclude when creating a package. To specify more than one pattern, repeat the -Exclude flag. See example below.
+
+- **`-ExcludeEmptyDirectories`**
+
+  Prevents inclusion of empty directories when building the package.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-IncludeReferencedProjects`**
+
+  Indicates that the built package should include referenced projects either as dependencies or as part of the package. If a referenced project has a corresponding `.nuspec` file that has the same name as the project, then that referenced project is added as a dependency. Otherwise, the referenced project is added as part of the package.
+
+- **`-InstallPackageToOutputPath`**
+
+  Specify if the command should prepare the package output directory to support share as feed.
+
+- **`-MinClientVersion`**
+
+  Set the *minClientVersion* attribute for the created package. This value will override the value of the existing *minClientVersion* attribute (if any) in the `.nuspec` file.
+
+- **`-MSBuildPath`**
+
+  *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`.
+
+- **`-MSBuildVersion`**
+
+  *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
+
+- **`-NoDefaultExcludes`**
+
+  Prevents default exclusion of NuGet package files and files and folders starting with a dot, such as `.svn` and `.gitignore`.
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-NoPackageAnalysis`**
+
+  Specifies that pack should not run package analysis after building the package.
+
+- **`-OutputDirectory`**
+
+  Specifies the folder in which the created package is stored. If no folder is specified, the current folder is used.
+
+- **`-OutputFileNamesWithoutVersion`**
+
+  Specify if the command should prepare the package output name without the version.
+
+- **`-PackagesDirectory`**
+
+  Specifies the packages folder.
+
+- **`-p|-Properties`**
+
+  Should appear last on the command line after other options. Specifies a list of properties that override values in the project file; see [Common MSBuild Project Properties](/visualstudio/msbuild/common-msbuild-project-properties) for property names. The Properties argument here is a list of token=value pairs, separated by semicolons, where each occurrence of `$token$` in the `.nuspec` file will be replaced with the given value. Values can be strings in quotation marks. Note that for the "Configuration" property, the default is "Debug". To change to a Release configuration, use `-Properties Configuration=Release`. **In general**, Properties should be the same that were used during the corresponding project build, in order to avoid potentially strange behavior.
+
+- **`-SolutionDirectory`**
+
+  Specifies the solution directory.
+
+- **`-Suffix`**
+
+  *(3.4.4+)* Appends a suffix to the internally generated version number, typically used for appending build or other pre-release identifiers. For example, using `-suffix nightly` will create a package with a version number like `1.2.3-nightly`. Suffixes must start with a letter to avoid warnings, errors, and potential incompatibilities with different versions of NuGet and the NuGet Package Manager.
+
+- **`-SymbolPackageFormat`**
+
+  When creating a symbols package, allows to choose between the `snupkg` and `symbols.nupkg` format.
+
+- **`-Symbols`**
+
+  Specifies that the package contains sources and symbols. When used with a `.nuspec` file, this creates a regular NuGet package file and the corresponding symbols package. By default it creates a [legacy symbol package](../../create-packages/Symbol-Packages.md). The new recommended format for symbol packages is .snupkg. See [Creating symbol packages (.snupkg)](../../create-packages/Symbol-Packages-snupkg.md).
+
+- **`-Tool`**
+
+   Specifies that the output files of the project should be placed in the `tool` folder.
+
+- **`-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
+
+- **`-Version`**
+
+  Overrides the version number from the `.nuspec` file.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-pack.md
+++ b/docs/reference/cli-reference/cli-ref-pack.md
@@ -34,7 +34,7 @@ where `<nuspecPath>` and `<projectPath>` specify the `.nuspec` or project file, 
 
   Specifies that the project should be built before building the package.
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
@@ -46,11 +46,11 @@ where `<nuspecPath>` and `<projectPath>` specify the `.nuspec` or project file, 
 
   Prevents inclusion of empty directories when building the package.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 

--- a/docs/reference/cli-reference/cli-ref-push.md
+++ b/docs/reference/cli-reference/cli-ref-push.md
@@ -28,21 +28,62 @@ where `<packagePath>` identifies the package to push to the server.
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ApiKey | The API key for the target repository. If not present,  the one specified in the config file is used. |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| DisableBuffering | Disables buffering when pushing to an HTTP(s) server to decrease memory usages. Caution: when this option is used, integrated Windows authentication might not work. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| NoSymbols | *(3.5+)* If a symbols package exists, it will not be pushed to a symbol server. |
-| Source | Specifies the server URL. NuGet identifies a UNC or local folder source and simply copies the file there instead of pushing it using HTTP.  Also, starting with NuGet 3.4.2, this is a mandatory parameter unless the `NuGet.Config` file specifies a *DefaultPushSource* value (see [Configuring NuGet behavior](../../consume-packages/configuring-nuget-behavior.md)). |
-| SkipDuplicate | *(5.1+)* If a package and version already exists, skip it and continue with the next package in the push, if any. |
-| SymbolSource | *(3.5+)* Specifies the symbol server URL; nuget.smbsrc.net is used when pushing to nuget.org |
-| SymbolApiKey | *(3.5+)* Specifies the API key for the URL specified in `-SymbolSource`. |
-| Timeout | Specifies the timeout, in seconds, for pushing to a server. The default is 300 seconds (5 minutes). |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-a|-ApiKey`**
+
+  The API key for the target repository. If not present,  the one specified in the config file is used.
+
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-d|-DisableBuffering`**
+
+  Disables buffering when pushing to an HTTP(s) server to decrease memory usages. Caution: when this option is used, integrated Windows authentication might not work.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-NoServiceEndpoint`**
+
+  Does not append `api/v2/packages` to the source URL.
+
+- **`-NoSymbols`**
+
+  *(3.5+)* If a symbols package exists, it will not be pushed to a symbol server.
+
+- **`-src|-Source`**
+
+  Specifies the server URL. NuGet identifies a UNC or local folder source and simply copies the file there instead of pushing it using HTTP.  Also, starting with NuGet 3.4.2, this is a mandatory parameter unless the `NuGet.Config` file specifies a *DefaultPushSource* value (see [Configuring NuGet behavior](../../consume-packages/configuring-nuget-behavior.md)).
+
+- **`-SkipDuplicate`**
+
+  *(5.1+)* If a package and version already exists, skip it and continue with the next package in the push, if any.
+
+- **`-SymbolSource`**
+
+  *(3.5+)* Specifies the symbol server URL; nuget.smbsrc.net is used when pushing to nuget.org
+
+- **`-SymbolApiKey`**
+
+  *(3.5+)* Specifies the API key for the URL specified in `-SymbolSource`.
+
+- **`-t|-Timeout`**
+
+  Specifies the timeout, in seconds, for pushing to a server. The default is 300 seconds (5 minutes).
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
+
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-push.md
+++ b/docs/reference/cli-reference/cli-ref-push.md
@@ -28,23 +28,23 @@ where `<packagePath>` identifies the package to push to the server.
 
 ## Options
 
-- **`-a|-ApiKey`**
+- **`-ApiKey`**
 
   The API key for the target repository. If not present,  the one specified in the config file is used.
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-d|-DisableBuffering`**
+- **`-DisableBuffering`**
 
   Disables buffering when pushing to an HTTP(s) server to decrease memory usages. Caution: when this option is used, integrated Windows authentication might not work.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
@@ -76,11 +76,11 @@ where `<packagePath>` identifies the package to push to the server.
 
   *(3.5+)* Specifies the API key for the URL specified in `-SymbolSource`.
 
-- **`-t|-Timeout`**
+- **`-Timeout`**
 
   Specifies the timeout, in seconds, for pushing to a server. The default is 300 seconds (5 minutes).
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-restore.md
+++ b/docs/reference/cli-reference/cli-ref-restore.md
@@ -25,32 +25,101 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| DirectDownload | *(4.0+)* Downloads packages directly without populating caches with any binaries or metadata. |
-| DisableParallelProcessing | Disables restoring multiple packages in parallel. |
-| FallbackSource | *(3.2+)* A list of package sources to use as fallbacks in case the package isn't found in the primary or default source. Use a semicolon to separate list entries. |
-| Force | In PackageReference based projects, forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is similar to deleting the `project.assets.json` file. This does not bypass the http-cache. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| ForceEvaluate | Forces restore to reevaluate all dependencies even if a lock file already exists. |
-| Help | Displays help information for the command. |
-| LockFilePath | Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'. |
-| LockedMode | Don't allow updating project lock file. |
-| MSBuildPath | *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`. |
-| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
-| NoCache | Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../../consume-packages/managing-the-global-packages-and-cache-folders.md). |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| OutputDirectory | Specifies the folder in which packages are installed. If no folder is specified, the current folder is used. Required when restoring with a `packages.config` file unless `PackagesDirectory` or `SolutionDirectory` is used.|
-| PackageSaveMode | Specifies the types of files to save after package installation: one of `nuspec`, `nupkg`, or `nuspec;nupkg`. |
-| PackagesDirectory | Same as `OutputDirectory`. Required when restoring with a `packages.config` file unless `OutputDirectory` or `SolutionDirectory` is used. |
-| Project2ProjectTimeOut | Timeout in seconds for resolving project-to-project references. |
-| Recursive | *(4.0+)* Restores all references projects for UWP and .NET Core projects. Does not apply to projects using `packages.config`. |
-| RequireConsent | Verifies that restoring packages is enabled before downloading and installing the packages. For details, see [Package Restore](../../consume-packages/package-restore.md). |
-| SolutionDirectory | Specifies the solution folder. Not valid when restoring packages for a solution. Required when restoring with a `packages.config` file unless `PackagesDirectory` or `OutputDirectory` is used. |
-| Source | Specifies the list of package sources (as URLs) to use for the restore. If omitted, the command uses the sources provided in configuration files, see [Configuring NuGet behavior](../../consume-packages/configuring-nuget-behavior.md). Use a semicolon to separate list entries. |
-| UseLockFile | Enables project lock file to be generated and used with restore. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-DirectDownload`**
+
+  *(4.0+)* Downloads packages directly without populating caches with any binaries or metadata.
+
+- **`-DisableParallelProcessing`**
+
+   Disables restoring multiple packages in parallel.
+
+- **`-FallbackSource`**
+
+  *(3.2+)* A list of package sources to use as fallbacks in case the package isn't found in the primary or default source. Use a semicolon to separate list entries.
+
+- **`-Force`**
+
+  In PackageReference based projects, forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is similar to deleting the `project.assets.json` file. This does not bypass the http-cache.
+
+- **`-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-ForceEvaluate`**
+
+  Forces restore to reevaluate all dependencies even if a lock file already exists.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-LockFilePath`**
+
+  Output location where project lock file is written. By default, this is `PROJECT_ROOT\packages.lock.json`.
+
+- **`-LockedMode`**
+
+  Don't allow updating project lock file.
+
+- **`-MSBuildPath`**
+
+   *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`.
+
+- **`-MSBuildVersion`**
+
+  *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
+
+- **`-NoCache`**
+
+  Prevents NuGet from using cached packages. See [Managing the global packages and cache folders](../../consume-packages/managing-the-global-packages-and-cache-folders.md).
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-o|-OutputDirectory`**
+
+  Specifies the folder in which packages are installed. If no folder is specified, the current folder is used. Required when restoring with a `packages.config` file unless `PackagesDirectory` or `SolutionDirectory` is used.
+
+- **`-PackageSaveMode`**
+
+  Specifies the types of files to save after package installation: one of `nuspec`, `nupkg`, or `nuspec;nupkg`.
+
+- **`-PackagesDirectory`**
+
+  Same as `OutputDirectory`. Required when restoring with a `packages.config` file unless `OutputDirectory` or `SolutionDirectory` is used.
+
+- **`-Project2ProjectTimeOut`**
+
+  Timeout in seconds for resolving project-to-project references.
+
+- **`-Recursive`**
+
+  *(4.0+)* Restores all references projects for UWP and .NET Core projects. Does not apply to projects using `packages.config`.
+
+- **`-RequireConsent`**
+
+  Verifies that restoring packages is enabled before downloading and installing the packages. For details, see [Package Restore](../../consume-packages/package-restore.md).
+
+- **`-SolutionDirectory`**
+
+  Specifies the solution folder. Not valid when restoring packages for a solution. Required when restoring with a `packages.config` file unless `PackagesDirectory` or `OutputDirectory` is used.
+
+- **`-Source`**
+
+  Specifies the list of package sources (as URLs) to use for the restore. If omitted, the command uses the sources provided in configuration files, see [Configuring NuGet behavior](../../consume-packages/configuring-nuget-behavior.md). Use a semicolon to separate list entries.
+
+- **`-u|-UseLockFile`**
+
+  Enables project lock file to be generated and used with restore.
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-restore.md
+++ b/docs/reference/cli-reference/cli-ref-restore.md
@@ -25,7 +25,7 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
@@ -53,7 +53,7 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
   Forces restore to reevaluate all dependencies even if a lock file already exists.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
@@ -81,7 +81,7 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
   Suppresses prompts for user input or confirmations.
 
-- **`-o|-OutputDirectory`**
+- **`-OutputDirectory`**
 
   Specifies the folder in which packages are installed. If no folder is specified, the current folder is used. Required when restoring with a `packages.config` file unless `PackagesDirectory` or `SolutionDirectory` is used.
 
@@ -89,7 +89,7 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
   Specifies the types of files to save after package installation: one of `nuspec`, `nupkg`, or `nuspec;nupkg`.
 
-- **`-OutputDirectory|-PackagesDirectory`**
+- **`-PackagesDirectory`**
 
   Same as `OutputDirectory`. Required when restoring with a `packages.config` file unless `OutputDirectory` or `SolutionDirectory` is used.
 
@@ -113,11 +113,11 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
   Specifies the list of package sources (as URLs) to use for the restore. If omitted, the command uses the sources provided in configuration files, see [Configuring NuGet behavior](../../consume-packages/configuring-nuget-behavior.md). Use a semicolon to separate list entries.
 
-- **`-u|-UseLockFile`**
+- **`-UseLockFile`**
 
   Enables project lock file to be generated and used with restore.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-restore.md
+++ b/docs/reference/cli-reference/cli-ref-restore.md
@@ -89,7 +89,7 @@ where `<projectPath>` specifies the location of a solution or a `packages.config
 
   Specifies the types of files to save after package installation: one of `nuspec`, `nupkg`, or `nuspec;nupkg`.
 
-- **`-PackagesDirectory`**
+- **`-OutputDirectory|-PackagesDirectory`**
 
   Same as `OutputDirectory`. Required when restoring with a `packages.config` file unless `OutputDirectory` or `SolutionDirectory` is used.
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -27,13 +27,25 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -23,7 +23,7 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
 > [!NOTE]
 > API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
-> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [acquire-an-api-key](../../nuget-org/scoped-api-keys#acquire-an-api-key)
+> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [acquire-an-api-key](../../nuget-org/scoped-api-keys.md#acquire-an-api-key)
 
 ## Options
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -27,27 +27,27 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-s|-src|-Source`**
+- **`-src|-Source`**
 
   Server URL where the API key is valid.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -23,7 +23,7 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
 > [!NOTE]
 > API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
-> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [publish-api-key](../../quickstart/includes/publish-api-key.md)
+> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [acquire-an-api-key](../../nuget-org/scoped-api-keys#acquire-an-api-key)
 
 ## Options
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -43,6 +43,10 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
   Suppresses prompts for user input or confirmations.
 
+- **`-s|-src|-Source`**
+
+  Server URL where the API key is valid.
+
 - **`-v|-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -27,24 +27,69 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| CertificateFingerprint | Specifies the SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate. |
-| CertificatePassword | Specifies the certificate password, if needed. If a certificate is password protected but no password is provided, the command will prompt for a password at run time, unless the -NonInteractive option is passed. |
-| CertificatePath | Specifies the file path to the certificate to be used in signing the package. |
-| CertificateStoreLocation | Specifies the name of the X.509 certificate store use to search for the certificate. Defaults to "CurrentUser", the X.509 certificate store used by the current user. This option should be used when specifying the certificate via -CertificateSubjectName or -CertificateFingerprint options. |
-| CertificateStoreName | Specifies the name of the X.509 certificate store to use to search for the certificate. Defaults to "My", the X.509 certificate store for personal certificates. This option should be used when specifying the certificate via -CertificateSubjectName or -CertificateFingerprint options. |
-| CertificateSubjectName | Specifies the subject name of the certificate used to search a local certificate store for the certificate.  The search is a case-insensitive string comparison using the supplied value, which will find all certificates with the subject name containing that string, regardless of other subject values.  The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options. |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | Forces nuget.exe to run using an invariant, English-based culture. |
-| HashAlgorithm | Hash algorithm to be used to sign the package. Defaults to SHA256. Possible values are SHA256, SHA384, and SHA512. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| OutputDirectory | Specifies the directory where the signed package should be saved. By default the original package is overwritten by the signed package. |
-| Overwrite | Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature. |
-| Timestamper | URL to an RFC 3161 timestamping server. |
-| TimestampHashAlgorithm | Hash algorithm to be used by the RFC 3161 timestamp server. Defaults to SHA256. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-CertificateFingerprint`**
+
+  Specifies the SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
+
+- **`-CertificatePassword`**
+
+  Specifies the certificate password, if needed. If a certificate is password protected but no password is provided, the command will prompt for a password at run time, unless the `-NonInteractive` option is passed.
+
+- **`-CertificatePath`**
+
+  Specifies the file path to the certificate to be used in signing the package.
+
+- **`-CertificateStoreLocation`**
+
+  Specifies the name of the X.509 certificate store use to search for the certificate. Defaults to "CurrentUser", the X.509 certificate store used by the current user. This option should be used when specifying the certificate via `-CertificateSubjectName` or `-CertificateFingerprint` options.
+
+- **`-CertificateStoreName`**
+
+  Specifies the name of the X.509 certificate store to use to search for the certificate. Defaults to "My", the X.509 certificate store for personal certificates. This option should be used when specifying the certificate via `-CertificateSubjectName` or `-CertificateFingerprint` options.
+
+- **`-CertificateSubjectName`**
+
+  Specifies the subject name of the certificate used to search a local certificate store for the certificate.  The search is a case-insensitive string comparison using the supplied value, which will find all certificates with the subject name containing that string, regardless of other subject values.  The certificate store can be specified by `-CertificateStoreName` and `-CertificateStoreLocation` options.
+
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-HashAlgorithm`**
+
+  Hash algorithm to be used to sign the package. Defaults to SHA256. Possible values are SHA256, SHA384, and SHA512.
+
+- **`-?|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-OutputDirectory`**
+
+  Specifies the directory where the signed package should be saved. By default the original package is overwritten by the signed package.
+
+- **`-Overwrite`**
+
+  Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.
+
+- **`-Timestamper`**
+
+  URL to an RFC 3161 timestamping server.
+
+- **`-TimestampHashAlgorithm`**
+
+  Hash algorithm to be used by the RFC 3161 timestamp server. Defaults to SHA256.
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 ## Examples
 

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -55,7 +55,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   Forces nuget.exe to run using an invariant, English-based culture.
 
@@ -67,7 +67,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
@@ -87,7 +87,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
   Hash algorithm to be used by the RFC 3161 timestamp server. Defaults to SHA256.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -25,7 +25,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
@@ -37,7 +37,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Applies to the `list` action and can be `Detailed` (the default) or `Short`.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
@@ -49,7 +49,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Suppresses prompts for user input or confirmations.
 
-- **`-p|-Password`**
+- **`-Password`**
 
   Specifies the password for authenticating with the source.
 
@@ -61,7 +61,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Indicates to store the password in unencrypted text instead of the default behavior of storing an encrypted form.
 
-- **`-u|-UserName`**
+- **`-UserName`**
 
   Specifies the user name for authenticating with the source.
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -25,17 +25,53 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Format | Applies to the `list` action and can be `Detailed` (the default) or `Short`. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Password | Specifies the password for authenticating with the source. |
-| StorePasswordInClearText | Indicates to store the password in unencrypted text instead of the default behavior of storing an encrypted form. |
-| UserName | Specifies the user name for authenticating with the source. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-Format`**
+
+  Applies to the `list` action and can be `Detailed` (the default) or `Short`.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-Name`**
+
+  Name of the source.
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-p|-Password`**
+
+  Specifies the password for authenticating with the source.
+
+- **`-src|-Source`**
+
+  Path to the package(s) source.
+
+- **`-StorePasswordInClearText`**
+
+  Indicates to store the password in unencrypted text instead of the default behavior of storing an encrypted form.
+
+- **`-u|-UserName`**
+
+  Specifies the user name for authenticating with the source.
+
+- **`-ValidAuthenticationTypes`**
+
+  Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: `basic,negotiate`.
+
+- **`-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 > [!Note]
 > Make sure to add the sources' password under the same user context as the nuget.exe is later used to access the package source. The password will be stored encrypted in the config file and can only be decrypted in the same user context as it was encrypted. So for example when you use a build server to restore NuGet packages the password must be encrypted with the same Windows user under which  the build server task will run.

--- a/docs/reference/cli-reference/cli-ref-spec.md
+++ b/docs/reference/cli-reference/cli-ref-spec.md
@@ -23,7 +23,7 @@ where `<packageID>` is an optional package identifier to save in the `.nuspec` f
 
 ## Options
 
-- **`-a|-AssemblyPath`**
+- **`-AssemblyPath`**
 
   Specifies the path to the assembly to use for metadata.
 
@@ -36,15 +36,15 @@ where `<packageID>` is an optional package identifier to save in the `.nuspec` f
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-spec.md
+++ b/docs/reference/cli-reference/cli-ref-spec.md
@@ -23,14 +23,30 @@ where `<packageID>` is an optional package identifier to save in the `.nuspec` f
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| AssemblyPath | Specifies the path to the assembly to use for metadata. |
-| Force | Overwrites any existing `.nuspec` file. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-a|-AssemblyPath`**
+
+  Specifies the path to the assembly to use for metadata.
+
+- **`-Force`**
+
+  Overwrites any existing `.nuspec` file.
+
+
+- **`-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -60,12 +60,21 @@ nuget trusted-signers add <package(s)> -Name <name> [options]
 
 where `<package(s)>` is one or more `.nupkg` files.
 
-| Option | Description |
-| --- | --- |
-| Author | Specifies that the author signature of the package(s) should be trusted. |
-| Repository | Specifies that the repository signature or countersignature of the package(s) should be trusted. |
-| AllowUntrustedRoot | Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. |
-| Owners | Semi-colon separated list of trusted owners to further restrict the trust of a repository. Only valid when using the `-Repository` option. |
+- **`-Author`**
+
+  Specifies that the author signature of the package(s) should be trusted.
+
+- **`-AllowUntrustedRoot`**
+
+  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
+
+- **`-Owners`**
+
+  Semi-colon separated list of trusted owners to further restrict the trust of a repository. Only valid when using the `-Repository` option.
+
+- **`-Repository`**
+
+  Specifies that the repository signature or countersignature of the package(s) should be trusted.
 
 Providing both `-Author` and `-Repository` at the same time is not supported.
 
@@ -77,11 +86,17 @@ nuget trusted-signers add -Name <name> [options]
 
 _Note_: This option will only add trusted repositories. 
 
-| Option | Description |
-| --- | --- |
-| ServiceIndex | Specifies the V3 service index of the repository to be trusted. This repository has to support the repository signatures resource. If not provided, the command will look for a package source with the same `-Name` and get the service index from there. |
-| AllowUntrustedRoot | Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. |
-| Owners | Semi-colon separated list of trusted owners to further restrict the trust of a repository. |
+- **`-AllowUntrustedRoot`**
+
+  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
+
+- **`-Owners`**
+
+  Semi-colon separated list of trusted owners to further restrict the trust of a repository.
+
+- **`-ServiceIndex`**
+
+  Specifies the V3 service index of the repository to be trusted. This repository has to support the repository signatures resource. If not provided, the command will look for a package source with the same `-Name` and get the service index from there.
 
 ## Options for add based on the certificate information
 
@@ -91,11 +106,18 @@ nuget trusted-signers add -Name <name> [options]
 
 _Note_: If a trusted signer with the given name already exists, the certificate item will be added to that signer. Otherwise a trusted author will be created with a certificate item from given certificate information.
 
-| Option | Description |
-| --- | --- |
-| CertificateFingerprint | Specifies a certificate fingerprints of a certificate which signed packages must be signed with. A certificate fingerprint is a hash of the certificate. The hash algorithm used for calculating this hash should be specifies in the `FingerprintAlgorithm` option. |
-| FingerprintAlgorithm | Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to `SHA256`. Values supported are `SHA256`, `SHA384` and `SHA512` |
-| AllowUntrustedRoot | Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root. |
+
+- **`-AllowUntrustedRoot`**
+
+  Specifies if the certificate for the trusted signer should be allowed to chain to an untrusted root.
+
+- **`-CertificateFingerprint`**
+
+  Specifies a certificate fingerprints of a certificate which signed packages must be signed with. A certificate fingerprint is a hash of the certificate. The hash algorithm used for calculating this hash should be specifies in the `FingerprintAlgorithm` option.
+
+- **`-FingerprintAlgorithm`**
+
+  Specifies the hash algorithm used to calculate the certificate fingerprint. Defaults to `SHA256`. Values supported are `SHA256`, `SHA384` and `SHA512`.
 
 ## nuget trusted-signers remove -Name \<name\>
 
@@ -109,12 +131,30 @@ _Note_: This gesture will delete the current list of certificates and replace th
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-ForceEnglishOutput`**
+
+  Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-Name`**
+
+  Name of the trusted signer.
+
+- **`-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
+
 
 ## Examples
 

--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -139,7 +139,7 @@ _Note_: This gesture will delete the current list of certificates and replace th
 
   Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
@@ -151,7 +151,7 @@ _Note_: This gesture will delete the current list of certificates and replace th
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-update.md
+++ b/docs/reference/cli-reference/cli-ref-update.md
@@ -29,23 +29,67 @@ where `<configPath>` identifies either a `packages.config` or solution file that
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| FileConflictAction | Specifies the action to take when asked to overwrite or ignore existing files referenced by the project. Values are *overwrite, ignore, none*. |
-| ForceEnglishOutput | *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| Id | Specifies a list of package IDs to update. |
-| MSBuildPath | *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`. |
-| MSBuildVersion | *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild. |
-| NonInteractive | Suppresses prompts for user input or confirmations. |
-| PreRelease | Allows updating to prerelease versions. This flag is not required when updating prerelease packages that are already installed. |
-| RepositoryPath | Specifies the local folder where packages are installed. |
-| Safe | Specifies that only updates with the highest version available within the same major and minor version as the installed package will be installed. |
-| Self | Updates nuget.exe to the latest version; all other arguments are ignored. |
-| Source | Specifies the list of package sources (as URLs) to use for the updates. If omitted, the command uses the sources provided in configuration files, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md). |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
-| Version | When used with one package ID, specifies the version of the package to update. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-FileConflictAction [PromptUser, Overwrite, Ignore]`**
+
+  Specifies the default action when a file from a package already exists in the target project. Set to `Overwrite` to always overwrite files. Set to `Ignore` to skip files.
+
+  The `PromptUser` action, the default, will prompt for each conflicting file unless `OverwriteAll` or `IgnoreAll` is provided, which will apply to all remaining files.
+
+- **`-ForceEnglishOutput`**
+
+  *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-i|-Id`**
+
+  Specifies a list of package IDs to update.
+
+- **`-MSBuildPath`**
+
+  *(4.0+)* Specifies the path of MSBuild to use with the command, taking precedence over `-MSBuildVersion`.
+
+- **`-MSBuildVersion`**
+
+  *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-p|-PreRelease`**
+
+  Allows updating to prerelease versions. This flag is not required when updating prerelease packages that are already installed.
+
+- **`-r|-RepositoryPath`**
+
+  Specifies the local folder where packages are installed.
+
+- **`-Safe`**
+
+  Specifies that only updates with the highest version available within the same major and minor version as the installed package will be installed.
+
+- **`-Self`**
+
+  Updates nuget.exe to the latest version; all other arguments are ignored.
+
+- **`-Source`**
+
+  Specifies the list of package sources (as URLs) to use for the updates. If omitted, the command uses the sources provided in configuration files, see [Common NuGet configurations](../../consume-packages/configuring-nuget-behavior.md).
+
+- **`-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
+
+- **`-Version`**
+
+  When used with one package ID, specifies the version of the package to update.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-update.md
+++ b/docs/reference/cli-reference/cli-ref-update.md
@@ -29,7 +29,7 @@ where `<configPath>` identifies either a `packages.config` or solution file that
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
@@ -43,11 +43,11 @@ where `<configPath>` identifies either a `packages.config` or solution file that
 
   *(3.5+)* Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-i|-Id`**
+- **`-Id`**
 
   Specifies a list of package IDs to update.
 
@@ -59,15 +59,15 @@ where `<configPath>` identifies either a `packages.config` or solution file that
 
   *(3.2+)* Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14, 15.1, 15.3, 15.4, 15.5, 15.6, 15.7, 15.8, 15.9. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-p|-PreRelease`**
+- **`-PreRelease`**
 
   Allows updating to prerelease versions. This flag is not required when updating prerelease packages that are already installed.
 
-- **`-r|-RepositoryPath`**
+- **`-RepositoryPath`**
 
   Specifies the local folder where packages are installed.
 

--- a/docs/reference/cli-reference/cli-ref-verify.md
+++ b/docs/reference/cli-reference/cli-ref-verify.md
@@ -40,23 +40,23 @@ Specifies that package signature verification should be performed.
 
 ## Options
 
-- **`-c|-ConfigFile`**
+- **`-ConfigFile`**
 
   The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
 
-- **`-f|-ForceEnglishOutput`**
+- **`-ForceEnglishOutput`**
 
   Forces nuget.exe to run using an invariant, English-based culture.
 
-- **`-?|-h|-help`**
+- **`-?|-help`**
 
   Displays help information for the command.
 
-- **`-n|-NonInteractive`**
+- **`-NonInteractive`**
 
   Suppresses prompts for user input or confirmations.
 
-- **`-v|-Verbosity [normal|quiet|detailed]`**
+- **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 

--- a/docs/reference/cli-reference/cli-ref-verify.md
+++ b/docs/reference/cli-reference/cli-ref-verify.md
@@ -34,18 +34,31 @@ Specifies that package signature verification should be performed.
 
 ## Options for "verify -Signatures"
 
-| Option | Description |
-| --- | --- |
-| CertificateFingerprint | Specifies one or more SHA-256 certificate fingerprints of certificates(s) which signed packages must be signed with. A certificate SHA-256 fingerprint is a SHA-256 hash of the certificate. Multiple inputs should be semicolon separated. |
+- **`-CertificateFingerprint`**
+
+  Specifies one or more SHA-256 certificate fingerprints of certificates(s) which signed packages must be signed with. A certificate SHA-256 fingerprint is a SHA-256 hash of the certificate. Multiple inputs should be semicolon separated.
 
 ## Options
 
-| Option | Description |
-| --- | --- |
-| ConfigFile | The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux) is used.|
-| ForceEnglishOutput | Forces nuget.exe to run using an invariant, English-based culture. |
-| Help | Displays help information for the command. |
-| Verbosity | Specifies the amount of detail displayed in the output: *normal*, *quiet*, *detailed*. |
+- **`-c|-ConfigFile`**
+
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+
+- **`-f|-ForceEnglishOutput`**
+
+  Forces nuget.exe to run using an invariant, English-based culture.
+
+- **`-?|-h|-help`**
+
+  Displays help information for the command.
+
+- **`-n|-NonInteractive`**
+
+  Suppresses prompts for user input or confirmations.
+
+- **`-v|-Verbosity [normal|quiet|detailed]`**
+
+  Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
 
 ## Examples
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/999

**Formatting**: Formatting has been converted for Options section from a table to a bulleted list, sorted alphabetically.
 
**Missing Options**: Some options were missing from the docs, but present in CLI -help summary text. Those should all be in Docs, now. In some cases, we just didn't update docs as new options were added. Other cases are likely addressed in "Required Options", below.
 
**Short Forms**: I listed all explicitly coded short-forms, and also listed some implicit short-forms (if only one option begins with 'a' (like "-ApiKey", then by nature, "-a" will work for that option). Technically, the first unique subset of characters will work this way, but obviously we don't want to list all permutations
Consideration: by documenting many of the implicit 1-character shortforms, we are making it difficult/impossible to make that an explicit shortform for this command in the future…

Ex: Say "AVeryImportantOption" comes along, we cannot use "-a" for it since it'll break users already using "-a" for "-ApiKey". In this case, we could follow the standard for CLI options containing multiple words, and use the first letter of each word, like "--ak" for ApiKey, or --avio for "AVeryImportantOption".
(This docs issue was about a user asking us to list all the shortforms we currently have).
 
**Required Options**: Our vocabulary for what is an "option" is not exactly consistent or standard, so we may want to make changes here now, or in a future PR.
I explicitly created an Options entry for things like -src/-Source even though they are listed in the description as separate from the [options] block. The reason I did this is the dotnet docs use a different format in their "Synopsis"/"Arguments" sections (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack#synopsis).  Rather than state "command -src [options]" they use the format of "command [--option1] [--option2], etc". 

...I think it's possibly confusing that I'm listing -src in the Options area. But I think our original intent was -src is a "required option" and "[options]" are not required. 
If we eventually move toward the Synopsis/Arguments/Options style, then this issue goes away. Let me know thoughts.
 
Our command help text just lists things like Name and Source as "options":
![image](https://user-images.githubusercontent.com/49205731/90296392-5358b700-de59-11ea-887a-48742b79a445.png)

**Multiple Options in Trusted-Signers** - trusted-signers is one of the few with multiple Options sections. My strategy was to add the common items like "-Name" to the generic "Options" rather than specific sections like "Options for add based on a service index", to keep them very specific in nature.