### PR TITLE
Offline book fix

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -1,4 +1,3 @@
-# [Docs at a glance](index.yml)
 # [What is NuGet?](what-is-nuget.md)
 # Get started
 ## [Install NuGet client tools](install-nuget-client-tools.md)


### PR DESCRIPTION
To support offline books, we need to remove the top TOC node, which links to the landing page. The landing page is not generated for offline books, and it's inclusion in the TOC causes an error.