### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@
 
 # @NuGet/core-team owns any file in the `/docs/nuget-org/` directory
 # in the root of your repository and any of its subdirectories.
-/docs/nuget-org/ @NuGet/core-team
+/docs/nuget-org/ @NuGet/nuget-client @NuGet/nuget-pm @NuGet/gallery-team
 
 # @NuGet/core-team owns any file in the `/docs/policies/` directory
 # in the root of your repository and any of its subdirectories.
-/docs/policies/ @NuGet/core-team
+/docs/policies/ @NuGet/nuget-client @NuGet/nuget-pm @NuGet/gallery-team


### PR DESCRIPTION
Fix codeowners by using the correct alias. 

The previous alias wasn't public and I don't want to change that personally, so this is a great alternate solution