### PR TITLE
Add nuget.org's search API limits

### DIFF
--- a/docs/api/search-query-service-resource.md
+++ b/docs/api/search-query-service-resource.md
@@ -69,6 +69,9 @@ The `skip` parameter defaults to 0.
 
 The `take` parameter should be an integer greater than zero. The server implementation may impose a maximum value.
 
+> [!Note]
+> nuget.org limits the `skip` parameter to 3,000 and the `take` parameter to 1,000.
+
 If `prerelease` is not provided, pre-release packages are excluded.
 
 The `semVerLevel` query parameter is used to opt-in to


### PR DESCRIPTION
⚠️ This is not ready to be published.

We are introducing a new limit to nuget.org's `skip` parameter to prevent Azure Search throttling. This updates our docs accordingly.

Preview:

![image](https://user-images.githubusercontent.com/737941/119896112-6a9df800-bef3-11eb-9321-ca7b3f94c182.png)

Part of: https://github.com/NuGet/Engineering/issues/3776