### PR TITLE
Add .csproj instructions for package types

### DIFF
--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -28,7 +28,7 @@ Packages not marked with a type, including all packages created with earlier ver
 
 ## Custom package types
 
-You can mark your package with one or more custom package types if its use does not fit the known package types. For example, imagine if customers of the `Contoso` app can install extensions. Extension authors could use the custom package type `ContosoExtension` to identify these packages as `Contoso` app extensions.
+You can mark your package with one or more custom package types if its use does not fit the [known package types](#known-package-types). For example, imagine if customers of the `Contoso` app can install extensions. Extension authors could use the custom package type `ContosoExtension` to identify these packages as `Contoso` app extensions.
 
 > [!WARNING]
 > A package with a custom package type cannot be installed by Visual Studio or nuget.exe. See [NuGet/Home#10468](https://github.com/NuGet/Home/issues/10468) for more information.
@@ -63,7 +63,7 @@ Packages with multiple intended uses can be marked with multiple package types u
 </Project>
 ```
 
-Package types can be versioned using a `,` delimiter between the package type and its version:
+Package types can be versioned using a `,` delimiter between the package type and its [`Version`](/dotnet/api/system.version) string:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -108,7 +108,7 @@ Packages with multiple intended uses may be marked with multiple package types:
 </package>
 ```
 
-Package types can be versioned:
+Package types can be versioned using a [`Version`](/dotnet/api/system.version) string:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -124,7 +124,6 @@ Package types can be versioned:
 ```
 
 ---
-
 
 The format of a package type string is exactly like a package ID. That is, a package type is a case-insensitive string matching the regular expression `^\w+([_.-]\w+)*$` having at least one character and at most 100 characters.
 

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -128,4 +128,4 @@ Package types can be versioned:
 
 The format of a package type string is exactly like a package ID. That is, a package type is a case-insensitive string matching the regular expression `^\w+([_.-]\w+)*$` having at least one character and at most 100 characters.
 
-The format of a package type version is exactly like a [`Version`](/dotnet/api/system.version).
+The format of a package type version is exactly like a [`Version`](/dotnet/api/system.version) string. The package type version is optional and defaults to `0.0`.

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -21,7 +21,8 @@ Packages can be marked with one more more *package types* to indicate its intend
 
 > [!NOTE]
 > Support for package types was added in NuGet 3.5.
-> If you don't need a custom package type, it's best to *not* explicitly set the package type. NuGet defaults to `Dependency` this type when no type is specified.
+> If you don't need a custom package type, it's best to *not* explicitly set the package type.
+> NuGet defaults to the `Dependency` type when no type is specified.
 
 # [Using dotnet CLI](#tab/dotnet)
 

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -9,28 +9,58 @@ ms.topic: conceptual
 
 # Set a NuGet package type
 
-With NuGet 3.5+, packages can be marked with a specific *package type* to indicate its intended use. Packages not marked with a type, including all packages created with earlier versions of NuGet, default to the `Dependency` type.
+Packages can be marked with one more more *package types* to indicate its intended use. Packages not marked with a type, including all packages created with earlier versions of NuGet, default to the `Dependency` type.
 
 - `Dependency` type packages add build- or run-time assets to libraries and applications, and can be installed in any project type (assuming they are compatible).
 
-- `DotnetTool` type packages are extensions to the [dotnet CLI](/dotnet/articles/core/tools/index) and are invoked from the command line. Such packages can be installed only in .NET Core projects and have no effect on restore operations. More details about these per-project extensions are available in the  [.NET Core extensibility](/dotnet/articles/core/tools/extensibility#per-project-based-extensibility) documentation.
+- `DotnetTool` type packages are .NET tools that can be installed by the [dotnet CLI](/dotnet/articles/core/tools/index).
 
 - `Template` type packages provide [custom templates](/dotnet/core/tools/custom-templates) that can be used to create files or projects like an app, service, tool, or class library.
 
 - Custom type packages use an arbitrary type identifier that conforms to the same format rules as package IDs. Any type other than `Dependency` and `DotnetTool`, however, are not recognized by the NuGet Package Manager in Visual Studio.
 
+> [!NOTE]
+> Support for package types was added in NuGet 3.5.
+> If you don't need a custom package type, it's best to *not* explicitly set the `Dependency` type. NuGet defaults to `Dependency` this type when no type is specified.
+
+# [Using dotnet CLI](#tab/dotnet)
+
+Package types can be set in the project file (`.csproj`):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    
+    <PackageType>MyCustomType, 1.0.0.0;Dependency, 1.0.0.0</PackageType>
+  </PropertyGroup>
+
+</Project>
+```
+
+# [Using nuget.exe](#tab/nugetexe)
+
 Package types are set in the `.nuspec` file. It's best for backwards compatibility to *not* explicitly set the `Dependency` type and to instead rely on NuGet assuming this type when no type is specified.
 
-- `.nuspec`: Indicate the package type within a `packageTypes\packageType` node under the `<metadata>` element:
+With NuGet 3.5+
 
-    ```xml
-    <?xml version="1.0" encoding="utf-8"?>
-    <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-        <metadata>
-        <!-- ... -->
-        <packageTypes>
-            <packageType name="DotnetTool" />
-        </packageTypes>
-        </metadata>
-    </package>
-    ```
+Indicate the package type within a `packageTypes\packageType` node under the `<metadata>` element:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+    <!-- ... -->
+    <packageTypes>
+        <packageType name="DotnetTool" />
+    </packageTypes>
+    </metadata>
+</package>
+```
+
+---
+
+> [!NOTE]
+> Support for package types was added in NuGet 3.5.
+> If you don't need a custom package type, it's best to *not* explicitly set the `Dependency` type. NuGet defaults to `Dependency` this type when no type is specified.

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -75,7 +75,6 @@ Package types can be versioned using a `,` delimiter between the package type an
   </PropertyGroup>
 
 </Project>
-
 ```
 
 # [Using nuget.exe](#tab/nugetexe)

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -87,10 +87,10 @@ Package types are set in the `.nuspec` file within a `packageTypes\packageType` 
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-    <!-- ... -->
-    <packageTypes>
-        <packageType name="ContosoExtension" />
-    </packageTypes>
+        <!-- ... -->
+        <packageTypes>
+            <packageType name="ContosoExtension" />
+        </packageTypes>
     </metadata>
 </package>
 ```
@@ -101,11 +101,11 @@ Packages with multiple intended uses may be marked with multiple package types:
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-    <!-- ... -->
-    <packageTypes>
-        <packageType name="PackageType1" />
-        <packageType name="PackageType2" />
-    </packageTypes>
+        <!-- ... -->
+        <packageTypes>
+            <packageType name="PackageType1" />
+            <packageType name="PackageType2" />
+        </packageTypes>
     </metadata>
 </package>
 ```
@@ -116,11 +116,11 @@ Package types can be versioned using a [`Version`](/dotnet/api/system.version) s
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-    <!-- ... -->
-    <packageTypes>
-        <packageType name="PackageType1" version="1.0.0.0" />
-        <packageType name="PackageType2" />
-    </packageTypes>
+        <!-- ... -->
+        <packageTypes>
+            <packageType name="PackageType1" version="1.0.0.0" />
+            <packageType name="PackageType2" />
+        </packageTypes>
     </metadata>
 </package>
 ```

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -28,7 +28,9 @@ Packages not marked with a type, including all packages created with earlier ver
 
 ## Custom package types
 
-You can mark your package with one or more custom package types if its use does not fit the [known package types](#known-package-types). For example, imagine if customers of the `Contoso` app can install extensions. Extension authors could use the custom package type `ContosoExtension` to identify these packages as `Contoso` app extensions.
+You can mark your package with one or more custom package types if its use does not fit the [known package types](#known-package-types).
+
+For example, imagine that customers of the `Contoso` app can install extensions. The app could require extension authors to use the custom package type `ContosoExtension` to identify their packages as proper extensions that follow the required conventions.
 
 > [!WARNING]
 > A package with a custom package type cannot be installed by Visual Studio or nuget.exe. See [NuGet/Home#10468](https://github.com/NuGet/Home/issues/10468) for more information.

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -129,4 +129,4 @@ Package types can be versioned:
 
 The format of a package type string is exactly like a package ID. That is, a package type is a case-insensitive string matching the regular expression `^\w+([_.-]\w+)*$` having at least one character and at most 100 characters.
 
-The format of a package type version is exactly like a [`Version`](en-us/dotnet/api/system.version).
+The format of a package type version is exactly like a [`Version`](/dotnet/api/system.version).

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -9,7 +9,9 @@ ms.topic: conceptual
 
 # Set a NuGet package type
 
-Packages can be marked with one more more *package types* to indicate its intended use. Packages not marked with a type, including all packages created with earlier versions of NuGet, default to the `Dependency` type.
+Packages can be marked with one more more *package types* to indicate its intended use.
+
+## Known package types
 
 - `Dependency` type packages add build- or run-time assets to libraries and applications, and can be installed in any project type (assuming they are compatible).
 
@@ -17,12 +19,19 @@ Packages can be marked with one more more *package types* to indicate its intend
 
 - `Template` type packages provide [custom templates](/dotnet/core/tools/custom-templates) that can be used to create files or projects like an app, service, tool, or class library.
 
-- Custom type packages use an arbitrary type identifier that conforms to the same format rules as package IDs. Any type other than `Dependency` and `DotnetTool`, however, are not recognized by the NuGet Package Manager in Visual Studio.
+Packages not marked with a type, including all packages created with earlier versions of NuGet, default to the `Dependency` type.
 
 > [!NOTE]
 > Support for package types was added in NuGet 3.5.
 > If you don't need a custom package type, it's best to *not* explicitly set the package type.
 > NuGet defaults to the `Dependency` type when no type is specified.
+
+## Custom package types
+
+You can mark your package with one or more custom package types if its use does not fit the known package types. For example, imagine if customers of the `Contoso` app can install extensions. Extension authors could use the custom package type `ContosoExtension` to identify these packages as `Contoso` app extensions.
+
+> [!WARNING]
+> A package with a custom package type cannot be installed by Visual Studio or nuget.exe. See [NuGet/Home#10468](https://github.com/NuGet/Home/issues/10468) for more information.
 
 # [Using dotnet CLI](#tab/dotnet)
 
@@ -34,10 +43,39 @@ Package types can be set in the project file (`.csproj`):
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     
-    <PackageType>MyCustomType, 1.0.0.0;Dependency</PackageType>
+    <PackageType>ContosoExtension</PackageType>
   </PropertyGroup>
 
 </Project>
+```
+
+Packages with multiple intended uses can be marked with multiple package types using the `;` delimiter:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    
+    <PackageType>PackageType1;PackageType2</PackageType>
+  </PropertyGroup>
+
+</Project>
+```
+
+Package types can be versioned using a `,` delimiter between the package type and its version:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    
+    <PackageType>PackageType1, 1.0.0.0;PackageType2</PackageType>
+  </PropertyGroup>
+
+</Project>
+
 ```
 
 # [Using nuget.exe](#tab/nugetexe)
@@ -50,7 +88,37 @@ Package types are set in the `.nuspec` file within a `packageTypes\packageType` 
     <metadata>
     <!-- ... -->
     <packageTypes>
-        <packageType name="DotnetTool" />
+        <packageType name="ContosoExtension" />
+    </packageTypes>
+    </metadata>
+</package>
+```
+
+Packages with multiple intended uses may be marked with multiple package types:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+    <!-- ... -->
+    <packageTypes>
+        <packageType name="PackageType1" />
+        <packageType name="PackageType2" />
+    </packageTypes>
+    </metadata>
+</package>
+```
+
+Package types can be versioned:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+    <!-- ... -->
+    <packageTypes>
+        <packageType name="PackageType1" version="1.0.0.0" />
+        <packageType name="PackageType2" />
     </packageTypes>
     </metadata>
 </package>
@@ -58,3 +126,7 @@ Package types are set in the `.nuspec` file within a `packageTypes\packageType` 
 
 ---
 
+
+The format of a package type string is exactly like a package ID. That is, a package type is a case-insensitive string matching the regular expression `^\w+([_.-]\w+)*$` having at least one character and at most 100 characters.
+
+The format of a package type version is exactly like a [`Version`](en-us/dotnet/api/system.version).

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -42,11 +42,7 @@ Package types can be set in the project file (`.csproj`):
 
 # [Using nuget.exe](#tab/nugetexe)
 
-Package types are set in the `.nuspec` file. It's best for backwards compatibility to *not* explicitly set the `Dependency` type and to instead rely on NuGet assuming this type when no type is specified.
-
-With NuGet 3.5+
-
-Indicate the package type within a `packageTypes\packageType` node under the `<metadata>` element:
+Package types are set in the `.nuspec` file within a `packageTypes\packageType` node under the `<metadata>` element:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -21,7 +21,7 @@ Packages can be marked with one more more *package types* to indicate its intend
 
 > [!NOTE]
 > Support for package types was added in NuGet 3.5.
-> If you don't need a custom package type, it's best to *not* explicitly set the `Dependency` type. NuGet defaults to `Dependency` this type when no type is specified.
+> If you don't need a custom package type, it's best to *not* explicitly set the package type. NuGet defaults to `Dependency` this type when no type is specified.
 
 # [Using dotnet CLI](#tab/dotnet)
 
@@ -61,6 +61,3 @@ Indicate the package type within a `packageTypes\packageType` node under the `<m
 
 ---
 
-> [!NOTE]
-> Support for package types was added in NuGet 3.5.
-> If you don't need a custom package type, it's best to *not* explicitly set the `Dependency` type. NuGet defaults to `Dependency` this type when no type is specified.

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -127,4 +127,4 @@ Package types can be versioned using a [`Version`](/dotnet/api/system.version) s
 
 The format of a package type string is exactly like a package ID. That is, a package type is a case-insensitive string matching the regular expression `^\w+([_.-]\w+)*$` having at least one character and at most 100 characters.
 
-The format of a package type version is exactly like a [`Version`](/dotnet/api/system.version) string. The package type version is optional and defaults to `0.0`.
+If provided, the package type version is a [`Version`](/dotnet/api/system.version) string. The package type version is optional and defaults to `0.0`.

--- a/docs/create-packages/set-package-type.md
+++ b/docs/create-packages/set-package-type.md
@@ -34,7 +34,7 @@ Package types can be set in the project file (`.csproj`):
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     
-    <PackageType>MyCustomType, 1.0.0.0;Dependency, 1.0.0.0</PackageType>
+    <PackageType>MyCustomType, 1.0.0.0;Dependency</PackageType>
   </PropertyGroup>
 
 </Project>

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -68,7 +68,7 @@ The following table describes the MSBuild properties that can be added to a proj
 | `Repository/Type` | `RepositoryType` | empty | Repository type. Examples: `git` (default), `tfs`. |
 | `Repository/Branch` | `RepositoryBranch` | empty | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
 | `Repository/Commit` | `RepositoryCommit` | empty | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
-| `PackageType` | `<PackageType>CustomType1, 1.0.0.0;CustomType2</PackageType>` | | Indicates the packages intended use. Package types use the same format as package IDs and are delimited by `;`. Package types may be versions by appending a `,` and a [`Version`](/dotnet/api/system.version) string. See [Set a NuGet package type](../create-packages/set-package-type.md) (NuGet 3.5.0+). |
+| `PackageType` | `<PackageType>CustomType1, 1.0.0.0;CustomType2</PackageType>` | | Indicates the package's intended use. Package types use the same format as package IDs and are delimited by `;`. Package types may be versioned by appending a `,` and a [`Version`](/dotnet/api/system.version) string. See [Set a NuGet package type](../create-packages/set-package-type.md) (NuGet 3.5.0+). |
 | `Summary` | Not supported | | |
 
 ### pack target inputs

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -68,7 +68,7 @@ The following table describes the MSBuild properties that can be added to a proj
 | `Repository/Type` | `RepositoryType` | empty | Repository type. Examples: `git` (default), `tfs`. |
 | `Repository/Branch` | `RepositoryBranch` | empty | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
 | `Repository/Commit` | `RepositoryCommit` | empty | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
-| `PackageType` | `<PackageType>DotNetCliTool, 1.0.0.0;Dependency, 2.0.0.0</PackageType>` | | |
+| `PackageType` | `<PackageType>MyCustomType, 1.0.0.0;Dependency</PackageType>` | | Indicates the packages intended use. See [Set a NuGet package type](../create-packages/set-package-type) (NuGet 3.5.0+). |
 | `Summary` | Not supported | | |
 
 ### pack target inputs

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -68,7 +68,7 @@ The following table describes the MSBuild properties that can be added to a proj
 | `Repository/Type` | `RepositoryType` | empty | Repository type. Examples: `git` (default), `tfs`. |
 | `Repository/Branch` | `RepositoryBranch` | empty | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
 | `Repository/Commit` | `RepositoryCommit` | empty | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
-| `PackageType` | `<PackageType>MyCustomType, 1.0.0.0;Dependency</PackageType>` | | Indicates the packages intended use. See [Set a NuGet package type](../create-packages/set-package-type) (NuGet 3.5.0+). |
+| `PackageType` | `<PackageType>CustomType1, 1.0.0.0;CustomType2</PackageType>` | | Indicates the packages intended use. Package types use the same format as package IDs and are delimited by `;`. Package types may be versions by appending a `,` and a [`Version`](/dotnet/api/system.version) string. See [Set a NuGet package type](../create-packages/set-package-type) (NuGet 3.5.0+). |
 | `Summary` | Not supported | | |
 
 ### pack target inputs

--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -68,7 +68,7 @@ The following table describes the MSBuild properties that can be added to a proj
 | `Repository/Type` | `RepositoryType` | empty | Repository type. Examples: `git` (default), `tfs`. |
 | `Repository/Branch` | `RepositoryBranch` | empty | Optional repository branch information. `RepositoryUrl` must also be specified for this property to be included. Example: *master* (NuGet 4.7.0+). |
 | `Repository/Commit` | `RepositoryCommit` | empty | Optional repository commit or changeset to indicate which source the package was built against. `RepositoryUrl` must also be specified for this property to be included. Example: *0e4d1b598f350b3dc675018d539114d1328189ef* (NuGet 4.7.0+). |
-| `PackageType` | `<PackageType>CustomType1, 1.0.0.0;CustomType2</PackageType>` | | Indicates the packages intended use. Package types use the same format as package IDs and are delimited by `;`. Package types may be versions by appending a `,` and a [`Version`](/dotnet/api/system.version) string. See [Set a NuGet package type](../create-packages/set-package-type) (NuGet 3.5.0+). |
+| `PackageType` | `<PackageType>CustomType1, 1.0.0.0;CustomType2</PackageType>` | | Indicates the packages intended use. Package types use the same format as package IDs and are delimited by `;`. Package types may be versions by appending a `,` and a [`Version`](/dotnet/api/system.version) string. See [Set a NuGet package type](../create-packages/set-package-type.md) (NuGet 3.5.0+). |
 | `Summary` | Not supported | | |
 
 ### pack target inputs


### PR DESCRIPTION
Reading material:

* https://github.com/NuGet/Home/wiki/Package-Type-%5BPacking%5D
* https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target
* https://github.com/NuGet/NuGet.Client/blob/f24bad0668193ce21a1db8cabd1ce95ba509c7f0/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs#L526-L545

I'm not sure who owns the NuGet pack experience now. Feel free to add reviewers if needed! :)
