### PR TITLE
Update docs with new https://nuget.org repository certificate

### DIFF
--- a/docs/api/_data/repository-signatures-index.json
+++ b/docs/api/_data/repository-signatures-index.json
@@ -1,5 +1,5 @@
 {
-  "allRepositorySigned": false,
+  "allRepositorySigned": true,
   "signingCertificates": [
     {
       "fingerprints": {
@@ -10,6 +10,16 @@
       "notBefore": "2018-04-10T00:00:00.0000000Z",
       "notAfter": "2021-04-14T12:00:00.0000000Z",
       "contentUrl": "https://api.nuget.org/v3-index/repository-signatures/certificates/0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d.crt"
+    },
+    {
+      "fingerprints": {
+        "2.16.840.1.101.3.4.2.1": "5a2901d6ada3d18260b9c6dfe2133c95d74b9eef6ae0e5dc334c8454d1477df4"
+      },
+      "subject": "CN=NuGet.org Repository by Microsoft, O=NuGet.org Repository by Microsoft, L=Redmond, S=Washington, C=US",
+      "issuer": "CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US",
+      "notBefore": "2021-02-16T00:00:00.0000000Z",
+      "notAfter": "2024-05-15T23:59:59.0000000Z",
+      "contentUrl": "https://api.nuget.org/v3-index/repository-signatures/certificates/5a2901d6ada3d18260b9c6dfe2133c95d74b9eef6ae0e5dc334c8454d1477df4.crt"
     }
   ]
 }

--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -37,6 +37,7 @@ Registered trusted signers:
       Service Index: https://api.nuget.org/v3/index.json
       Certificate fingerprint(s):
         SHA256 - 0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D
+        SHA256 - 5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4
 
  2.   microsoft [author]
       Certificate fingerprint(s):

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -283,6 +283,7 @@ If a `certificate` specifies `allowUntrustedRoot` as `true` the given certificat
     </author>
     <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
         <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
         <owners>microsoft;aspnet;nuget</owners>
     </repository>
 </trustedSigners>
@@ -431,6 +432,7 @@ Below is an example `nuget.config` file that illustrates a number of settings in
         </author>
         <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
             <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+            <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
             <owners>microsoft;aspnet;nuget</owners>
         </repository>
     </trustedSigners>


### PR DESCRIPTION
Update docs to include fingerprints for both the active and the new (inactive) https://nuget.org repository signing certificate.

CC @chgill-MSFT, @loic-sharma, @heng-liu, @kartheekp-ms