### PR TITLE
Add issue management bots

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -67,7 +67,7 @@
           "eventNames": [
             "issue_comment"
           ],
-          "taskName": "[Manage \"WaitingFor\" labels] [4-2] Replace tag \"WaitingForCustomer\" with \"WaitingForNuGetTeam\" when the author comments on an issue. Also remove `Status:No recent activity` if it's been set.",
+          "taskName": "[Manage \"WaitingFor\" labels] Replace tag \"WaitingForCustomer\" with \"WaitingForNuGetTeam\" when the author comments on an issue. Also remove `Status:No recent activity` if it's been set.",
           "actions": [
             {
               "name": "removeLabel",
@@ -130,7 +130,7 @@
             "issues",
             "project_card"
           ],
-          "taskName": "[Manage \"WaitingFor\" labels] [4-3] Remove any \"WaitingFor\" label when the issue is closed",
+          "taskName": "[Manage \"WaitingFor\" labels] Remove any \"WaitingFor\" label when the issue is closed",
           "actions": [
             {
               "name": "removeLabel",
@@ -185,7 +185,7 @@
           "eventNames": [
             "issue_comment"
           ],
-          "taskName": "[Manage \"WaitingFor\" labels] [4-4] Replace tag \"WaitingForNuGetTeam\" with \"WaitingForCustomer\" when NuGet team comments on an issue.",
+          "taskName": "[Manage \"WaitingFor\" labels] Replace tag \"WaitingForNuGetTeam\" with \"WaitingForCustomer\" when NuGet team comments on an issue.",
           "actions": [
             {
               "name": "removeLabel",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,410 @@
+{
+    "version": "1.0",
+    "tasks": [
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "created"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "WaitingForCustomer"
+                }
+              },
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "operator": "and",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "Transferred issue"
+                        }
+                      },
+                      {
+                        "operator": "not",
+                        "operands": [
+                          {
+                            "name": "activitySenderHasPermissions",
+                            "parameters": {
+                              "permissions": "write"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": {
+                        "type": "author"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ],
+          "taskName": "[Manage \"WaitingFor\" labels] [4-2] Replace tag \"WaitingForCustomer\" with \"WaitingForNuGetTeam\" when the author comments on an issue. Also remove `Status:No recent activity` if it's been set.",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "WaitingForCustomer"
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "WaitingForNuGetTeam"
+              }
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            }
+          ]
+        },
+        "disabled": false
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "WaitingForNuGetTeam"
+                    }
+                  },
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "WaitingForCustomer"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "[Manage \"WaitingFor\" labels] [4-3] Remove any \"WaitingFor\" label when the issue is closed",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "WaitingForNuGetTeam"
+              }
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "WaitingForCustomer"
+              }
+            }
+          ]
+        },
+        "disabled": false
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "created"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "WaitingForNuGetTeam"
+                }
+              },
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ],
+          "taskName": "[Manage \"WaitingFor\" labels] [4-4] Replace tag \"WaitingForNuGetTeam\" with \"WaitingForCustomer\" when NuGet team comments on an issue.",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "WaitingForNuGetTeam"
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "WaitingForCustomer"
+              }
+            }
+          ]
+        },
+        "disabled": false
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.0",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "WaitingForCustomer"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 14
+              }
+            },
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "noLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            }
+          ],
+          "taskName": "[Manage stale WaitingForCustomer issues] Search for WaitingForCustomer issues with no activity over 14 days and warn.",
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            },
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue has been automatically marked as stale because we have not received a response in 14 days. It will be closed if no further activity occurs within another 14 days of this comment."
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.0",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                6
+              ],
+              "timezoneOffset": -7
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 14
+              }
+            },
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            }
+          ],
+          "taskName": "[Close stale WaitingForCustomer issues] Search for stale WaitingForCustomer issues with no activity over 14 days and warn.",
+          "actions": [
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Status:No recent activity"
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Resolution:NeedMoreInfo"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "userGroups": []
+  }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Client.Engineering/issues/1754

This adds various tasks: 


- [Manage 'WaitingFor' labels] Replace tag 'WaitingForCustomer' with 'WaitingForNuGetTeam' when the author comments on an issue. Also remove `Status:No recent activity` if it's been set.

- [Manage 'WaitingFor' labels] Remove any 'WaitingFor' label when the issue is closed

- [Manage 'WaitingFor' labels] Replace tag 'WaitingForNuGetTeam' with 'WaitingForCustomer' when NuGet team comments on an issue.

- [Manage stale WaitingForCustomer issues] Search for WaitingForCustomer issues with no activity over 14 days and warn.

- [Close stale WaitingForCustomer issues] Search for stale WaitingForCustomer issues with no activity over 14 days and warn.

