### PR TITLE
Fixed formatting bugs with the Note section and the Usage column in NuGet CLI Search's reference page

### DIFF
--- a/docs/reference/cli-reference/cli-ref-search.md
+++ b/docs/reference/cli-reference/cli-ref-search.md
@@ -41,7 +41,7 @@ Also see [Environment variables](cli-ref-environment-variables.md)
 
 > [!NOTE]
 > API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
-> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [publish-api-key](../../quickstart/includes/publish-api-key.md)
+> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to.
 
 ## Examples
 

--- a/docs/reference/cli-reference/cli-ref-search.md
+++ b/docs/reference/cli-reference/cli-ref-search.md
@@ -21,10 +21,6 @@ nuget search [search terms] [options]
 
 where the search terms are applied to the names of packages, tags, and package descriptions just as they are when using them on nuget.org.
 
-> [!NOTE]
-> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
-> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to.
-
 ## Options
 
 | Name | Description | Usage |

--- a/docs/reference/cli-reference/cli-ref-search.md
+++ b/docs/reference/cli-reference/cli-ref-search.md
@@ -33,11 +33,15 @@ where the search terms are applied to the names of packages, tags, and package d
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 
-> [!NOTE]
+> [!NOTE] 
 > Verbosity Levels:
 > * _quiet_ - Package ID, Version
 > * _normal_ - Package ID, Version, Downloads, Preview of Description
 > * _detailed_ - Package ID, Version, Downloads, Full Description, Other information such as the query URL
+
+> [!NOTE]
+> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to [publish-api-key](../../quickstart/includes/publish-api-key.md)
 
 ## Examples
 

--- a/docs/reference/cli-reference/cli-ref-search.md
+++ b/docs/reference/cli-reference/cli-ref-search.md
@@ -21,6 +21,10 @@ nuget search [search terms] [options]
 
 where the search terms are applied to the names of packages, tags, and package descriptions just as they are when using them on nuget.org.
 
+> [!NOTE]
+> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
+> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to.
+
 ## Options
 
 | Name | Description | Usage |
@@ -38,10 +42,6 @@ Also see [Environment variables](cli-ref-environment-variables.md)
 > * _quiet_ - Package ID, Version
 > * _normal_ - Package ID, Version, Downloads, Preview of Description
 > * _detailed_ - Package ID, Version, Downloads, Full Description, Other information such as the query URL
-
-> [!NOTE]
-> API key is not used for authenticating with the private feed. Refer to [`nuget sources` command](../cli-reference/cli-ref-sources.md) to manage credentials for authenticating with the source.
-> API keys can be obtained from the individual NuGet servers. To create and manage APIKeys for nuget.org refer to.
 
 ## Examples
 

--- a/docs/reference/cli-reference/cli-ref-search.md
+++ b/docs/reference/cli-reference/cli-ref-search.md
@@ -28,18 +28,18 @@ where the search terms are applied to the names of packages, tags, and package d
 | PreRelease | Pre-release packages are not included by default, but can be included by using this argument | -PreRelease |
 | Source | Specific package source(s) to search instead of querying the default sources in __nuget.config__ | -Source `<Source URL>`|
 | Take | The number of results to return. The default value is 20. | -Take `<positive integer>` |
-| Verbosity | The level of detail to display in the output. The default is _normal_. (See the note below)  | -Verbosity `<quiet\|normal\|detailed>` |
+| Verbosity | The level of detail to display in the output. The default is _normal_. (See the note below)  | -Verbosity `<quiet|normal|detailed>` |
 | Help | Displays help information for the command | -Help |
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 
-__NOTE__
+> [!NOTE]
 
-Verbosity Levels:
+> Verbosity Levels:
 
-* _quiet_ - Package ID, Version
-* _normal_ - Package ID, Version, Downloads, Preview of Description
-* _detailed_ - Package ID, Version, Downloads, Full Description, Other information such as the query URL
+> * _quiet_ - Package ID, Version
+> * _normal_ - Package ID, Version, Downloads, Preview of Description
+> * _detailed_ - Package ID, Version, Downloads, Full Description, Other information such as the query URL
 
 ## Examples
 

--- a/docs/reference/cli-reference/cli-ref-search.md
+++ b/docs/reference/cli-reference/cli-ref-search.md
@@ -34,9 +34,7 @@ where the search terms are applied to the names of packages, tags, and package d
 Also see [Environment variables](cli-ref-environment-variables.md)
 
 > [!NOTE]
-
 > Verbosity Levels:
-
 > * _quiet_ - Package ID, Version
 > * _normal_ - Package ID, Version, Downloads, Preview of Description
 > * _detailed_ - Package ID, Version, Downloads, Full Description, Other information such as the query URL


### PR DESCRIPTION
1. The *Note* section (Verbosity Levels) should look more like the shaded *Note* in https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-setapikey

2. The Usage column for the `-Verbosity` option shows the backslashes in "`<quiet|normal|detailed>`", so that it looks like "`<quiet\|normal\|detailed>`". I think that the GitHub markdown preview differs from how the markdown renders on the Docs website, which is why this wasn't caught when the original PR for Search was being reviewed and merged.