### PR TITLE
Replace typo package.config with packages.config

### DIFF
--- a/docs/consume-packages/migrate-packages-config-to-package-reference.md
+++ b/docs/consume-packages/migrate-packages-config-to-package-reference.md
@@ -1,6 +1,6 @@
 ---
-title: Migrating from package.config to PackageReference formats
-description: Details on how to migrate a project from the package.config management format to PackageReference as supported by NuGet 4.0+ and VS2017 and .NET Core 2.0
+title: Migrating from packages.config to PackageReference formats
+description: Details on how to migrate a project from the packages.config management format to PackageReference as supported by NuGet 4.0+ and VS2017 and .NET Core 2.0
 author: karann-msft
 ms.author: karann
 ms.date: 05/24/2019


### PR DESCRIPTION
There doesn't appear to actually exsist a `package.config` however `packages.config` does exsist. It seems the only instances for `package.config` on the internet are typos with `packages.config` mentioned on the same page.

If you know otherwise let me know. 

Even the VS settings for default package management format is plural.