### PR TITLE
Document asset target fallback

### DIFF
--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -398,12 +398,12 @@ Refer to the table below for examples of how `AssetTargetFallback` affects compa
 
 | Project framework | AssetTargetFallback | Package frameworks | Result |
 |-------------------|---------------------|--------------------|--------|
-| .NET Framework 4.7.2 | | .NET Standard 2.0, .NET Standard 1.6 | .NET Standard 2.0 |
+| .NET Framework 4.7.2 | | .NET Standard 2.0 | .NET Standard 2.0 |
 | .NET Core App 3.1 | | .NET Standard 2.0, .NET Framework 4.7.2 | .NET Standard 2.0 |
-| .NET Core App 3.1 | | .NET Framework 4.7.2, .NET Framework 4.7.1 | Incompatible, fail with [`NU1202`](../reference/errors-and-warnings/NU1202.md) |
-| .NET Core App 3.1 | net472;net471;net462;net461 | .NET Framework 4.7.2, .NET Framework 4.7.1 | .NET Framework 4.7.2 with [`NU1701`](../reference/errors-and-warnings/NU1701.md) |
+| .NET Core App 3.1 | | .NET Framework 4.7.2 | Incompatible, fail with [`NU1202`](../reference/errors-and-warnings/NU1202.md) |
+| .NET Core App 3.1 | net472;net471 | .NET Framework 4.7.2 | .NET Framework 4.7.2 with [`NU1701`](../reference/errors-and-warnings/NU1701.md) |
 
-To add a fallback framework you can do the following:
+Multiple frameworks can be specified using `;` as a delimiter. To add a fallback framework you can do the following. 
 
 ```xml
 <AssetTargetFallback Condition=" '$(TargetFramework)'=='netcoreapp3.1' ">

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -1,8 +1,8 @@
 ---
 title: NuGet PackageReference format (package references in project files)
 description: Details on NuGet PackageReference in project files as supported by NuGet 4.0+ and VS2017 and .NET Core 2.0
-author: karann-msft
-ms.author: karann
+author: nkolev92
+ms.author: nikolev
 ms.date: 03/16/2018
 ms.topic: conceptual
 ---
@@ -392,15 +392,16 @@ You can control various behaviors of restore with lock file as described below:
 The `AssetTargetFallback` property lets you specify additional compatible framework versions for projects that your project references and NuGet packages that your project consumes.
 
 If you specify a package dependency using `PackageReference` but that package doesn't contain assets that are compatible with your projects's target framework, the `AssetTargetFallback` property comes into play. The compatibility of the referenced package is rechecked using each target framework that's specified in `AssetTargetFallback`.
-When a `project` or a `package` is referenced through `AssetTargetFallback`, the [NU1701](../reference/errors-and-warnings/nu1701) warning will be raised.
+When a `project` or a `package` is referenced through `AssetTargetFallback`, the [NU1701](../reference/errors-and-warnings/NU1701.md) warning will be raised.
 
 Refer to the below table for examples of how `AssetTargetFallback` affects compatibility.
 
 | Project framework | AssetTargetFallback | Package frameworks | Result |
+|-------------------|---------------------|--------------------|--------|
 | .NET Framework 4.7.2 | | .NET Standard 2.0, .NET Standard 1.6 | .NET Standard 2.0 |
 | .NET Core App 3.1 | | .NET Standard 2.0, .NET Framework 4.7.2 | .NET Standard 2.0 |
-| .NET Core App 3.1 | | .NET Framework 4.7.2, .NET Framework 4.7.1 | Incompatible, fail with [`NU1202`](../reference/errors-and-warnings/NU1202) |
-| .NET Core App 3.1 | net472;net471;net462;net461 | .NET Framework 4.7.2, .NET Framework 4.7.1 | .NET Framework 4.7.2 with [`NU1701`](../reference/errors-and-warnings/nu1701) |
+| .NET Core App 3.1 | | .NET Framework 4.7.2, .NET Framework 4.7.1 | Incompatible, fail with [`NU1202`](../reference/errors-and-warnings/NU1202.md) |
+| .NET Core App 3.1 | net472;net471;net462;net461 | .NET Framework 4.7.2, .NET Framework 4.7.1 | .NET Framework 4.7.2 with [`NU1701`](../reference/errors-and-warnings/NU1701.md) |
 
 To add a fallback framework you can do the following:
 

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -394,7 +394,7 @@ The `AssetTargetFallback` property lets you specify additional compatible framew
 If you specify a package dependency using `PackageReference` but that package doesn't contain assets that are compatible with your projects's target framework, the `AssetTargetFallback` property comes into play. The compatibility of the referenced package is rechecked using each target framework that's specified in `AssetTargetFallback`.
 When a `project` or a `package` is referenced through `AssetTargetFallback`, the [NU1701](../reference/errors-and-warnings/NU1701.md) warning will be raised.
 
-Refer to the below table for examples of how `AssetTargetFallback` affects compatibility.
+Refer to the table below for examples of how `AssetTargetFallback` affects compatibility.
 
 | Project framework | AssetTargetFallback | Package frameworks | Result |
 |-------------------|---------------------|--------------------|--------|

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -416,4 +416,4 @@ You can leave off `$(AssetTargetFallback)` if you wish to overwrite, instead of 
 > [!NOTE]
 > If you are using a [.NET SDK based project](/dotnet/core/sdk), appropriate `$(AssetTargetFallback)` values are configured and you do not need to set them manually.
 >
-> `$(PackageTargetFallback)` was an earlier feature that attempted to adress this challenge, but is fundamentally broken and as such *should* not  be used. To migrate from `$(PackageTargetFallback)` to `$(AssetTargetFallback)`, simply change the property name.
+> `$(PackageTargetFallback)` was an earlier feature that attempted to address this challenge, but it is fundamentally broken and *should* not be used. To migrate from `$(PackageTargetFallback)` to `$(AssetTargetFallback)`, simply change the property name.

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -411,7 +411,7 @@ To add a fallback framework you can do the following:
 </AssetTargetFallback>
 ```
 
-You can leave of `$(AssetTargetFallback)` if you wish to overwrite, instead of add to the existing `AssetTargetFallback` values.
+You can leave off `$(AssetTargetFallback)` if you wish to overwrite, instead of add to the existing `AssetTargetFallback` values.
 
 > [!NOTE]
 > If you are using a [.NET SDK based project](/dotnet/core/sdk), appropriate `$(AssetTargetFallback)` values are configured and you do not need to set them manually.

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -403,7 +403,7 @@ Refer to the table below for examples of how `AssetTargetFallback` affects compa
 | .NET Core App 3.1 | | .NET Framework 4.7.2 | Incompatible, fail with [`NU1202`](../reference/errors-and-warnings/NU1202.md) |
 | .NET Core App 3.1 | net472;net471 | .NET Framework 4.7.2 | .NET Framework 4.7.2 with [`NU1701`](../reference/errors-and-warnings/NU1701.md) |
 
-Multiple frameworks can be specified using `;` as a delimiter. To add a fallback framework you can do the following. 
+Multiple frameworks can be specified using `;` as a delimiter. To add a fallback framework you can do the following:
 
 ```xml
 <AssetTargetFallback Condition=" '$(TargetFramework)'=='netcoreapp3.1' ">

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -387,7 +387,7 @@ You can control various behaviors of restore with lock file as described below:
 | `-ForceEvaluate` | `--force-evaluate` | RestoreForceEvaluate | This option is useful with packages with floating version defined in the project. By default, NuGet restore will not update the package version automatically upon each restore unless you run restore with this option. |
 | `-LockFilePath` | `--lock-file-path` | NuGetLockFilePath | Defines a custom lock file location for a project. By default, NuGet supports `packages.lock.json` at the root directory. If you have multiple projects in the same directory, NuGet supports project specific lock file `packages.<project_name>.lock.json` |
 
-### AssetTargetFallback
+## AssetTargetFallback
 
 The `AssetTargetFallback` property lets you specify additional compatible framework versions for projects that your project references and NuGet packages that your project consumes.
 

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -464,26 +464,6 @@ msbuild -t:restore -p:RestorePackagesConfig=true
 > [!NOTE]
 > `packages.config` restore is only available with `MSBuild 16.5+`, and not with `dotnet.exe`
 
-### PackageTargetFallback
-
-The `PackageTargetFallback` element allows you to specify a set of compatible targets to be used when restoring packages. It's designed to allow packages that use a dotnet [TxM](../reference/target-frameworks.md) to work with compatible packages that don't declare a dotnet TxM. That is, if your project uses the dotnet TxM, then all the packages it depends on must also have a dotnet TxM, unless you add the `<PackageTargetFallback>` to your project in order to allow non-dotnet platforms to be compatible with dotnet.
-
-For example, if the project is using the `netstandard1.6` TxM, and a dependent package contains only `lib/net45/a.dll` and `lib/portable-net45+win81/a.dll`, then the project will fail to build. If what you want to bring in is the latter DLL, then you can add a `PackageTargetFallback` as follows to say that the `portable-net45+win81` DLL is compatible:
-
-```xml
-<PackageTargetFallback Condition="'$(TargetFramework)'=='netstandard1.6'">
-    portable-net45+win81
-</PackageTargetFallback>
-```
-
-To declare a fallback for all targets in your project, leave off the `Condition` attribute. You can also extend any existing `PackageTargetFallback` by including `$(PackageTargetFallback)` as shown here:
-
-```xml
-<PackageTargetFallback>
-    $(PackageTargetFallback);portable-net45+win81
-</PackageTargetFallback >
-```
-
 ### Replacing one library from a restore graph
 
 If a restore is bringing the wrong assembly, it's possible to exclude that packages default choice, and replace it with your own choice. First with a top level `PackageReference`, exclude all assets:


### PR DESCRIPTION
Fixes https://github.com/NuGet/docs.microsoft.com-nuget/issues/511

* Remove PackageTargetFallback documentation cause it's not relevant anymore. 
* Document AssetTargetFallback
* Move to the generic PackageReference page rather than `msbuild-targets` as it's a PackageReference feature, not one that needs to be hidden in the references.