### PR TITLE
packages.config must be in the project directory

### DIFF
--- a/docs/reference/packages-config.md
+++ b/docs/reference/packages-config.md
@@ -9,9 +9,9 @@ ms.topic: reference
 
 # packages.config reference
 
-The `packages.config` file is used in some project types to maintain the list of packages referenced by the project. This allows NuGet to easily restore the project's dependencies when the project is to be transported to a different machine, such as a build server, without all those packages.
+The `packages.config` file is used in some project types (e.g. C++) to maintain the list of packages referenced by the project. This allows NuGet to easily restore the project's dependencies when the project is to be transported to a different machine, such as a build server, without all those packages.
 
-If used, `packages.config` is typically located in a project root. It's automatically created when the first NuGet operation is run, but can also be created manually before running any commands such as `nuget restore`.
+If used, `packages.config` must be located in a project root. It's automatically created when the first NuGet operation is run, but can also be created manually before running any commands such as `nuget restore`.
 
 Projects that use [PackageReference](../consume-packages/Package-References-in-Project-Files.md) do not use `packages.config`.
 


### PR DESCRIPTION
my testing found that this file must be in the project root next to the .vcxproj file. attempts to share this file between multiple projects, putting it above (e.g. `..\packages.config`) and referencing it from the .vcxproj file, does not work.