### PR TITLE
Add scenarios where a PackageDetails leaf is produced

### DIFF
--- a/docs/api/catalog-resource.md
+++ b/docs/api/catalog-resource.md
@@ -207,7 +207,7 @@ following scenarios:
 1. A package is **deprecated**.
 1. A package is **undeprecated**.
 1. A package is **reflowed**.
-1. A package is marked **vulnerable**.
+1. A package's **vulnerability status** is updated.
 
 A package reflow is an administrative gesture that essentially generates a fake push of an existing package with no
 changes to the package itself. On nuget.org, a reflow is used after fixing a bug in one of the background jobs

--- a/docs/api/catalog-resource.md
+++ b/docs/api/catalog-resource.md
@@ -202,7 +202,7 @@ version combination). A package details catalog item is produced when a package 
 following scenarios:
 
 1. A package is **pushed**.
-1. A package is **listed**.
+1. A package is **relisted**.
 1. A package is **unlisted**.
 1. A package is **deprecated**.
 1. A package is **undeprecated**.

--- a/docs/api/catalog-resource.md
+++ b/docs/api/catalog-resource.md
@@ -204,7 +204,10 @@ following scenarios:
 1. A package is **pushed**.
 1. A package is **listed**.
 1. A package is **unlisted**.
+1. A package is **deprecated**.
+1. A package is **undeprecated**.
 1. A package is **reflowed**.
+1. A package is marked **vulnerable**.
 
 A package reflow is an administrative gesture that essentially generates a fake push of an existing package with no
 changes to the package itself. On nuget.org, a reflow is used after fixing a bug in one of the background jobs


### PR DESCRIPTION
Update which scenarios produce a `PackageDetails` catalog leaf as Terrapin team may use NuGet Insight's catalog leaves data.

Please let me know if I forgot any scenarios!