### PR TITLE
Spell "Everything" correctly

### DIFF
--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -119,7 +119,7 @@ Allowable values for these tags are as follows, with multiple values separated b
 <ItemGroup>
     <!-- ... -->
     <!-- Everything except the content files will be consumed by the project -->
-    <!-- Everythign except content files and analyzers will flow to the parent project-->
+    <!-- Everything except content files and analyzers will flow to the parent project-->
     <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.0">
         <IncludeAssets>all</IncludeAssets> <!-- Default is `all`, can be omitted-->
         <ExcludeAssets>contentFiles</ExcludeAssets>
@@ -127,7 +127,7 @@ Allowable values for these tags are as follows, with multiple values separated b
     </PackageReference>
     <!-- ... -->
     <!-- Everything except the compile will be consumed by the project -->
-    <!-- Everythign except contentFiles will flow to the parent project-->
+    <!-- Everything except contentFiles will flow to the parent project-->
     <PackageReference Include="Contoso.Utility.SomeOtherUsefulStuff" Version="3.6.0">
         <ExcludeAssets>compile</ExcludeAssets>
         <PrivateAssets>contentFiles</PrivateAssets>


### PR DESCRIPTION
I noticed a typo while reading this documentation:

https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets

![image](https://user-images.githubusercontent.com/1559108/166148299-e9d3dcc4-d646-4114-b34b-3a1f3c71e860.png)

Now it's fixed.
