### PR TITLE
Adding SSL.com CA

### DIFF
--- a/docs/create-packages/Sign-a-Package.md
+++ b/docs/create-packages/Sign-a-Package.md
@@ -14,7 +14,7 @@ Signed packages allows for content integrity verification checks which provides 
 
 ## Get a code signing certificate
 
-Valid certificates may be obtained from a public certificate authority such as [DigiCert](https://www.digicert.com/code-signing/), [Global Sign](https://www.globalsign.com/en/code-signing-certificate/), [Comodo](https://www.comodo.com/e-commerce/code-signing/code-signing-certificate.php), [Certum](https://www.certum.eu/certum/cert,offer_en_open_source_cs.xml), etc. The complete list of certification authorities trusted by Windows can be obtained from [http://aka.ms/trustcertpartners](/security/trusted-root/participants-list).
+Valid certificates may be obtained from a public certificate authority such as [SSL.com](https://www.ssl.com/certificates/code-signing/), [DigiCert](https://www.digicert.com/code-signing/), [Global Sign](https://www.globalsign.com/en/code-signing-certificate/), [Comodo](https://www.comodo.com/e-commerce/code-signing/code-signing-certificate.php), [Certum](https://www.certum.eu/certum/cert,offer_en_open_source_cs.xml), etc. The complete list of certification authorities trusted by Windows can be obtained from [http://aka.ms/trustcertpartners](/security/trusted-root/participants-list).
 
 You can use self-issued certificates for testing purposes. However, packages signed using self-issued certificates are not accepted by NuGet.org. Learn more about [creating a test certificate](#create-a-test-certificate)
 


### PR DESCRIPTION
SSL.com is a participant in the Microsoft Root CA program and is also referenced in other code signing related pages (see https://docs.microsoft.com/en-us/windows-hardware/drivers/dashboard/code-signing-cert-manage)