### PR TITLE
Add detail about devops not supporting snupkg

### DIFF
--- a/docs/create-packages/Symbol-Packages-snupkg.md
+++ b/docs/create-packages/Symbol-Packages-snupkg.md
@@ -65,6 +65,9 @@ The [`SymbolPackageFormat`](/dotnet/core/tools/csproj#symbolpackageformat) prope
 
 ## Publishing a symbol package
 
+> [!Note]
+> [Azure Devops Artifacts](https://azure.microsoft.com/services/devops/artifacts) does not currently support debugging via `.snupkg` files.
+
 1. For convenience, first save your API key with NuGet (see [publish a package](../nuget-org/publish-a-package.md)).
 
     ```cli


### PR DESCRIPTION
Ref: https://developercommunity.visualstudio.com/t/add-snupkg-support-to-azure-devops-artifacts/657354

When (if) the support is added, this can be removed.