### PR TITLE
Fix missing text

### DIFF
--- a/docs/create-packages/creating-a-package-msbuild.md
+++ b/docs/create-packages/creating-a-package-msbuild.md
@@ -152,7 +152,7 @@ To automatically run `msbuild -t:pack` when you build or restore the project, ad
 <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 ```
 
-When you run `msbuild -t:pack` on a solution, this packs all the projects in the solution that are packable ([<IsPackable>](/dotnet/core/tools/csproj#nuget-metadata-properties) property is set to `true`).
+When you run `msbuild -t:pack` on a solution, this packs all the projects in the solution that are packable ([`<IsPackable>`](/dotnet/core/tools/csproj#nuget-metadata-properties) property is set to `true`).
 
 > [!NOTE]
 > When you automatically generate the package, the time to pack increases the build time for your project.


### PR DESCRIPTION
Because the XML was not escaped in backticks, it was being removed from the rendered markdown. Consequently it was not clear what property the sentence is referring to.

The fix is to mark the property as an inline code snippet, which also makes it consistent with other property references in the document.