### PR TITLE
Fix code snippet indent

### DIFF
--- a/docs/consume-packages/install-use-packages-dotnet-cli.md
+++ b/docs/consume-packages/install-use-packages-dotnet-cli.md
@@ -42,9 +42,9 @@ This article shows you basic usage for a few of the most common dotnet CLI comma
    You can open the `.csproj` file to see the added reference:
 
     ```xml
-   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-   </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    </ItemGroup>
     ```
 
 ## Install a specific version of a package

--- a/docs/quickstart/install-and-use-a-package-using-the-dotnet-cli.md
+++ b/docs/quickstart/install-and-use-a-package-using-the-dotnet-cli.md
@@ -47,9 +47,9 @@ NuGet packages can be installed into a .NET project of some kind. For this walkt
 2. After the command completes, open the `.csproj` file to see the added reference:
 
     ```xml
-   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-   </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    </ItemGroup>
     ```
 
 ## Use the Newtonsoft.Json API in the app


### PR DESCRIPTION
Silly little patch, but noticed live docs site is collapsing the markdown indent and code snippet indent for these two snippets, such that the rendered snippets are not indented.

Not entirely sure this will fix it on the live site, but it's reproducible/fixable in GFM:

- Before:
    ```xml
   <ItemGroup>
    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
    ```
- After:
    ```xml
    <ItemGroup>
      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
    </ItemGroup>
    ```

Pages:
- https://docs.microsoft.com/nuget/consume-packages/install-use-packages-dotnet-cli
- https://docs.microsoft.com/nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli

![image](https://user-images.githubusercontent.com/21338699/110855834-e4273200-8284-11eb-9f36-13fd75afac7a.png)
