### PR TITLE
Make PackageReference string searchable

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -27,7 +27,7 @@
 ### [Work with source control systems](consume-packages/packages-and-source-control.md)
 ### [Common NuGet configurations](consume-packages/configuring-nuget-behavior.md)
 ## Reference packages in your project
-### [Package references in project files](consume-packages/package-references-in-project-files.md)
+### [PackageReference in project files](consume-packages/package-references-in-project-files.md)
 ### [Migrate packages.config to PackageReference](consume-packages/migrate-packages-config-to-package-reference.md)
 ### [packages.config](reference/packages-config.md)
 # Create packages


### PR DESCRIPTION
Fixes https://github.com/NuGet/docs.microsoft.com-nuget/issues/2086


This allows people to just search for `PackageReference` in the search bar and `actually` get a result. 

Using PackageReference and `package references` interchangeably is wrong, becuase package references only could imply the references from packages themselves. 

We could consider retitling https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/consume-packages/Package-References-in-Project-Files.md as well. 

What do we think?