### PR TITLE
Fix last two examples by removing hypen

### DIFF
--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -170,7 +170,7 @@ nuget trusted-signers Add -Name author1 -CertificateFingerprint CE40881FF5F0AD3E
 
 nuget trusted-signers Add -Repository .\..\MyRepositorySignedPackage.nupkg -Name TrustedRepo
 
-nuget-trusted-signers Remove -Name TrustedRepo
+nuget trusted-signers Remove -Name TrustedRepo
 
-nuget-trusted-signers Sync -Name TrustedRepo
+nuget trusted-signers Sync -Name TrustedRepo
 ```


### PR DESCRIPTION
`nuget` is the command, not `nuget-trusted-signers`.