### PR TITLE
Address inconsistency user settings on Mac/Linux

### DIFF
--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -16,8 +16,29 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 | Scope | `NuGet.Config` file location | Description |
 | --- | --- | --- |
 | Solution | Current folder (aka Solution folder) or any folder up to the drive root.| In a solution folder, settings apply to all projects in subfolders. Note that if a config file is placed in a project folder, it has no effect on that project. |
-| User | **Windows:** `%appdata%\NuGet\NuGet.Config`<br/>**Mac/Linux:** `~/.config/NuGet/NuGet.Config` or `~/.nuget/NuGet/NuGet.Config` (varies by OS distribution) <br/>Additional configs are supported on all platforms. These configs cannot be edited by the tooling. </br> **Windows:** `%appdata%\NuGet\config\*.Config` <br/>**Mac/Linux:** `~/.config/NuGet/config/*.config` or `~/.nuget/config/*.config` | Settings apply to all operations, but are overridden by any project-level settings. |
+| User | **Windows:** `%appdata%\NuGet\NuGet.Config`<br/>**Mac/Linux:** `~/.config/NuGet/NuGet.Config` or `~/.nuget/NuGet/NuGet.Config` (varies by tooling, see notes for discrepencies) <br/>Additional configs are supported on all platforms. These configs cannot be edited by the tooling. </br> **Windows:** `%appdata%\NuGet\config\*.Config` <br/>**Mac/Linux:** `~/.config/NuGet/config/*.config` or `~/.nuget/config/*.config` | Settings apply to all operations, but are overridden by any project-level settings. |
 | Computer | **Windows:** `%ProgramFiles(x86)%\NuGet\Config`<br/>**Mac/Linux:** `$XDG_DATA_HOME`. If `$XDG_DATA_HOME` is null or empty, `~/.local/share` or `/usr/local/share` will be used (varies by OS distribution)  | Settings apply to all operations on the computer, but are overridden by any user- or project-level settings. |
+
+> [!Note]
+> On Mac/Linux, the user config file location varies by tooling. Dotnet CLI uses `~/.nuget/NuGet` folder, while Mono uses `~/.config/NuGet` folder. 
+
+### On Mac/Linux, the user-level config file location varies by tooling. 
+On Mac/Linux, the user config file location varies by tooling. 
+Majority users uses tools looking for user config file under `~/.nuget/NuGet` folder. 
+While following tools looks for user config files under `~/.config/NuGet` folder:
+* Mono
+* NuGet.exe
+* Visual Studio 2019 for Mac (and earlier versions)
+* Visual Studio 2022 for Mac, only when working on classic Mono projects.
+
+If the tooling you use involves both locations, consolidating them by following steps allows you to work with only one user-level config file:  
+1. Check the contents of the two user-level config files and keep the one you want under `~/.nuget/NuGet` folder. 
+2. Set symbolic link from `~/.nuget/NuGet` to `~/.config/Nuget`. E.g. Run bash command: `ln -s ~/.nuget/NuGet ~/.config/Nuget`
+
+Why NuGet doesn't fix the inconsistency?
+Majority users uses tooling looking for `~/.nuget/NuGet` folder, so changing this path is of high risk.
+Mono is in maintenance mode. So even if NuGet changes `~/.config/NuGet` folder, the change will not flow to Mono.
+
 
 Notes for earlier versions of NuGet:
 - NuGet 3.3 and earlier used a `.nuget` folder for solution-wide settings. This folder is not used in NuGet 3.4+.
@@ -28,7 +49,7 @@ Notes for earlier versions of NuGet:
 A `NuGet.Config` file is a simple XML text file containing key/value pairs as described in the [NuGet Configuration Settings](../reference/nuget-config-file.md) topic.
 
 Settings are managed using the NuGet CLI [config command](../reference/cli-reference/cli-ref-config.md):
-- By default, changes are made to the user-level config file.
+- By default, changes are made to the user-level config file. (On Mac/Linux, the location of user-level config file varies by tooling)
 - To change settings in a different file, use the `-configFile` switch. In this case files can use any filename.
 - Keys are always case sensitive.
 - Elevation is required to change settings in the computer-level settings file.

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -20,7 +20,7 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 | Computer | **Windows:** `%ProgramFiles(x86)%\NuGet\Config`<br/>**Mac/Linux:** `$XDG_DATA_HOME`. If `$XDG_DATA_HOME` is null or empty, `~/.local/share` or `/usr/local/share` will be used (varies by OS distribution)  | Settings apply to all operations on the computer, but are overridden by any user- or project-level settings. |
 
 > [!Note]
-> On Mac/Linux, the user config file location varies by tooling. Dotnet CLI uses `~/.nuget/NuGet` folder, while Mono uses `~/.config/NuGet` folder. 
+> On Mac/Linux, the user config file location varies by tooling. .NET CLI uses `~/.nuget/NuGet` folder, while Mono uses `~/.config/NuGet` folder. 
 
 ### On Mac/Linux, the user-level config file location varies by tooling. 
 On Mac/Linux, the user config file location varies by tooling. 

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -31,7 +31,7 @@ These other tools look for the user config file under the `~/.config/NuGet` fold
 * Visual Studio 2019 for Mac (and earlier versions)
 * Visual Studio 2022 for Mac (and later versions), only when working on classic Mono projects.
 
-If the tooling you use involves both locations, consolidating them by following steps allows you to work with only one user-level config file:  
+If the tooling you use involves both locations, consider consolidating them by following these steps to allow you to work with only one user-level config file:  
 1. Check the contents of the two user-level config files and keep the one you want under `~/.nuget/NuGet` folder. 
 2. Set symbolic link from `~/.nuget/NuGet` to `~/.config/Nuget`. E.g. Run bash command: `ln -s ~/.nuget/NuGet ~/.config/Nuget`.
 

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -22,7 +22,7 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 > [!Note]
 > On Mac/Linux, the user config file location varies by tooling. .NET CLI uses `~/.nuget/NuGet` folder, while Mono uses `~/.config/NuGet` folder. 
 
-### On Mac/Linux, the user-level config file location varies by tooling. 
+### On Mac/Linux, the user-level config file location varies by tooling
 On Mac/Linux, the user config file location varies by tooling. 
 Majority of users use tools that look for the user config file under the `~/.nuget/NuGet` folder. 
 These other tools look for the user config file under the `~/.config/NuGet` folder:

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -25,7 +25,7 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 ### On Mac/Linux, the user-level config file location varies by tooling. 
 On Mac/Linux, the user config file location varies by tooling. 
 Majority of users use tools that look for the user config file under the `~/.nuget/NuGet` folder. 
-While following tools look for user config files under `~/.config/NuGet` folder:
+These other tools look for the user config file under the `~/.config/NuGet` folder:
 * Mono
 * NuGet.exe
 * Visual Studio 2019 for Mac (and earlier versions)

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -24,7 +24,7 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 
 ### On Mac/Linux, the user-level config file location varies by tooling. 
 On Mac/Linux, the user config file location varies by tooling. 
-Majority users uses tools looking for user config file under `~/.nuget/NuGet` folder. 
+Majority of users use tools that look for the user config file under the `~/.nuget/NuGet` folder. 
 While following tools look for user config files under `~/.config/NuGet` folder:
 * Mono
 * NuGet.exe

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -25,15 +25,16 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 ### On Mac/Linux, the user-level config file location varies by tooling. 
 On Mac/Linux, the user config file location varies by tooling. 
 Majority users uses tools looking for user config file under `~/.nuget/NuGet` folder. 
-While following tools looks for user config files under `~/.config/NuGet` folder:
+While following tools look for user config files under `~/.config/NuGet` folder:
 * Mono
 * NuGet.exe
 * Visual Studio 2019 for Mac (and earlier versions)
-* Visual Studio 2022 for Mac, only when working on classic Mono projects.
+* Visual Studio 2022 for Mac (and later versions), only when working on classic Mono projects.
 
 If the tooling you use involves both locations, consolidating them by following steps allows you to work with only one user-level config file:  
 1. Check the contents of the two user-level config files and keep the one you want under `~/.nuget/NuGet` folder. 
 2. Set symbolic link from `~/.nuget/NuGet` to `~/.config/Nuget`. E.g. Run bash command: `ln -s ~/.nuget/NuGet ~/.config/Nuget`.
+
 
 Notes for earlier versions of NuGet:
 - NuGet 3.3 and earlier used a `.nuget` folder for solution-wide settings. This folder is not used in NuGet 3.4+.

--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -16,7 +16,7 @@ NuGet's behavior is driven by the accumulated settings in one or more `NuGet.Con
 | Scope | `NuGet.Config` file location | Description |
 | --- | --- | --- |
 | Solution | Current folder (aka Solution folder) or any folder up to the drive root.| In a solution folder, settings apply to all projects in subfolders. Note that if a config file is placed in a project folder, it has no effect on that project. |
-| User | **Windows:** `%appdata%\NuGet\NuGet.Config`<br/>**Mac/Linux:** `~/.config/NuGet/NuGet.Config` or `~/.nuget/NuGet/NuGet.Config` (varies by tooling, see notes for discrepencies) <br/>Additional configs are supported on all platforms. These configs cannot be edited by the tooling. </br> **Windows:** `%appdata%\NuGet\config\*.Config` <br/>**Mac/Linux:** `~/.config/NuGet/config/*.config` or `~/.nuget/config/*.config` | Settings apply to all operations, but are overridden by any project-level settings. |
+| User | **Windows:** `%appdata%\NuGet\NuGet.Config`<br/>**Mac/Linux:** `~/.config/NuGet/NuGet.Config` or `~/.nuget/NuGet/NuGet.Config` (varies by tooling) <br/>Additional configs are supported on all platforms. These configs cannot be edited by the tooling. </br> **Windows:** `%appdata%\NuGet\config\*.Config` <br/>**Mac/Linux:** `~/.config/NuGet/config/*.config` or `~/.nuget/config/*.config` | Settings apply to all operations, but are overridden by any project-level settings. |
 | Computer | **Windows:** `%ProgramFiles(x86)%\NuGet\Config`<br/>**Mac/Linux:** `$XDG_DATA_HOME`. If `$XDG_DATA_HOME` is null or empty, `~/.local/share` or `/usr/local/share` will be used (varies by OS distribution)  | Settings apply to all operations on the computer, but are overridden by any user- or project-level settings. |
 
 > [!Note]
@@ -33,12 +33,7 @@ While following tools looks for user config files under `~/.config/NuGet` folder
 
 If the tooling you use involves both locations, consolidating them by following steps allows you to work with only one user-level config file:  
 1. Check the contents of the two user-level config files and keep the one you want under `~/.nuget/NuGet` folder. 
-2. Set symbolic link from `~/.nuget/NuGet` to `~/.config/Nuget`. E.g. Run bash command: `ln -s ~/.nuget/NuGet ~/.config/Nuget`
-
-Why NuGet doesn't fix the inconsistency?
-Majority users uses tooling looking for `~/.nuget/NuGet` folder, so changing this path is of high risk.
-Mono is in maintenance mode. So even if NuGet changes `~/.config/NuGet` folder, the change will not flow to Mono.
-
+2. Set symbolic link from `~/.nuget/NuGet` to `~/.config/Nuget`. E.g. Run bash command: `ln -s ~/.nuget/NuGet ~/.config/Nuget`.
 
 Notes for earlier versions of NuGet:
 - NuGet 3.3 and earlier used a `.nuget` folder for solution-wide settings. This folder is not used in NuGet 3.4+.

--- a/docs/reference/cli-reference/cli-ref-config.md
+++ b/docs/reference/cli-reference/cli-ref-config.md
@@ -35,7 +35,7 @@ In NuGet 3.4+, `<value>` can use [environment variables](cli-ref-environment-var
 
 - **`-ConfigFile`**
 
-  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](../../consume-packages/configuring-nuget-behavior.md#on-maclinux-the-user-level-config-file-location-varies-by-tooling).
 
 - **`-ForceEnglishOutput`**
 

--- a/docs/reference/cli-reference/cli-ref-setapikey.md
+++ b/docs/reference/cli-reference/cli-ref-setapikey.md
@@ -29,7 +29,7 @@ where `<source>` identifies the server and `<key>` is the key to save. If `<sour
 
 - **`-ConfigFile`**
 
-  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](../../consume-packages/configuring-nuget-behavior.md#on-maclinux-the-user-level-config-file-location-varies-by-tooling).
 
 - **`-ForceEnglishOutput`**
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -27,7 +27,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
 - **`-ConfigFile`**
 
-  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](../../consume-packages/configuring-nuget-behavior.md#on-maclinux-the-user-level-config-file-location-varies-by-tooling).
 
 - **`-ForceEnglishOutput`**
 

--- a/docs/reference/cli-reference/cli-ref-trusted-signers.md
+++ b/docs/reference/cli-reference/cli-ref-trusted-signers.md
@@ -135,7 +135,7 @@ _Note_: This gesture will delete the current list of certificates and replace th
 
 - **`-ConfigFile`**
 
-  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used.
+  The NuGet configuration file to apply. If not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](../../consume-packages/configuring-nuget-behavior.md#on-maclinux-the-user-level-config-file-location-varies-by-tooling).
 
 - **`-ForceEnglishOutput`**
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2822

Update [Common NuGet configurations](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior), explaining the inconsistency and providing the workaround of manually consolidating the two paths into one by setting up symbolic link.
Add the link of inconsistency in all the NuGet.exe commands which changes the user-wide NuGet.Config file:
[NuGet.exe config](https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) command
[NuGet.exe sources](https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-sources) command
[NuGet.exe setapikey](https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-setapikey) command