### PR TITLE
LinkFix docs.microsoft.com-nuget (2021-10)

### DIFF
--- a/docs/create-packages/Creating-a-Package.md
+++ b/docs/create-packages/Creating-a-Package.md
@@ -19,12 +19,12 @@ ms.reviewer:
 
 No matter what your package does or what code it contains, you use `nuget.exe` to package that functionality into a component that can be shared with and used by any number of other developers. To install `nuget.exe`, see [Install NuGet CLI](../install-nuget-client-tools.md#nugetexe-cli). Note that Visual Studio does not automatically include `nuget.exe`.
 
-Technically speaking, a NuGet package is just a ZIP file that's been renamed with the `.nupkg` extension and whose contents match certain conventions. This topic describes the detailed process of creating a package that meets those conventions. For a focused walkthrough, refer to [Quickstart: create and publish a package](../quickstart/create-and-publish-a-package.md).
+Technically speaking, a NuGet package is just a ZIP file that's been renamed with the `.nupkg` extension and whose contents match certain conventions. This topic describes the detailed process of creating a package that meets those conventions. For a focused walkthrough, refer to [Quickstart: create and publish a package](../quickstart/create-and-publish-a-package-using-visual-studio.md).
 
 Packaging begins with the compiled code (assemblies), symbols, and/or other files that you want to deliver as a package (see [Overview and workflow](overview-and-workflow.md)). This process is independent from compiling or otherwise generating the files that go into the package, although you can use draw from information in a project file to keep the compiled assemblies and packages in sync.
 
 > [!Note]
-> This topic applies to project types other than .NET Core projects using Visual Studio 2017 and NuGet 4.0+. In those .NET Core projects, NuGet uses information in the project file directly. For details, see [Create .NET Standard Packages with Visual Studio 2017](../guides/create-net-standard-packages-vs2017.md) and [NuGet pack and restore as MSBuild targets](../reference/msbuild-targets.md).
+> This topic applies to project types other than .NET Core projects using Visual Studio 2017 and NuGet 4.0+. In those .NET Core projects, NuGet uses information in the project file directly. For details, see [Create .NET Standard Packages with Visual Studio 2017](../quickstart/create-and-publish-a-package-using-visual-studio.md) and [NuGet pack and restore as MSBuild targets](../reference/msbuild-targets.md).
 
 ## Deciding which assemblies to package
 

--- a/docs/create-packages/Source-and-Config-File-Transformations.md
+++ b/docs/create-packages/Source-and-Config-File-Transformations.md
@@ -56,7 +56,7 @@ The `$rootnamespace$` token is the most commonly used project property; all othe
 As described in the sections that follow, config file transformations can be done in two ways:
 
 - Include `app.config.transform` and `web.config.transform` files in your package's `content` folder, where the `.transform` extension tells NuGet that these files contain the XML to merge with existing config files when the package is installed. When a package is uninstalled, that same XML is removed.
-- Include `app.config.install.xdt` and `web.config.install.xdt` files in your package's `content` folder, using [XDT syntax](https://msdn.microsoft.com/library/dd465326.aspx) to describe the desired changes. With this option you can also include a `.uninstall.xdt` file to reverse changes when the package is removed from a project.
+- Include `app.config.install.xdt` and `web.config.install.xdt` files in your package's `content` folder, using [XDT syntax](/previous-versions/aspnet/dd465326(v=vs.110)) to describe the desired changes. With this option you can also include a `.uninstall.xdt` file to reverse changes when the package is removed from a project.
 
 > [!Note]
 > Transformations are not applied to `.config` files referenced as a link in Visual Studio.
@@ -116,7 +116,7 @@ To see the effect of installing and uninstalling the package, create a new ASP.N
 
 ### XDT transforms
 
-You can modify config files using [XDT syntax](https://msdn.microsoft.com/library/dd465326.aspx). You can also have NuGet replace tokens with [project properties](/dotnet/api/vslangproj.projectproperties?view=visualstudiosdk-2017&viewFallbackFrom=netframework-4.7) by including the property name within `$` delimeters (case-insensitive).
+You can modify config files using [XDT syntax](/previous-versions/aspnet/dd465326(v=vs.110)). You can also have NuGet replace tokens with [project properties](/dotnet/api/vslangproj.projectproperties?view=visualstudiosdk-2017&viewFallbackFrom=netframework-4.7) by including the property name within `$` delimeters (case-insensitive).
 
 For example, the following `app.config.install.xdt` file will insert an `appSettings` element into `app.config` containing the `FullPath`, `FileName`, and `ActiveConfigurationSettings` values from the project:
 

--- a/docs/policies/Ecosystem.md
+++ b/docs/policies/Ecosystem.md
@@ -70,7 +70,7 @@ These are tools and utilities built on NuGet:
 
 ## Training materials and references
 
-Using a new tool or technology usually comes with a learning curve. Luckily for you, NuGet has no steep learning curve it all! In fact, anyone can [get started consuming packages](../quickstart/use-a-package.md) quickly.
+Using a new tool or technology usually comes with a learning curve. Luckily for you, NuGet has no steep learning curve it all! In fact, anyone can [get started consuming packages](../quickstart/install-and-use-a-package-in-visual-studio.md) quickly.
 
 That said, authoring packages–and especially good packages–along with  embracing NuGet in automated build and deployment processes, requires spending a little more time with the following resources:
 

--- a/docs/policies/NuGet-FAQ.md
+++ b/docs/policies/NuGet-FAQ.md
@@ -103,7 +103,7 @@ This is a known issue with how PowerShell interacts with a COM object. Try the f
 
 **How do I list my package in a feed?**
 
-See [Creating and publishing a package](../quickstart/create-and-publish-a-package.md).
+See [Creating and publishing a package](../quickstart/create-and-publish-a-package-using-visual-studio.md).
 
 **I have multiple versions of my library that target different versions of the .NET Framework. How do I build a single package that supports this?**
 
@@ -172,7 +172,7 @@ In addition, uploading packages to [staging.nuget.org](http://staging.nuget.org)
 
 **Is it possible to reserve names for packages that will be published in future?**
 
-Yes. You can reserve IDs for packages on [nuget.org](https://www.nuget.org/) by requesting a package ID prefix for your account. In order to request a package ID prefix, follow the instructions in the [documentation](https://docs.microsoft.com/nuget/reference/id-prefix-reservation).
+Yes. You can reserve IDs for packages on [nuget.org](https://www.nuget.org/) by requesting a package ID prefix for your account. In order to request a package ID prefix, follow the instructions in the [documentation](../reference/id-prefix-reservation.md).
 
 **How do I claim ownership for packages ?**
 

--- a/docs/reference/Errors-and-Warnings.md
+++ b/docs/reference/Errors-and-Warnings.md
@@ -125,7 +125,7 @@ The errors and warnings listed here are available only with [PackageReference-ba
 | --- | --- |
 | **Issue** | The package cannot be found on any sources. |
 | **Example message** | *Unable to find package System.Missing. No packages exist with this id in source(s): dotnet-core, dotnet-roslyn, nuget.org* |
-| **Solution** | Examine the project's dependencies in Visual Studio to be sure you're using the correct package identifier and version number. Also check that the [NuGet configuration](../consume-packages/Configuring-NuGet-Behavior.md) identifies the package sources your expect to be using. If you use packages that have [Semantic Versioning 2.0.0](https://docs.microsoft.com/en-us/nuget/reference/package-versioning#semantic-versioning-200), please make sure that you are using the [V3 feed](https://api.nuget.org/v3/index.json) in the [NuGet configuration](../consume-packages/Configuring-NuGet-Behavior.md). |
+| **Solution** | Examine the project's dependencies in Visual Studio to be sure you're using the correct package identifier and version number. Also check that the [NuGet configuration](../consume-packages/Configuring-NuGet-Behavior.md) identifies the package sources your expect to be using. If you use packages that have [Semantic Versioning 2.0.0](./package-versioning.md#semantic-versioning-200), please make sure that you are using the [V3 feed](https://api.nuget.org/v3/index.json) in the [NuGet configuration](../consume-packages/Configuring-NuGet-Behavior.md). |
 
 ### NU1102
 

--- a/docs/reference/Signed-Packages-Reference.md
+++ b/docs/reference/Signed-Packages-Reference.md
@@ -47,11 +47,11 @@ Valid certificates may be obtained from public certificate authorities like:
 - [Comodo](https://www.comodo.com/e-commerce/code-signing/code-signing-certificate.php)
 - [Certum](https://www.certum.eu/certum/cert,offer_en_open_source_cs.xml) 
 
-The complete list of certification authorities trusted by Windows can be obtained from [http://aka.ms/trustcertpartners](http://aka.ms/trustcertpartners).
+The complete list of certification authorities trusted by Windows can be obtained from [http://aka.ms/trustcertpartners](/security/trusted-root/participants-list).
 
 ## Create a test certificate
 
-You can use self-issued certificates for testing purposes. To create a self-issued certificate, use the [New-SelfSignedCertificate](https://docs.microsoft.com/en-us/powershell/module/pkiclient/new-selfsignedcertificate) PowerShell command.
+You can use self-issued certificates for testing purposes. To create a self-issued certificate, use the [New-SelfSignedCertificate](/powershell/module/pkiclient/new-selfsignedcertificate) PowerShell command.
 
 ```ps
 New-SelfSignedCertificate -Subject "CN=NuGet Test Developer, OU=Use for testing purposes ONLY" `

--- a/docs/reference/analyzers-conventions.md
+++ b/docs/reference/analyzers-conventions.md
@@ -16,7 +16,7 @@ ms.reviewer:
 
 # Analyzer NuGet formats
 
-The .NET Compiler Platform (also known as "Roslyn") allow developers to create [analyzers] (https://github.com/dotnet/roslyn/wiki/How-To-Write-a-C%23-Analyzer-and-Code-Fix) that examine the syntax tree and semantics of code as it's being written. This provides developers with a way to create and domain-specific analysis tools, such as those that would help guide the use of a particular API or library. You can find more information on the [.NET/Roslyn](https://github.com/dotnet/roslyn/wiki) GitHub wiki. Also see the article, [Use Roslyn to Write a Live Code Analyzer for your API](https://msdn.microsoft.com/magazine/dn879356.aspx) in MSDN Magazine.
+The .NET Compiler Platform (also known as "Roslyn") allow developers to create [analyzers] (https://github.com/dotnet/roslyn/wiki/How-To-Write-a-C%23-Analyzer-and-Code-Fix) that examine the syntax tree and semantics of code as it's being written. This provides developers with a way to create and domain-specific analysis tools, such as those that would help guide the use of a particular API or library. You can find more information on the [.NET/Roslyn](https://github.com/dotnet/roslyn/wiki) GitHub wiki. Also see the article, [Use Roslyn to Write a Live Code Analyzer for your API](/archive/msdn-magazine/2014/special-issue/csharp-and-visual-basic-use-roslyn-to-write-a-live-code-analyzer-for-your-api) in MSDN Magazine.
 
 Analyzers themselves are typically packaged and distributed as part of the NuGet packages that implement the API or library in question.
 

--- a/docs/release-notes/NuGet-1.8.md
+++ b/docs/release-notes/NuGet-1.8.md
@@ -41,7 +41,7 @@ We have since released a hotfix that addresses this issue.  By updating NuGet th
 ### Satellite Packages for Localized Resources
 NuGet 1.8 now supports the ability to create separate packages for localized resources, similar to the satellite assembly capabilities of the .NET Framework.  A satellite package is created in the same way as any other NuGet package with the addition of a few conventions:
 
-* The satellite package ID and file name should include a suffix that matches one of the standard [culture strings used by the .NET Framework](http://msdn.microsoft.com/goglobal/bb896001.aspx).
+* The satellite package ID and file name should include a suffix that matches one of the standard [culture strings used by the .NET Framework](/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c).
 * In its `.nuspec` file, the satellite package should define a language element with the same culture string used in the ID
 * The satellite package should define a dependency in its `.nuspec` file to its core package, which is simply the package with the same ID minus the language suffix.  The core package needs to be available in the repository for successful installation.
 

--- a/docs/release-notes/NuGet-2.6.md
+++ b/docs/release-notes/NuGet-2.6.md
@@ -74,7 +74,7 @@ applications in your project.
 
 #### What you can do with XDT
 
-One of XDT’s greatest strengths is its [simple but powerful syntax](http://msdn.microsoft.com/library/dd465326.aspx)
+One of XDT’s greatest strengths is its [simple but powerful syntax](/previous-versions/aspnet/dd465326(v=vs.110))
 for manipulating the structure of an XML DOM. Rather than simply overlaying one fixed document
 structure onto another structure, XDT provides controls for matching elements in a variety of
 ways, from simple attribute name matching to full XPath support. Once a matching element or

--- a/docs/release-notes/NuGet-3.3.md
+++ b/docs/release-notes/NuGet-3.3.md
@@ -22,7 +22,7 @@ NuGet 3.3 was released November 30, 2015 with a significant number of user inter
 
 ## New Features
 
-* Credential Providers have been introduced that allow NuGet command-line clients to be able to work seamlessly with an authenticated feed. [Instructions on how to install the Visual Studio Team Services credential provider ](../api/nuget-exe-credential-providers.md) and configure the NuGet clients to use it are available on NuGet Docs.
+* Credential Providers have been introduced that allow NuGet command-line clients to be able to work seamlessly with an authenticated feed. [Instructions on how to install the Visual Studio Team Services credential provider ](../reference/extensibility/nuget-exe-credential-providers.md) and configure the NuGet clients to use it are available on NuGet Docs.
 
 ## New User Interface Features
 

--- a/docs/release-notes/NuGet-4.6-rtm.md
+++ b/docs/release-notes/NuGet-4.6-rtm.md
@@ -1,4 +1,3 @@
-
 ---
 title: NuGet 4.6 RTM Release Notes | Microsoft Docs
 author: anangaur
@@ -21,8 +20,8 @@ ms.reviewer:
 [Visual Studio 2017 15.6 RTW](https://www.visualstudio.com/news/releasenotes/vs2017-relnotes) comes with [NuGet 4.6.0](https://dist.nuget.org/win-x86-commandline/v4.6.0/nuget.exe).
 
 ## Summary: What's New in this Release
-* We have added support for [signing packages](https://docs.microsoft.com/en-us/nuget/create-packages/sign-a-package).  
-* Visual Studio 2017 and nuget.exe now verifies package integrity before installing, restoring packages for [signed packages](https://docs.microsoft.com/en-us/nuget/reference/signed-packages-reference).
+* We have added support for [signing packages](../create-packages/sign-a-package.md).  
+* Visual Studio 2017 and nuget.exe now verifies package integrity before installing, restoring packages for [signed packages](../reference/signed-packages-reference.md).
 * We have improved performance of successive restores.
 
 ## Known issues

--- a/docs/tools/Package-Manager-Console.md
+++ b/docs/tools/Package-Manager-Console.md
@@ -182,7 +182,7 @@ $profile
 C:\Users\<user>\Documents\WindowsPowerShell\NuGet_profile.ps1
 ```
 
-For more details, refer to [Windows PowerShell Profiles](https://technet.microsoft.com/library/bb613488.aspx).
+For more details, refer to [Windows PowerShell Profiles](/previous-versions//bb613488(v=vs.85)).
 
 ## Using the nuget.exe CLI in the console
 

--- a/docs/tools/PowerShell-Reference.md
+++ b/docs/tools/PowerShell-Reference.md
@@ -46,7 +46,7 @@ For complete, detailed help on any of these commands within the console, just ru
 Get-Help <command> -full
 ```
 
-All Package Manager Console commands support the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216):
+All Package Manager Console commands support the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters):
 
 - Debug
 - ErrorAction
@@ -58,4 +58,4 @@ All Package Manager Console commands support the following [common PowerShell pa
 - WarningAction
 - WarningVariable
 
-For details, refer to [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216) in the PowerShell documentation.
+For details, refer to [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters) in the PowerShell documentation.

--- a/docs/tools/ps-ref-add-bindingredirect.md
+++ b/docs/tools/ps-ref-add-bindingredirect.md
@@ -38,7 +38,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Add-BindingRedirect` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Add-BindingRedirect` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-find-package.md
+++ b/docs/tools/ps-ref-find-package.md
@@ -44,7 +44,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Find-Package` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Find-Package` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-get-package.md
+++ b/docs/tools/ps-ref-get-package.md
@@ -49,7 +49,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Get-Package` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Get-Package` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-get-project.md
+++ b/docs/tools/ps-ref-get-project.md
@@ -37,7 +37,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Get-Project` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Get-Project` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-install-package.md
+++ b/docs/tools/ps-ref-install-package.md
@@ -53,7 +53,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Install-Package` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Install-Package` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-open-packagepage.md
+++ b/docs/tools/ps-ref-open-packagepage.md
@@ -42,7 +42,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Open-PackagePage` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Open-PackagePage` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-register-tabexpansion.md
+++ b/docs/tools/ps-ref-register-tabexpansion.md
@@ -37,7 +37,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Register-TabExpansion` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Register-TabExpansion` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-sync-package.md
+++ b/docs/tools/ps-ref-sync-package.md
@@ -46,7 +46,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Sync-Package` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Sync-Package` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-uninstall-package.md
+++ b/docs/tools/ps-ref-uninstall-package.md
@@ -44,7 +44,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ## Common Parameters
 
-`Uninstall-Package` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Uninstall-Package` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ## Examples
 

--- a/docs/tools/ps-ref-update-package.md
+++ b/docs/tools/ps-ref-update-package.md
@@ -56,7 +56,7 @@ None of these parameters accept pipeline input or wildcard characters.
 
 ### Common Parameters
 
-`Update-Package` supports the following [common PowerShell parameters](http://go.microsoft.com/fwlink/?LinkID=113216): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
+`Update-Package` supports the following [common PowerShell parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters): Debug, Error Action, ErrorVariable, OutBuffer, OutVariable, PipelineVariable, Verbose, WarningAction, and WarningVariable.
 
 ### Examples
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 