### PR TITLE
Add missing "=true" to RestoreUseStaticGraphEvaluation

### DIFF
--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -527,7 +527,7 @@ In very few scenarios, static graph restore may behave differently from current 
 To ease your mind, as a one time check, when migrating to static graph restore, consider running:
 
 ```cli
-msbuild.exe -t:restore -p:RestoreUseStaticGraphEvaluation
+msbuild.exe -t:restore -p:RestoreUseStaticGraphEvaluation=true
 msbuild.exe -t:restore
 ```
 


### PR DESCRIPTION
Without this "=true", msbuild throws an error:

MSBUILD : error MSB1006: Property is not valid.
Switch: RestoreUseStaticGraphEvaluation

It is correct (=true) earlier in the document.