### PR TITLE
Mention about NuGet.PackageSourcemapper tool for package source mapping feature

### DIFF
--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -100,7 +100,11 @@ To learn more about how package installation works, see [the conceptual document
 
 ### Get started
 
-To fully onboard your repository you can do it 2 ways either manually or automated [NuGet.PackageSourceMapper tool](https://www.nuget.org/packages/NuGet.PackageSourceMapper/0.1.3-preview.22218.1#readme-body-tab), for manual onboarding you may take the following steps.
+To fully onboard your repository you can do it 2 ways either manually or automated tool.
+
+#### Manual onboarding
+
+For manual onboarding you may take the following steps:
 
 1. Declare a new [global packages folder for your repo](../reference/nuget-config-file.md#config-section).
 1. Run [`dotnet list package --include-transitive`](/dotnet/core/tools/dotnet-list-package#synopsis) to view all top-level and transitive packages in your solution.
@@ -111,8 +115,12 @@ To fully onboard your repository you can do it 2 ways either manually or automat
     * Simplifying the configuration to fewer declarations by using broader package ID prefixes or [setting a default source](#setting-default-sources) where possible.
     * Verifying the source each package was restored from by checking the [metadata files in the global packages folder or reviewing the restore logs](https://devblogs.microsoft.com/nuget/performance-and-polish-with-nuget-5-9/).
 
-For an idea of how your source mappings may look like, refer to our [samples repo](https://github.com/NuGet/Samples/tree/main/PackageSourceMappingExample).
+#### Automated onboarding using tool
 
+For large solution with a many packages above manual onboarding could be time consuming and error prone. We developed [NuGet.PackageSourceMapper tool](https://www.nuget.org/packages/NuGet.PackageSourceMapper) automatically generate a NuGet.config for you based on your project’s known packages and sources. The package source mapper tool requires you to have completed a successful package restore in which it will read each respective `.nupkg.metadata` file generated as part of your build to best understand how you map your respective packages and sources. Tool not only covers top dependencies it also considers all the transitive dependencies when generating mapping.
+Tool has several option how to generate mapping pattern depending on your need, please check [blog post](https://devblogs.microsoft.com/nuget/quickly-map-your-nuget-packages-to-sources) and tool's [readme instruction](https://www.nuget.org/packages/NuGet.PackageSourceMapper#readme-body-tab) for more details.
+
+For an idea of how your source mappings may look like, refer to our [samples repo](https://github.com/NuGet/Samples/tree/main/PackageSourceMappingExample).
 
 > [!Note]
 > This feature is in active development. We appreciate you trying it out and providing any feedback you may have at [NuGet/Home](https://github.com/nuget/home/issues).

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -100,7 +100,7 @@ To learn more about how package installation works, see [the conceptual document
 
 ### Get started
 
-There are 2 ways you can fully onboard your repository, manually or using the NuGet.PackageSourceMapper tool.
+There are 2 ways you can fully onboard your repository, [manually](#manual-onboarding) or using the [NuGet.PackageSourceMapper tool](#automated-onboarding-using-tool).
 
 #### Manual onboarding
 
@@ -117,7 +117,10 @@ For manual onboarding you may take the following steps:
 
 #### Automated onboarding using tool
 
-For large solution with a many packages above manual onboarding could be time consuming and error prone. We developed [NuGet.PackageSourceMapper tool](https://www.nuget.org/packages/NuGet.PackageSourceMapper) automatically generate a NuGet.config for you based on your project’s known packages and sources. The package source mapper tool requires you to have completed a successful package restore in which it will read each respective `.nupkg.metadata` file generated as part of your build to best understand how you map your respective packages and sources. Tool not only covers top dependencies it also considers all the transitive dependencies when generating mapping.
+Many repositories have a large number of packages and doing the work manually can be time consuming. The [NuGet.PackageSourceMapper tool](https://www.nuget.org/packages/NuGet.PackageSourceMapper) can automatically generate a NuGet.config for you, based on your project's known packages and sources. 
+
+The package source mapper tool requires you to have completed a successful package restore in which it will read each respective `.nupkg.metadata` file generated as part of your build to best understand how you map your respective packages and sources. Tool not only covers top dependencies it also considers all the transitive dependencies when generating mapping.
+
 Tool has several option how to generate mapping pattern depending on your need, please check [blog post](https://devblogs.microsoft.com/nuget/quickly-map-your-nuget-packages-to-sources) and tool's [readme instruction](https://www.nuget.org/packages/NuGet.PackageSourceMapper#readme-body-tab) for more details.
 
 For an idea of how your source mappings may look like, refer to our [samples repo](https://github.com/NuGet/Samples/tree/main/PackageSourceMappingExample).

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -100,7 +100,7 @@ To learn more about how package installation works, see [the conceptual document
 
 ### Get started
 
-To fully onboard your repository you may take the following steps:
+To fully onboard your repository you can do it 2 ways either manually or automated [NuGet.PackageSourceMapper tool](https://www.nuget.org/packages/NuGet.PackageSourceMapper/0.1.3-preview.22218.1#readme-body-tab), for manual onboarding you may take the following steps.
 
 1. Declare a new [global packages folder for your repo](../reference/nuget-config-file.md#config-section).
 1. Run [`dotnet list package --include-transitive`](/dotnet/core/tools/dotnet-list-package#synopsis) to view all top-level and transitive packages in your solution.

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -100,7 +100,7 @@ To learn more about how package installation works, see [the conceptual document
 
 ### Get started
 
-To fully onboard your repository you can do it 2 ways either manually or automated tool.
+There are 2 ways you can fully onboard your repository, manually or using the NuGet.PackageSourceMapper tool.
 
 #### Manual onboarding
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2779

To create visibility for [NuGet.PackageSourceMapper tool](https://www.nuget.org/packages/NuGet.PackageSourceMapper/0.1.3-preview.22218.1#readme-body-tab) mention it in doc. It'll drive customers onboarding to reducing time they spend on creating source mapping patterns.