### PR TITLE
Add warning for keeping API keys a secret

### DIFF
--- a/docs/quickstart/includes/publish-api-key.md
+++ b/docs/quickstart/includes/publish-api-key.md
@@ -11,7 +11,7 @@
     ![Copying the API key to the clipboard](../media/QS_Create-02-APIKey.png)
 
 > [!Warning]
-> **Always keep your API key a secret!** If your key is accidentally revealed, you can always regenerate it at any time.
+> **Always keep your API key a secret!** Treat your API key as a password that allows anyone to manage packages on your behalf. You should delete or regenerate your API key if it is accidentally revealed.
 
 > [!Important]
 > Save your key in a secure location because you cannot copy the key again later on. If you return to the API key page, you need to regenerate the key to copy it. You can also remove the API key if you no longer want to push packages.


### PR DESCRIPTION
Add a Warning callout reminding users to keep API keys a secret.
The text is derived from the image at
https://devblogs.microsoft.com/nuget/nuget-api-key-expiration/#how-do-i-know-when-my-api-key-expires

Also change the Important below to a callout and remove the "via the CLI" portion.

---

The file edited (docs\quickstart\includes\publish-api-key.md)
is currently used at the following locations:

- docs\nuget-org\Publish-a-package.md
- docs\nuget-org\scoped-api-keys.md
- docs\quickstart\create-and-publish-a-package-using-the-dotnet-cli.md
- docs\quickstart\create-and-publish-a-package-using-visual-studio-net-framework.md
- docs\quickstart\create-and-publish-a-package-using-visual-studio.md
