### PR TITLE
Avoid localizing nuspec and NuGet MSBuild properties 

### DIFF
--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -70,7 +70,7 @@ This is typically found in one of two places:
 -	[`packages.config`](../reference/packages-config.md) – Located in the project root.
 -	[`<PackageReference>`](../consume-packages/package-references-in-project-files.md) – Located in the project file. 
 
-Depending on what method you use to manage your NuGet dependencies, you can also use Visual Studio to view your dependencies directly in [Solution Explorer](/visualstudio/ide/solutions-and-projects-in-visual-studio?view=vs-2019#solution-explorer) or [NuGet Package Manager](../consume-packages/install-use-packages-visual-studio.md).
+Depending on what method you use to manage your NuGet dependencies, you can also use Visual Studio to view your dependencies directly in [Solution Explorer](/visualstudio/ide/solutions-and-projects-in-visual-studio#solution-explorer) or [NuGet Package Manager](../consume-packages/install-use-packages-visual-studio.md).
 
 For CLI environments, you can use the [`dotnet list package`](/dotnet/core/tools/dotnet-list-package) command to list out your project or solution’s dependencies. 
 
@@ -135,7 +135,7 @@ To configure client trust policies, [see the following documentation](../consume
 
 Lock files store the hash of your package’s content. If the content hash of a package you want to install matches with the lock file, it will ensure package repeatability.
 
-To enable lock files, [see the following documentation](../consume-packages/package-references-packagereference-in-project-files#locking-dependencies).
+To enable lock files, [see the following documentation](../consume-packages/package-references-in-project-files.md#locking-dependencies).
 
 ## Monitor your supply chain
 

--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -135,7 +135,7 @@ To configure client trust policies, [see the following documentation](../consume
 
 Lock files store the hash of your package’s content. If the content hash of a package you want to install matches with the lock file, it will ensure package repeatability.
 
-To enable lock files, [see the following documentation](../consume-packages/package-references-in-project-files#locking-dependencies).
+To enable lock files, [see the following documentation](../consume-packages/package-references-packagereference-in-project-files#locking-dependencies).
 
 ## Monitor your supply chain
 

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -7,7 +7,7 @@ ms.date: 03/16/2018
 ms.topic: conceptual
 ---
 
-# Package references (PackageReference) in project files
+# Package references (`PackageReference`) in project files
 
 Package references, using the `PackageReference` node, manage NuGet dependencies directly within project files (as opposed to a separate `packages.config` file). Using PackageReference, as it's called, doesn't affect other aspects of NuGet; for example, settings in `NuGet.config` files (including package sources) are still applied as explained in [Common NuGet configurations](configuring-nuget-behavior.md).
 

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -5,6 +5,7 @@ author: nkolev92
 ms.author: nikolev
 ms.date: 03/23/2018
 ms.topic: conceptual
+no-loc: [NuGet, MSBuild, .nuspec, nuspec]
 ---
 
 # NuGet pack and restore as MSBuild targets
@@ -273,11 +274,12 @@ For historical reasons, NuGet & MSBuild treat paths without an extension as dire
 ```
 
 [File without an extension sample](https://github.com/NuGet/Samples/blob/master/PackageLicenseFileExtensionlessExample/).
+
 ### IsTool
 
 When using `MSBuild -t:pack -p:IsTool=true`, all output files, as specified in the [Output Assemblies](#output-assemblies) scenario, are copied to the `tools` folder instead of the `lib` folder. Note that this is different from a `DotNetCliTool` which is specified by setting the `PackageType` in `.csproj` file.
 
-### Packing using a .nuspec file
+### Packing using a :::no-loc text=".nuspec"::: file
 
 Although it is recommended that you [include all the properties](../reference/msbuild-targets.md#pack-target) that are usually in the `.nuspec` file in the project file instead, you can choose to use a `.nuspec` file to pack your project. For a non-SDK-style project that uses `PackageReference`, you must import `NuGet.Build.Tasks.Pack.targets` so that the pack task can be executed. You still need to restore the project before you can pack a nuspec file. (An SDK-style project includes the pack targets by default.)
 
@@ -323,7 +325,7 @@ The `pack` target provides two extension points that run in the inner, target fr
 - `TargetsForTfmSpecificBuildOutput` target: Use for files inside the `lib` folder or a folder specified using `BuildOutputTargetFolder`.
 - `TargetsForTfmSpecificContentInPackage` target: Use for files outside the `BuildOutputTargetFolder`.
 
-#### TargetsForTfmSpecificBuildOutput
+#### `TargetsForTfmSpecificBuildOutput`
 
 Write a custom target and specify it as the value of the `$(TargetsForTfmSpecificBuildOutput)` property. For any files that need to go into the `BuildOutputTargetFolder` (lib by default), the target should write those files into the ItemGroup `BuildOutputInPackage` and set the following two metadata values:
 

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -17,7 +17,7 @@ With MSBuild 15.1+, NuGet is also a first-class MSBuild citizen with the `pack` 
 
 ## Target build order
 
-Because `pack` and `restore` are  MSBuild targets, you can access them to enhance your workflow. For example, let’s say you want to copy your package to a network share after packing it. You can do that by adding the following in your project file:
+Because `pack` and `restore` are  MSBuild targets, you can access them to enhance your workflow. For example, let's say you want to copy your package to a network share after packing it. You can do that by adding the following in your project file:
 
 ```xml
 <Target Name="CopyPackage" AfterTargets="Pack">
@@ -33,93 +33,94 @@ Similarly, you can write an MSBuild task, write your own target and consume NuGe
 > [!NOTE]
 > `$(OutputPath)` is relative and expects that you are running the command from the project root.
 
-## pack target
+## NuGet pack target
 
 For .NET projects that use the `PackageReference` format, using `msbuild -t:pack` draws inputs from the project file to use in creating a NuGet package.
 
 The following table describes the MSBuild properties that can be added to a project file within the first `<PropertyGroup>` node. You can make these edits easily in Visual Studio 2017 and later by right-clicking the project and selecting **Edit {project_name}** on the context menu. For convenience, the table is organized by the equivalent property in a [`.nuspec` file](../reference/nuspec.md).
 
-Note that the `Owners` and `Summary` properties from `.nuspec` are not supported with MSBuild.
+> [!NOTE]
+> `Owners` and `Summary` properties from `.nuspec` are not supported with MSBuild.
 
-| Attribute/NuSpec Value | MSBuild Property | Default | Notes |
+| Attribute/nuspec Value | MSBuild Property | Default | Notes |
 |--------|--------|--------|--------|
-| `Id` | `PackageId` | AssemblyName | $(AssemblyName) from MSBuild |
-| :::no-loc text="Version"::: | :::no-loc text="PackageVersion"::: | Version | This is semver compatible, for example “1.0.0”, “1.0.0-beta”, or “1.0.0-beta-00345” |
-| :::no-loc text="`VersionPrefix`"::: | :::no-loc text="`PackageVersionPrefix`"::: | empty | Setting PackageVersion overwrites PackageVersionPrefix |
-| VersionSuffix | PackageVersionSuffix | empty | $(VersionSuffix) from MSBuild. Setting PackageVersion overwrites PackageVersionSuffix |
-| Authors | Authors | Username of the current user | A semicolon-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors. |
-| Owners | N/A | Not present in NuSpec | |
-| Title | Title | The PackageId| A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio. |
-| Description | Description | "Package Description" | A long description for the assembly. If `PackageDescription` is not specified, then this property is also used as the description of the package. |
-| Copyright | Copyright | empty | Copyright details for the package. |
-| RequireLicenseAcceptance | PackageRequireLicenseAcceptance | false | A Boolean value that specifies whether the client must prompt the consumer to accept the package license before installing the package. |
-| license | PackageLicenseExpression | empty | Corresponds to `<license type="expression">`. See [Packing a license expression or a license file](#packing-a-license-expression-or-a-license-file). |
-| license | PackageLicenseFile | empty | Path to a license file within the package if you're using a custom license or a license that hasn't been assigned an SPDX identifier. You need to explicitly pack the referenced license file. Corresponds to `<license type="file">`. See [Packing a license expression or a license file](#packing-a-license-expression-or-a-license-file). |
-| LicenseUrl | PackageLicenseUrl | empty | `PackageLicenseUrl` is deprecated. Use `PackageLicenseExpression` or `PackageLicenseFile` instead. |
-| ProjectUrl | PackageProjectUrl | empty | |
-| Icon | PackageIcon | empty | A path to an image in the package to use as a package icon. You need to explicitly pack the referenced icon image file. For more information, see [Packing an icon image file](#packing-an-icon-image-file) and [`icon` metadata](/nuget/reference/nuspec#icon). |
-| IconUrl | PackageIconUrl | empty | `PackageIconUrl` is deprecated in favor of `PackageIcon`. However, for the best downlevel experience, you should specify `PackageIconUrl` in addition to `PackageIcon`. |
-| Tags | PackageTags | empty | A semicolon-delimited list of tags that designates the package. |
-| ReleaseNotes | PackageReleaseNotes | empty | Release notes for the package. |
-| Repository/Url | RepositoryUrl | empty | Repository URL used to clone or retrieve source code. Example: *https://github.com/NuGet/NuGet.Client.git*. |
-| Repository/Type | RepositoryType | empty | Repository type. Examples: `git` (default), `tfs`. |
-| Repository/Branch | RepositoryBranch | empty | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
-| Repository/Commit | RepositoryCommit | empty | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
-| PackageType | `<PackageType>DotNetCliTool, 1.0.0.0;Dependency, 2.0.0.0</PackageType>` | | |
-| Summary | Not supported | | |
+| `Id` | `PackageId` | `$(AssemblyName)` | `$(AssemblyName)` from MSBuild |
+| `Version` | `PackageVersion` | Version | This is semver compatible, for example `1.0.0`, `1.0.0-beta`, or `1.0.0-beta-00345` |
+| `VersionPrefix` | `PackageVersionPrefix` | empty | Setting `PackageVersion` overwrites `PackageVersionPrefix` |
+| `VersionSuffix` | `PackageVersionSuffix` | empty | `$(VersionSuffix)` from MSBuild. Setting `PackageVersion` overwrites `PackageVersionSuffix` |
+| `Authors` | `Authors` | Username of the current user | A semicolon-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors. |
+| `Owners` | N/A | Not present in nuspec | |
+| `Title` | `Title` | The `PackageId` | A human-friendly title of the package, typically used in UI displays as on nuget.org and the Package Manager in Visual Studio. |
+| `Description` | `Description` | "Package Description" | A long description for the assembly. If `PackageDescription` is not specified, then this property is also used as the description of the package. |
+| `Copyright` | `Copyright` | empty | Copyright details for the package. |
+| `RequireLicenseAcceptance` | `PackageRequireLicenseAcceptance` | `false` | A Boolean value that specifies whether the client must prompt the consumer to accept the package license before installing the package. |
+| `license` | `PackageLicenseExpression` | empty | Corresponds to `<license type="expression">`. See [Packing a license expression or a license file](#packing-a-license-expression-or-a-license-file). |
+| `license` | `PackageLicenseFile` | empty | Path to a license file within the package if you're using a custom license or a license that hasn't been assigned an SPDX identifier. You need to explicitly pack the referenced license file. Corresponds to `<license type="file">`. See [Packing a license expression or a license file](#packing-a-license-expression-or-a-license-file). |
+| `LicenseUrl` | `PackageLicenseUrl` | empty | `PackageLicenseUrl` is deprecated. Use `PackageLicenseExpression` or `PackageLicenseFile` instead. |
+| `ProjectUrl` | `PackageProjectUrl` | empty | |
+| `Icon` | `PackageIcon` | empty | A path to an image in the package to use as a package icon. You need to explicitly pack the referenced icon image file. For more information, see [Packing an icon image file](#packing-an-icon-image-file) and [`icon` metadata](/nuget/reference/nuspec#icon). |
+| `IconUrl` | `PackageIconUrl` | empty | `PackageIconUrl` is deprecated in favor of `PackageIcon`. However, for the best downlevel experience, you should specify `PackageIconUrl` in addition to `PackageIcon`. |
+| `Tags` | `PackageTags` | empty | A semicolon-delimited list of tags that designates the package. |
+| `ReleaseNotes` | `PackageReleaseNotes` | empty | Release notes for the package. |
+| `Repository/Url` | `RepositoryUrl` | empty | Repository URL used to clone or retrieve source code. Example: *https://github.com/NuGet/NuGet.Client.git*. |
+| `Repository/Type` | `RepositoryType` | empty | Repository type. Examples: `git` (default), `tfs`. |
+| `Repository/Branch` | `RepositoryBranch` | empty | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
+| `Repository/Commit` | `RepositoryCommit` | empty | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
+| `PackageType` | `<PackageType>DotNetCliTool, 1.0.0.0;Dependency, 2.0.0.0</PackageType>` | | |
+| `Summary` | Not supported | | |
 
-### pack target inputs
+### NuGet pack target inputs
 
 | Property | Description |
 | - | - |
-| IsPackable | A Boolean value that specifies whether the project can be packed. The default value is `true`. |
-| SuppressDependenciesWhenPacking | Set to `true` to suppress package dependencies from the generated NuGet package. |
-| PackageVersion | Specifies the version that the resulting package will have. Accepts all forms of NuGet version string. Default is the value of `$(Version)`, that is, of the property `Version` in the project. |
-| PackageId | Specifies the name for the resulting package. If not specified, the `pack` operation will default to using the `AssemblyName` or directory name as the name of the package. |
-| PackageDescription | A long description of the package for UI display. |
-| Authors | A semicolon-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors. |
-| Description | A long description for the assembly. If `PackageDescription` is not specified, then this property is also used as the description of the package. |
-| Copyright | Copyright details for the package. |
-| PackageRequireLicenseAcceptance | A Boolean value that specifies whether the client must prompt the consumer to accept the package license before installing the package. The default is `false`. |
-| DevelopmentDependency | A Boolean value that specifies whether the package is marked as a development-only dependency, which prevents the package from being included as a dependency in other packages. With `PackageReference` (NuGet 4.8+), this flag also means that compile-time assets are excluded from compilation. For more information, see [DevelopmentDependency support for PackageReference](https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference). |
-| PackageLicenseExpression | An [SPDX license identifier](https://spdx.org/licenses/) or expression, for example, `Apache-2.0`. For more information, see [Packing a license expression or a license file](#packing-a-license-expression-or-a-license-file). |
-| PackageLicenseFile | Path to a license file within the package if you're using a custom license or a license that hasn't been assigned an SPDX identifier. |
-| PackageLicenseUrl | `PackageLicenseUrl` is deprecated. Use `PackageLicenseExpression` or `PackageLicenseFile` instead. |
-| PackageProjectUrl | |
-| PackageIcon | Specifies the package icon path, relative to the root of the package. For more information, see [Packing an icon image file](#packing-an-icon-image-file). |
-| PackageReleaseNotes| Release notes for the package. |
-| PackageTags | A semicolon-delimited list of tags that designates the package. |
-| PackageOutputPath | Determines the output path in which the packed package will be dropped. Default is `$(OutputPath)`. |
-| IncludeSymbols | This Boolean value indicates whether the package should create an additional symbols package when the project is packed. The symbols package's format is controlled by the `SymbolPackageFormat` property. For more information, see [IncludeSymbols](#includesymbols). |
-| IncludeSource | This Boolean value indicates whether the pack process should create a source package. The source package contains the library's source code as well as PDB files. Source files are put under the `src/ProjectName` directory in the resulting package file. For more information, see [IncludeSource](#includesource). |
-| PackageTypes
-| IsTool | Specifies whether all output files are copied to the *tools* folder instead of the *lib* folder. For more information, see [IsTool](#istool). |
-| RepositoryUrl | Repository URL used to clone or retrieve source code. Example: *https://github.com/NuGet/NuGet.Client.git*. |
-| RepositoryType | Repository type. Examples: `git` (default), `tfs`. |
-| RepositoryBranch | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
-| RepositoryCommit | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
-| SymbolPackageFormat | Specifies the format of the symbols package. If "symbols.nupkg", a legacy symbols package is created with a *.symbols.nupkg* extension containing PDBs, DLLs, and other output files. If "snupkg", a snupkg symbol package is created containing the portable PDBs. The default is "symbols.nupkg". |
-| NoPackageAnalysis | Specifies that `pack` should not run package analysis after building the package. |
-| MinClientVersion | Specifies the minimum version of the NuGet client that can install this package, enforced by nuget.exe and the Visual Studio Package Manager. |
-| IncludeBuildOutput | This Boolean value specifies whether the build output assemblies should be packed into the *.nupkg* file or not. |
-| IncludeContentInPack | This Boolean value specifies whether any items that have a type of `Content` are included in the resulting package automatically. The default is `true`. |
-| BuildOutputTargetFolder | Specifies the folder where to place the output assemblies. The output assemblies (and other output files) are copied into their respective framework folders. For more information, see [Output assemblies](#output-assemblies). |
-| ContentTargetFolders | Specifies the default location of where all the content files should go if `PackagePath` is not specified for them. The default value is "content;contentFiles". For more information, see [Including content in a package](#including-content-in-a-package). |
-| NuspecFile | Relative or absolute path to the *.nuspec* file being used for packing. If specified, it's used **exclusively** for packaging information, and any information in the projects is not used. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
-| NuspecBasePath | Base path for the *.nuspec* file. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
-| NuspecProperties | Semicolon separated list of key=value pairs. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
+| `IsPackable` | A Boolean value that specifies whether the project can be packed. The default value is `true`. |
+| `SuppressDependenciesWhenPacking` | Set to `true` to suppress package dependencies from the generated NuGet package. |
+| `PackageVersion` | Specifies the version that the resulting package will have. Accepts all forms of NuGet version string. Default is the value of `$(Version)`, that is, of the property `Version` in the project. |
+| `PackageId` | Specifies the name for the resulting package. If not specified, the `pack` operation will default to using the `AssemblyName` or directory name as the name of the package. |
+| `PackageDescription` | A long description of the package for UI display. |
+| `Authors` | A semicolon-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors. |
+| `Description` | A long description for the assembly. If `PackageDescription` is not specified, then this property is also used as the description of the package. |
+| `Copyright` | Copyright details for the package. |
+| `PackageRequireLicenseAcceptance` | A Boolean value that specifies whether the client must prompt the consumer to accept the package license before installing the package. The default is `false`. |
+| `DevelopmentDependency` | A Boolean value that specifies whether the package is marked as a development-only dependency, which prevents the package from being included as a dependency in other packages. With `PackageReference` (NuGet 4.8+), this flag also means that compile-time assets are excluded from compilation. For more information, see [DevelopmentDependency support for PackageReference](https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference). |
+| `PackageLicenseExpression` | An [SPDX license identifier](https://spdx.org/licenses/) or expression, for example, `Apache-2.0`. For more information, see [Packing a license expression or a license file](#packing-a-license-expression-or-a-license-file). |
+| `PackageLicenseFile` | Path to a license file within the package if you're using a custom license or a license that hasn't been assigned an SPDX identifier. |
+| `PackageLicenseUrl` | `PackageLicenseUrl` is deprecated. Use `PackageLicenseExpression` or `PackageLicenseFile` instead. |
+| `PackageProjectUrl` | |
+| `PackageIcon` | Specifies the package icon path, relative to the root of the package. For more information, see [Packing an icon image file](#packing-an-icon-image-file). |
+| `PackageReleaseNotes` | Release notes for the package. |
+| `PackageTags` | A semicolon-delimited list of tags that designates the package. |
+| `PackageOutputPath` | Determines the output path in which the packed package will be dropped. Default is `$(OutputPath)`. |
+| `IncludeSymbols` | This Boolean value indicates whether the package should create an additional symbols package when the project is packed. The symbols package's format is controlled by the `SymbolPackageFormat` property. For more information, see [IncludeSymbols](#includesymbols). |
+| `IncludeSource` | This Boolean value indicates whether the pack process should create a source package. The source package contains the library's source code as well as PDB files. Source files are put under the `src/ProjectName` directory in the resulting package file. For more information, see [IncludeSource](#includesource). |
+| `PackageType` | |
+| `IsTool` | Specifies whether all output files are copied to the *tools* folder instead of the *lib* folder. For more information, see [IsTool](#istool). |
+| `RepositoryUrl` | Repository URL used to clone or retrieve source code. Example: *https://github.com/NuGet/NuGet.Client.git*. |
+| `RepositoryType` | Repository type. Examples: `git` (default), `tfs`. |
+| `RepositoryBranch` | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
+| `RepositoryCommit` | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
+| `SymbolPackageFormat` | Specifies the format of the symbols package. If "symbols.nupkg", a legacy symbols package is created with a *.symbols.nupkg* extension containing PDBs, DLLs, and other output files. If "snupkg", a snupkg symbol package is created containing the portable PDBs. The default is "symbols.nupkg". |
+| `NoPackageAnalysis` | Specifies that `pack` should not run package analysis after building the package. |
+| `MinClientVersion` | Specifies the minimum version of the NuGet client that can install this package, enforced by nuget.exe and the Visual Studio Package Manager. |
+| `IncludeBuildOutput` | This Boolean value specifies whether the build output assemblies should be packed into the *.nupkg* file or not. |
+| `IncludeContentInPack` | This Boolean value specifies whether any items that have a type of `Content` are included in the resulting package automatically. The default is `true`. |
+| `BuildOutputTargetFolder` | Specifies the folder where to place the output assemblies. The output assemblies (and other output files) are copied into their respective framework folders. For more information, see [Output assemblies](#output-assemblies). |
+| `ContentTargetFolders` | Specifies the default location of where all the content files should go if `PackagePath` is not specified for them. The default value is "content;contentFiles". For more information, see [Including content in a package](#including-content-in-a-package). |
+| `NuspecFile` | Relative or absolute path to the *.nuspec* file being used for packing. If specified, it's used **exclusively** for packaging information, and any information in the projects is not used. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
+| `NuspecBasePath` | Base path for the *.nuspec* file. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
+| `NuspecProperties` | Semicolon separated list of key=value pairs. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
 
-## pack scenarios
+## NuGet pack scenarios
 
-### Suppress dependencies
+### Suppressing dependencies
 
 To suppress package dependencies from generated NuGet package, set `SuppressDependenciesWhenPacking` to `true` which will allow skipping all the dependencies from generated nupkg file.
 
-### PackageIconUrl
+### `PackageIconUrl`
 
 `PackageIconUrl` is deprecated in favor of the [`PackageIcon`](#packageicon) property. Starting with NuGet 5.3 and Visual Studio 2019 version 16.3, `pack` raises the [NU5048](./errors-and-warnings/nu5048.md) warning if the package metadata only specifies `PackageIconUrl`.
 
-### PackageIcon
+### `PackageIcon`
 
 > [!Tip]
 > To maintain backward compatibility with clients and sources that don't yet support `PackageIcon`, specify both `PackageIcon` and `PackageIconUrl`. Visual Studio supports `PackageIcon` for packages coming from a folder-based source.
@@ -163,7 +164,7 @@ See [Package References in Project Files](../consume-packages/package-references
 
 ### Project to project references
 
-Project to project references are considered by default as nuget package references, for example:
+Project to project references are considered by default as NuGet package references. For example:
 
 ```xml
 <ProjectReference Include="..\UwpLibrary2\UwpLibrary2.csproj"/>
@@ -276,7 +277,7 @@ For historical reasons, NuGet & MSBuild treat paths without an extension as dire
 
 When using `MSBuild -t:pack -p:IsTool=true`, all output files, as specified in the [Output Assemblies](#output-assemblies) scenario, are copied to the `tools` folder instead of the `lib` folder. Note that this is different from a `DotNetCliTool` which is specified by setting the `PackageType` in `.csproj` file.
 
-### Packing using a .nuspec
+### Packing using a .nuspec file
 
 Although it is recommended that you [include all the properties](../reference/msbuild-targets.md#pack-target) that are usually in the `.nuspec` file in the project file instead, you can choose to use a `.nuspec` file to pack your project. For a non-SDK-style project that uses `PackageReference`, you must import `NuGet.Build.Tasks.Pack.targets` so that the pack task can be executed. You still need to restore the project before you can pack a nuspec file. (An SDK-style project includes the pack targets by default.)
 
@@ -345,7 +346,7 @@ Example:
 </Target>
 ```
 
-#### TargetsForTfmSpecificContentInPackage
+#### `TargetsForTfmSpecificContentInPackage`
 
 Write a custom target and specify it as the value of the `$(TargetsForTfmSpecificContentInPackage)` property. For any files to include in the package, the target should write those files into the ItemGroup `TfmSpecificPackageFile` and set the following optional metadata:
 
@@ -370,7 +371,7 @@ An example:
 </Target>  
 ```
 
-## restore target
+## NuGet restore target
 
 `MSBuild -t:restore` (which `nuget restore` and `dotnet restore` use with .NET Core projects), restores packages referenced in the project file as follows:
 
@@ -393,27 +394,27 @@ Additional restore settings may come from MSBuild properties in the project file
 
 | Property | Description |
 |--------|--------|
-| RestoreSources | Semicolon-delimited list of package sources. |
-| RestorePackagesPath | User packages folder path. |
-| RestoreDisableParallel | Limit downloads to one at a time. |
-| RestoreConfigFile | Path to a `Nuget.Config` file to apply. |
-| RestoreNoCache | If true, avoids using cached packages. See [Managing the global packages and cache folders](../consume-packages/managing-the-global-packages-and-cache-folders.md). |
-| RestoreIgnoreFailedSources | If true, ignores failing or missing package sources. |
-| RestoreFallbackFolders | Fallback folders, used in the same way the user packages folder is used. |
-| RestoreAdditionalProjectSources | Additional sources to use during restore. |
-| RestoreAdditionalProjectFallbackFolders | Additional fallback folders to use during restore. |
-| RestoreAdditionalProjectFallbackFoldersExcludes | Excludes fallback folders specified in `RestoreAdditionalProjectFallbackFolders` |
-| RestoreTaskAssemblyFile | Path to `NuGet.Build.Tasks.dll`. |
-| RestoreGraphProjectInput | Semicolon-delimited list of projects to restore, which should contain absolute paths. |
-| RestoreUseSkipNonexistentTargets  | When the projects are collected via MSBuild it determines whether they are collected using the `SkipNonexistentTargets` optimization. When not set, defaults to `true`. The consequence is a fail-fast behavior when a project's targets cannot be imported. |
-| MSBuildProjectExtensionsPath | Output folder, defaulting to `BaseIntermediateOutputPath` and the `obj` folder. |
-| RestoreForce | In PackageReference based projects, forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is similar to deleting the `project.assets.json` file. This does not bypass the http-cache. |
-| RestorePackagesWithLockFile | Opts into the usage of a lock file. |
-| RestoreLockedMode | Run restore in locked mode. This means that restore will not reevaluate the dependencies. |
-| NuGetLockFilePath | A custom location for the lock file. The default location is next to the project and is named `packages.lock.json`. |
-| RestoreForceEvaluate | Forces restore to recompute the dependencies and update the lock file without any warning. |
-| RestorePackagesConfig | An opt-in switch, that restores projects with packages.config. Support with `MSBuild -t:restore` only. |
-| RestoreUseStaticGraphEvaluation | An opt-in switch to use static graph MSBuild evaluation instead of the standard evaluation. Static graph evaluation is an experimental feature that's significantly faster for large repos and solutions. |
+| `RestoreSources` | Semicolon-delimited list of package sources. |
+| `RestorePackagesPath` | User packages folder path. |
+| `RestoreDisableParallel` | Limit downloads to one at a time. |
+| `RestoreConfigFile` | Path to a `Nuget.Config` file to apply. |
+| `RestoreNoCache` | If true, avoids using cached packages. See [Managing the global packages and cache folders](../consume-packages/managing-the-global-packages-and-cache-folders.md). |
+| `RestoreIgnoreFailedSources` | If true, ignores failing or missing package sources. |
+| `RestoreFallbackFolders` | Fallback folders, used in the same way the user packages folder is used. |
+| `RestoreAdditionalProjectSources` | Additional sources to use during restore. |
+| `RestoreAdditionalProjectFallbackFolders` | Additional fallback folders to use during restore. |
+| `RestoreAdditionalProjectFallbackFoldersExcludes` | Excludes fallback folders specified in `RestoreAdditionalProjectFallbackFolders` |
+| `RestoreTaskAssemblyFile` | Path to `NuGet.Build.Tasks.dll`. |
+| `RestoreGraphProjectInput` | Semicolon-delimited list of projects to restore, which should contain absolute paths. |
+| `RestoreUseSkipNonexistentTargets`  | When the projects are collected via MSBuild it determines whether they are collected using the `SkipNonexistentTargets` optimization. When not set, defaults to `true`. The consequence is a fail-fast behavior when a project's targets cannot be imported. |
+| `MSBuildProjectExtensionsPath` | Output folder, defaulting to `BaseIntermediateOutputPath` and the `obj` folder. |
+| `RestoreForce` | In PackageReference based projects, forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is similar to deleting the `project.assets.json` file. This does not bypass the http-cache. |
+| `RestorePackagesWithLockFile` | Opts into the usage of a lock file. |
+| `RestoreLockedMode` | Run restore in locked mode. This means that restore will not reevaluate the dependencies. |
+| `NuGetLockFilePath` | A custom location for the lock file. The default location is next to the project and is named `packages.lock.json`. |
+| `RestoreForceEvaluate` | Forces restore to recompute the dependencies and update the lock file without any warning. |
+| `RestorePackagesConfig` | An opt-in switch, that restores projects with packages.config. Support with `MSBuild -t:restore` only. |
+| `RestoreUseStaticGraphEvaluation` | An opt-in switch to use static graph MSBuild evaluation instead of the standard evaluation. Static graph evaluation is an experimental feature that's significantly faster for large repos and solutions. |
 
 #### Examples
 
@@ -458,7 +459,7 @@ msbuild -t:build -restore
 
 The same logic applies to other targets similar to `build`.
 
-### Restoring PackageReference and packages.config with MSBuild
+### Restoring PackageReference and packages.config projects with MSBuild
 
 With MSBuild 16.5+, packages.config are also supported for `msbuild -t:restore`.
 

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -43,9 +43,9 @@ Note that the `Owners` and `Summary` properties from `.nuspec` are not supported
 
 | Attribute/NuSpec Value | MSBuild Property | Default | Notes |
 |--------|--------|--------|--------|
-| Id | PackageId | AssemblyName | $(AssemblyName) from MSBuild |
-| Version | PackageVersion | Version | This is semver compatible, for example “1.0.0”, “1.0.0-beta”, or “1.0.0-beta-00345” |
-| VersionPrefix | PackageVersionPrefix | empty | Setting PackageVersion overwrites PackageVersionPrefix |
+| `Id` | `PackageId` | AssemblyName | $(AssemblyName) from MSBuild |
+| :::no-loc text="Version"::: | :::no-loc text="PackageVersion"::: | Version | This is semver compatible, for example “1.0.0”, “1.0.0-beta”, or “1.0.0-beta-00345” |
+| :::no-loc text="`VersionPrefix`"::: | :::no-loc text="`PackageVersionPrefix`"::: | empty | Setting PackageVersion overwrites PackageVersionPrefix |
 | VersionSuffix | PackageVersionSuffix | empty | $(VersionSuffix) from MSBuild. Setting PackageVersion overwrites PackageVersionSuffix |
 | Authors | Authors | Username of the current user | A semicolon-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors. |
 | Owners | N/A | Not present in NuSpec | |

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -107,9 +107,9 @@ The following table describes the MSBuild properties that can be added to a proj
 | `IncludeContentInPack` | This Boolean value specifies whether any items that have a type of `Content` are included in the resulting package automatically. The default is `true`. |
 | `BuildOutputTargetFolder` | Specifies the folder where to place the output assemblies. The output assemblies (and other output files) are copied into their respective framework folders. For more information, see [Output assemblies](#output-assemblies). |
 | `ContentTargetFolders` | Specifies the default location of where all the content files should go if `PackagePath` is not specified for them. The default value is "content;contentFiles". For more information, see [Including content in a package](#including-content-in-a-package). |
-| `NuspecFile` | Relative or absolute path to the *.nuspec* file being used for packing. If specified, it's used **exclusively** for packaging information, and any information in the projects is not used. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
-| `NuspecBasePath` | Base path for the *.nuspec* file. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
-| `NuspecProperties` | Semicolon separated list of key=value pairs. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
+| `NuspecFile` | Relative or absolute path to the *.nuspec* file being used for packing. If specified, it's used **exclusively** for packaging information, and any information in the projects is not used. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec-file). |
+| `NuspecBasePath` | Base path for the *.nuspec* file. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec-file). |
+| `NuspecProperties` | Semicolon separated list of key=value pairs. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec-file). |
 
 ## pack scenarios
 
@@ -279,7 +279,7 @@ For historical reasons, NuGet & MSBuild treat paths without an extension as dire
 
 When using `MSBuild -t:pack -p:IsTool=true`, all output files, as specified in the [Output Assemblies](#output-assemblies) scenario, are copied to the `tools` folder instead of the `lib` folder. Note that this is different from a `DotNetCliTool` which is specified by setting the `PackageType` in `.csproj` file.
 
-### Packing using a :::no-loc text=".nuspec"::: file
+### Packing using a `.nuspec` file
 
 Although it is recommended that you [include all the properties](../reference/msbuild-targets.md#pack-target) that are usually in the `.nuspec` file in the project file instead, you can choose to use a `.nuspec` file to pack your project. For a non-SDK-style project that uses `PackageReference`, you must import `NuGet.Build.Tasks.Pack.targets` so that the pack task can be executed. You still need to restore the project before you can pack a nuspec file. (An SDK-style project includes the pack targets by default.)
 
@@ -385,7 +385,7 @@ An example:
 1. Write assets file, targets, and props
 
 The `restore` target works for projects using the PackageReference format.
-`MSBuild 16.5+` also has [opt-in support](#restoring-packagereference-and-packagesconfig-with-msbuild) for the `packages.config` format.
+`MSBuild 16.5+` also has [opt-in support](#restoring-packagereference-and-packagesconfig-projects-with-msbuild) for the `packages.config` format.
 
 > [!NOTE]
 > The `restore` target [should not be run](#restoring-and-building-with-one-msbuild-command) in combination with the `build` target.

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -34,7 +34,7 @@ Similarly, you can write an MSBuild task, write your own target and consume NuGe
 > [!NOTE]
 > `$(OutputPath)` is relative and expects that you are running the command from the project root.
 
-## NuGet pack target
+## pack target
 
 For .NET projects that use the `PackageReference` format, using `msbuild -t:pack` draws inputs from the project file to use in creating a NuGet package.
 
@@ -70,7 +70,7 @@ The following table describes the MSBuild properties that can be added to a proj
 | `PackageType` | `<PackageType>DotNetCliTool, 1.0.0.0;Dependency, 2.0.0.0</PackageType>` | | |
 | `Summary` | Not supported | | |
 
-### NuGet pack target inputs
+### pack target inputs
 
 | Property | Description |
 | - | - |
@@ -111,7 +111,7 @@ The following table describes the MSBuild properties that can be added to a proj
 | `NuspecBasePath` | Base path for the *.nuspec* file. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
 | `NuspecProperties` | Semicolon separated list of key=value pairs. For more information, see [Packing using a .nuspec](#packing-using-a-nuspec). |
 
-## NuGet pack scenarios
+## pack scenarios
 
 ### Suppressing dependencies
 
@@ -373,7 +373,7 @@ An example:
 </Target>  
 ```
 
-## NuGet restore target
+## restore target
 
 `MSBuild -t:restore` (which `nuget restore` and `dotnet restore` use with .NET Core projects), restores packages referenced in the project file as follows:
 

--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -29,7 +29,7 @@ In this topic:
 
 - A `.nuspec` file is not required to create packages for [SDK-style projects](../resources/check-project-format.md) (typically .NET Core and .NET Standard projects that use the [SDK attribute](/dotnet/core/tools/csproj#additions)). (Note that a `.nuspec` is generated when you create the package.)
 
-   If you are creating a package using `dotnet.exe pack` or `msbuild pack target`, we recommend that you [include all the properties](../reference/msbuild-targets.md#pack-target) that are usually in the `.nuspec` file in the project file instead. However, you can instead choose to [use a `.nuspec` file to pack using `dotnet.exe` or `msbuild pack target`](../reference/msbuild-targets.md#packing-using-a-nuspec).
+   If you are creating a package using `dotnet.exe pack` or `msbuild pack target`, we recommend that you [include all the properties](../reference/msbuild-targets.md#pack-target) that are usually in the `.nuspec` file in the project file instead. However, you can instead choose to [use a `.nuspec` file to pack using `dotnet.exe` or `msbuild pack target`](../reference/msbuild-targets.md#packing-using-a-nuspec-file).
 
 - For projects migrated from `packages.config` to [PackageReference](../consume-packages/package-references-in-project-files.md), a `.nuspec` file is not required to create the package. Instead, use [msbuild -t:pack](../consume-packages/migrate-packages-config-to-package-reference.md#create-a-package-after-migration).
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/docs.microsoft.com-nuget/issues/2006

- Adds some global `no-loc` terms
- Uses inline code blocks in .nuspec properties and in MSBuild properties for NuGet pack and restore targets.
- Minor proofreading