### PR TITLE
Add new author signing certificate fingerprint to documentation

### DIFF
--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -41,6 +41,7 @@ Registered trusted signers:
  2.   microsoft [author]
       Certificate fingerprint(s):
         SHA256 - 3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE
+        SHA256 - AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27
 
  3.   myUntrustedAuthorSignature [author]
       Certificate fingerprint(s):

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -277,13 +277,14 @@ If a `certificate` specifies `allowUntrustedRoot` as `true` the given certificat
 
 ```xml
 <trustedSigners>
-	<author name="microsoft">
-		<certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-	</author>
-	<repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
-		<certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-		<owners>microsoft;aspnet;nuget</owners>
-	</repository>
+    <author name="microsoft">
+        <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+        <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
+    <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+        <owners>microsoft;aspnet;nuget</owners>
+    </repository>
 </trustedSigners>
 ```
 
@@ -426,6 +427,7 @@ Below is an example `nuget.config` file that illustrates a number of settings in
     <trustedSigners>
         <author name="microsoft">
             <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+            <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
         </author>
         <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
             <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />


### PR DESCRIPTION
Update docs to include fingerprints for both the active and the new (inactive) Microsoft author signing certificate.

Will hold off merging until the time is right.

CC @chgill-MSFT, @heng-liu, @kartheekp-ms