### PR TITLE
Update document for nuget trusted-signers only 1 signed package is can be passed.

### DIFF
--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -57,14 +57,14 @@ Adds a trusted signer with the given name to the config. This option has differe
 ## Options for add based on a package
 
 ```cli
-nuget trusted-signers add <package(s)> -Name <name> [options]
+nuget trusted-signers add <package> -Name <name> [options]
 ```
 
-where `<package(s)>` is one or more `.nupkg` files.
+where `<package>` is one signed `.nupkg` file.
 
 - **`-Author`**
 
-  Specifies that the author signature of the package(s) should be trusted.
+  Specifies that the author signature of the signed package should be trusted.
 
 - **`-AllowUntrustedRoot`**
 
@@ -76,7 +76,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 - **`-Repository`**
 
-  Specifies that the repository signature or countersignature of the package(s) should be trusted.
+  Specifies that the repository signature or countersignature of the signed package should be trusted.
 
 Providing both `-Author` and `-Repository` at the same time is not supported.
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/docs.microsoft.com-nuget/issues/2399

Due do [better security practice](https://github.com/nuget/home/issues/10647#issuecomment-801523491) we made nuget trusted-signers add nupkgPath command accept only 1 nupkg file instead of many. It's consistent with other MS product practice.