### PR TITLE
Fix typo

### DIFF
--- a/docs/reference/errors-and-warnings/NU3028.md
+++ b/docs/reference/errors-and-warnings/NU3028.md
@@ -20,7 +20,7 @@ f1_keywords:
 Certificate chain building failed for the timestamp signature. The timestamp signing certificate is untrusted, revoked, or revocation information for the certificate is unavailable.
 
 ### Solution
-Use a trusted and valid certificate. Check internet connectivity.gits
+Use a trusted and valid certificate. Check internet connectivity.
 
 ### Revocation check mode *(4.8.1+)*
 If the machine has restricted internet access (such as a build machine in a CI/CD scenario), installing/restoring a signed nuget package will result in this warning since the revocation servers are not reachable. This is expected.


### PR DESCRIPTION
This looks like the `gits` shouldn't be here