### PR TITLE
Clarify SemVer 2.0.0 prerelease sort order

### DIFF
--- a/docs/concepts/Package-Versioning.md
+++ b/docs/concepts/Package-Versioning.md
@@ -35,7 +35,7 @@ A specific version number is in the form *Major.Minor.Patch[-Suffix]*, where the
 1.0.1
 6.11.1231
 4.3.1-rc
-2.2.44-beta1
+2.2.44-beta.1
 ```
 
 > [!Important]
@@ -52,20 +52,23 @@ That said, package developers generally follow recognized naming conventions:
 - `-rc`: Release candidate, typically a release that's potentially final (stable) unless significant bugs emerge.
 
 > [!Note]
-> NuGet 4.3.0+ supports [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html), which supports pre-release numbers with dot notation, as in *1.0.1-build.23*. Dot notation is not supported with NuGet versions before 4.3.0. You can use a form like *1.0.1-build23*.
+> NuGet 4.3.0+ supports [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html), which supports pre-release numbers with dot notation, as in *1.0.1-build.23*. Dot notation is not supported with NuGet versions before 4.3.0. You can use a form like *1.0.1-build23*. It is recommended to use NuGet 4.3.0+, because nuget.org and newer NuGet clients will not treat "1.0.1-build23" as greater than "1.0.1-build3".
 
-When resolving package references and multiple package versions differ only by suffix, NuGet chooses a version without a suffix first, then applies precedence to pre-release versions in reverse alphabetical order. For example, the following versions would be chosen in the exact order shown:
+When resolving package references and multiple package versions differ only by suffix, NuGet chooses a version without a suffix first, then applies precedence to pre-release versions in reverse alphabetical order and treats dot notation numbers with numerical order. For example, the following versions would be chosen in the exact order shown:
 
 ```
 1.0.1
 1.0.1-zzz
-1.0.1-rc
+1.0.1-rc.10
+1.0.1-rc.2
 1.0.1-open
 1.0.1-beta
 1.0.1-alpha2
-1.0.1-alpha
+1.0.1-alpha10
 1.0.1-aaa
 ```
+
+Note that, 1.0.1-alpha10 is sorted strictly in reverse alphabetical order, whereas 1.0.1-rc.10 is greater precedence than 1.0.1-rc.2.
 
 ## Semantic Versioning 2.0.0
 


### PR DESCRIPTION
Note: EF Package name is not really a best practice for SemVer, so the documentation is a bit confusing.