### PR TITLE
Fixing 'code-block-indented' messages, in NuGet-Protocols.md

### DIFF
--- a/docs/api/NuGet-Protocols.md
+++ b/docs/api/NuGet-Protocols.md
@@ -3,7 +3,7 @@ title: nuget.org Protocols
 description: The evolving nuget.org protocols to interact with NuGet clients.
 author: anangaur
 ms.author: anangaur
-ms.date: 10/30/2017
+ms.date: 01/21/2021
 ms.topic: conceptual
 ms.reviewer: kraigb
 ---
@@ -37,7 +37,9 @@ be used to validate that the package belongs to a particular user (account) on n
 
 Clients are required to pass the following header when they make API calls to **push** packages to nuget.org:
 
-    X-NuGet-Protocol-Version: 4.1.0
+```
+X-NuGet-Protocol-Version: 4.1.0
+```
 
 Note that the `X-NuGet-Client-Version` header has similar semantics but is reserved to only be used by the official
 NuGet client. Third party clients should use the `X-NuGet-Protocol-Version` header and value.
@@ -52,7 +54,9 @@ If a client interacts with external services and needs to validate whether a pac
 
 This API is used to get a verify-scope key for a nuget.org author to validate a package owned by him/her.
 
-    POST api/v2/package/create-verification-key/{ID}/{VERSION}
+```
+POST api/v2/package/create-verification-key/{ID}/{VERSION}
+```
 
 #### Request parameters
 
@@ -75,7 +79,9 @@ X-NuGet-ApiKey | Header | string | yes      | For example, `X-NuGet-ApiKey: {USE
 
 This API is used to validate a verify-scope key for package owned by the nuget.org author.
 
-    GET api/v2/verifykey/{ID}/{VERSION}
+```
+GET api/v2/verifykey/{ID}/{VERSION}
+```
 
 #### Request parameters
 


### PR DESCRIPTION
Fixing 'code-block-indented' messages, in NuGet-Protocols.md.
Experiencing how little time it takes to fix messages of this type.

GeneMi (= MightyPen)