### PR TITLE
update .gitignore to ignore `.vs` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ _themes/
 _themes.MSDN.Modern/
 _themes.VS.Modern/
 
+# Visual Studio
+.vs/
+
 .openpublishing.buildcore.ps1


### PR DESCRIPTION
I update .gitignore to ignore `.vs` folder, because I often open this repo in Visual Studio, not just in any other text editors or other IDE.