### PR TITLE
Clarify .snupkg symbol packages do not support native projects

### DIFF
--- a/docs/create-packages/Symbol-Packages-snupkg.md
+++ b/docs/create-packages/Symbol-Packages-snupkg.md
@@ -58,7 +58,7 @@ nuget pack MyPackage.csproj -Symbols -SymbolPackageFormat snupkg
 The [`SymbolPackageFormat`](/dotnet/core/tools/csproj#symbolpackageformat) property can have one of two values: `symbols.nupkg` (the default) or `snupkg`. If this property is not specified, a legacy symbol package will be created.
 
 > [!Note]
-> The legacy format `.symbols.nupkg` is still supported but only for compatibility reasons (see [Legacy Symbol Packages](Symbol-Packages.md)). NuGet.org's symbol server only accepts the new symbol package format - `.snupkg`.
+> The legacy format `.symbols.nupkg` is still supported but only for compatibility reasons like native packages (see [Legacy Symbol Packages](Symbol-Packages.md)). NuGet.org's symbol server only accepts the new symbol package format - `.snupkg`.
 
 ## Publishing a symbol package
 
@@ -98,6 +98,9 @@ NuGet.org has the following constraints for symbol packages:
 - The PDBs and their associated .nupkg DLLs need to be built with the compiler in Visual Studio version 15.9 or above (see [PDB crypto hash](https://github.com/dotnet/roslyn/issues/24429))
 
 Symbol packages published to NuGet.org will fail validation if these constraints aren't met. 
+
+> [!NOTE]
+> Native projects, such as C++ projects, produce Windows PDBs instead of Portable PDBs. These are not supported by NuGet.org's symbol server. Please use [Legacy Symbol Packages](Symbol-Packages.md) instead.
 
 ### Symbol package validation and indexing
 


### PR DESCRIPTION
I received a support request that ran into this problem. 