### PR TITLE
verify command is added to dotnet CLI

### DIFF
--- a/docs/reference/cli-reference/cli-ref-verify.md
+++ b/docs/reference/cli-reference/cli-ref-verify.md
@@ -14,7 +14,7 @@ ms.reviewer: rmpablos
 
 Verifies a package.
 
-Verification of signed packages is not yet supported in .NET Core, under Mono, or on non-Windows platforms.
+Verification of signed packages is not yet supported under Mono.
 
 ## Usage
 


### PR DESCRIPTION
Fixes: #2182

`dotnet nuget verify` command was added to the `dotnet CLI/SDK` in `.NET 5.0.100-rc.2.x version`. Changed the text to `Verification of signed packages is not yet supported under Mono. `