### PR TITLE
Fix semver v2.0.0 floating version for "latest prerelease"

### DIFF
--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -71,7 +71,7 @@ In PackageReference projects, the transitive dependency versions are resolved at
 <ItemGroup>
     <!-- ... -->
     <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.*" />
-    <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.0-beta*" />
+    <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.0-beta.*" />
     <!-- ... -->
 </ItemGroup>
 ```


### PR DESCRIPTION
The sample for creating a floating version for a SemVer version suffix is somewhat incorrect, in that it allows an unbounded number of suffixes without incrementing suffix numbers.

For more information, consider reading the documentation about NuGet versioning:
https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions

Or the SemVer spec:
https://semver.org/spec/v2.0.0.html

We may want to add an additional example for "latest build" as well as "latest prerelease", and possible add comments in the sample MSBuild XML so people can follow it more clearly.