### PR TITLE
[BULK UPDATE] DocuTune - Rebranding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ No contribution is too big or too small.
 1. Edit the markdown:
     1. If you're including images (use PNGs, generally), place them in the media folder that's in the topic's folder. Links are then `media/<image_name>.png`.
     1. Relative links to other pages in this docset should be in the form `../<folder>/<topic-file>.md` including the training `.md`. If you're linking to another topic in the same folder, then `../<folder>/` can be omitted. When using anchors, always remember to include the `.md` before the `#`.
-    1. When using external links, especially to Microsoft Docs (or msdn.microsoft.com for any older content), omit any language tag like "en-us" so that a reader in another language lands on a target page in that same language if it's available.
+    1. When using external links, especially to Microsoft Learn, omit any language tag like "en-us" so that a reader in another language lands on a target page in that same language if it's available.
 1. When you're done, enter a commit message below, and click **Propose file change**.
 1. Send a pull request for your change. We review PRs on a regular basis.
 1. Thank you!
@@ -12,17 +12,20 @@ No contribution is too big or too small.
 If you're creating a new topic, keep the following in mind as well:
 
 1. Always place the new topic in an appropriate subfolder, and follow the conventions for filenames as you see them used here.
-1. You must include a metadata block as you see on other topics. Typical defaults (such as for ms.workload and ms.reviewer) are set within docs/docjx.json, so you need only change the following:
 
-  - title: The title that appears in search results. For SEO, this ideally isn't the same as the top-level # (H1) of the article.
-  - description: The abstract of the article that appears in search results.
-  - author: the author's GitHub ID, to which issues files for this article are assigned.
-  - ms.author: if the author is a Microsoft employee, this is the Microsoft alias. Used for reporting and forwarding feedback from other channels.
-  - manager: Microsoft alias of the author's manager, if applicable.
-  - ms.date: the date of the last revision or review of the article in mm/dd/yyyy format (use leading zeros). This is a communication to the reader about freshness, so it's not updated for minor changes, only for more significant revisions OR when the article has reverified even if there are no changes.
-  - ms.topic: used to categorize the article in reports. See table below. Most articles are "conceptual". 
-1. In addition to adding your page, edit docs/TOC.md to add a link to that page.
-1. If you're adding a top-level node to the TOC, also make an entry for it in docs/index.md.
+1. You must include a metadata block as you see on other topics. Typical defaults (such as for `ms.workload` and `ms.reviewer`) are set within `docs/docjx.json`, so you need only change the following:
+
+   - title: The title that appears in search results. For SEO, this ideally isn't the same as the top-level # (H1) of the article.
+   - description: The abstract of the article that appears in search results.
+   - author: the author's GitHub ID, to which issues files for this article are assigned.
+   - ms.author: if the author is a Microsoft employee, this is the Microsoft alias. Used for reporting and forwarding feedback from other channels.
+   - manager: Microsoft alias of the author's manager, if applicable.
+   - ms.date: the date of the last revision or review of the article in mm/dd/yyyy format (use leading zeros). This is a communication to the reader about freshness, so it's not updated for minor changes, only for more significant revisions OR when the article has reverified even if there are no changes.
+   - ms.topic: used to categorize the article in reports. See table below. Most articles are "conceptual". 
+
+1. In addition to adding your page, edit `docs/TOC.md` to add a link to that page.
+
+1. If you're adding a top-level node to the TOC, also make an entry for it in `docs/index.md`.
 
 | ms.topic category | Description |
 | --- | --- |
@@ -31,4 +34,4 @@ If you're creating a new topic, keep the following in mind as well:
 | quickstart | Anything under the "Quickstart" node in the TOC that's authored according to Quickstart guidelines. |
 | tutorial | Anything under the "Tutorial" node in the TOC that's authored according to Tutorial guidelines. |
 | reference | Any reference-type article that isn't auto-generated. |
-| article | Use for community-contributed content (that is, anything from outside the engineering team or the docs team at Microsoft. |
+| article | Use for community-contributed content (that is, anything from outside the engineering team or the content team at Microsoft. |

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 The NuGet documentation contained in this repository is hosted in [NuGet documentation](https://learn.microsoft.com/nuget/). This repository was migrated from the former NuGetDocs repository, https://github.com/NuGet/NuGetDocs, which is no longer in active use.
 
-Contributions to this docset are welcome. Please submit PRs to the *main* branch. The main branch is used for staging changes which is periodically merged into the *live* branch which is what's published to the live docs site.
+Contributions to this docset are welcome. Please submit PRs to the *main* branch. The main branch is used for staging changes which is periodically merged into the *live* branch which is what's published to the live Microsoft Learn site.
 
 NuGet follows the [.NET Foundation Contributors Code of Conduct](https://github.com/dotnet/home/blob/master/guidance/be-nice.md). Please take a few minutes to review it.
 
 ## Repository structure
 
-- All markdown files are in the docs folder and various subfolders.
-- The docs/index.md file defines the landing (hub) page as it appears in the [NuGet documentation](https://learn.microsoft.com/nuget).
-- The docs/TOC.md file defines the left-hand navigation panel that appears when you navigate to any page other than the hub page.
+- All markdown files are in the `docs` folder and various subfolders.
+- The `docs/index.md` file defines the landing (hub) page as it appears in the [NuGet documentation](https://learn.microsoft.com/nuget).
+- The `docs/TOC.md` file defines the left-hand navigation panel that appears when you navigate to any page other than the hub page.
 - Images are contained within media folders within each subfolder.
-- The docs/docfx.json file contains various defaults, especially for metadata.
-- The docs/.openpublishing.redirection.json file contains redirects for old filenames; if you rename a file, create an entry here that maps the old to the new.
-- The docs/_breadcrumb/toc.yml file defines the breadcrumbs that appear on the site and their target pages. Be mindful of this if you make changes to filenames or placement of articles.
+- The `docs/docfx.json` file contains various defaults, especially for metadata.
+- The `docs/.openpublishing.redirection.json` file contains redirects for old filenames; if you rename a file, create an entry here that maps the old to the new.
+- The `docs/_breadcrumb/toc.yml` file defines the breadcrumbs that appear on the site and their target pages. Be mindful of this if you make changes to filenames or placement of articles.
 
 ## Contribution workflow
 
@@ -24,27 +24,30 @@ No contribution is too big or too small.
 1. Edit the markdown:
     1. If you're including images (use PNGs, generally), place them in the media folder that's in the topic's folder. Links are then `media/<image_name>.png`.
     1. Relative links to other pages in this docset should be in the form `../<folder>/<topic-file>.md` including the training `.md`. If you're linking to another topic in the same folder, then `../<folder>/` can be omitted. When using anchors, always remember to include the `.md` before the `#`.
-    1. When using external links, especially to Microsoft Docs (or msdn.microsoft.com for any older content), omit any language tag like "en-us" so that a reader in another language lands on a target page in that same language if it's available.
+    1. When using external links, especially to Microsoft Learn, omit any language tag like "en-us" so that a reader in another language lands on a target page in that same language if it's available.
 1. When you're done, enter a commit message below, and click **Propose file change**.
 1. Send a pull request for your change. We review PRs on a regular basis.
 1. Thank you!
 
-> **If your content is not live yet, there is a manual `main` -> `live` pull request that is needed to pick-up the changes. Please create a PR or ping a docs owner to do so on your behalf.**
+> **If your content is not live yet, there is a manual `main` -> `live` pull request that is needed to pick-up the changes. Please create a PR or ping a content owner to do so on your behalf.**
 
 If you're creating a new topic, keep the following in mind as well:
 
 1. Always place the new topic in an appropriate subfolder, and follow the conventions for filenames as you see them used here.
-1. You must include a metadata block as you see on other topics. Typical defaults (such as for ms.workload and ms.reviewer) are set within docs/docjx.json, so you need only change the following:
 
-  - title: The title that appears in search results. For SEO, this ideally isn't the same as the top-level # (H1) of the article.
-  - description: The abstract of the article that appears in search results.
-  - author: the author's GitHub ID, to which issues files for this article are assigned.
-  - ms.author: if the author is a Microsoft employee, this is the Microsoft alias. Used for reporting and forwarding feedback from other channels.
-  - manager: Microsoft alias of the author's manager, if applicable.
-  - ms.date: the date of the last revision or review of the article in mm/dd/yyyy format (use leading zeros). This is a communication to the reader about freshness, so it's not updated for minor changes, only for more significant revisions OR when the article has reverified even if there are no changes.
-  - ms.topic: used to categorize the article in reports. See table below. Most articles are "conceptual". 
-1. In addition to adding your page, edit docs/TOC.md to add a link to that page.
-1. If you're adding a top-level node to the TOC, also make an entry for it in docs/index.md.
+1. You must include a metadata block as you see on other topics. Typical defaults (such as for `ms.workload` and `ms.reviewer`) are set within `docs/docjx.json`, so you need only change the following:
+
+   - title: The title that appears in search results. For SEO, this ideally isn't the same as the top-level # (H1) of the article.
+   - description: The abstract of the article that appears in search results.
+   - author: the author's GitHub ID, to which issues files for this article are assigned.
+   - ms.author: if the author is a Microsoft employee, this is the Microsoft alias. Used for reporting and forwarding feedback from other channels.
+   - manager: Microsoft alias of the author's manager, if applicable.
+   - ms.date: the date of the last revision or review of the article in mm/dd/yyyy format (use leading zeros). This is a communication to the reader about freshness, so it's not updated for minor changes, only for more significant revisions OR when the article has reverified even if there are no changes.
+   - ms.topic: used to categorize the article in reports. See table below. Most articles are "conceptual". 
+
+1. In addition to adding your page, edit `docs/TOC.md` to add a link to that page.
+
+1. If you're adding a top-level node to the TOC, also make an entry for it in `docs/index.md`.
 
 | ms.topic category | Description |
 | --- | --- |
@@ -53,7 +56,7 @@ If you're creating a new topic, keep the following in mind as well:
 | quickstart | Anything under the "Quickstart" node in the TOC that's authored according to Quickstart guidelines. |
 | tutorial | Anything under the "Tutorial" node in the TOC that's authored according to Tutorial guidelines. |
 | reference | Any reference-type article that isn't auto-generated. |
-| article | Use for community-contributed content (that is, anything from outside the engineering team or the docs team at Microsoft. |
+| article | Use for community-contributed content (that is, anything from outside the engineering team or the content team at Microsoft. |
 
 ## Conventions
 
@@ -61,7 +64,7 @@ In general, if you don't see something described here, look in editing markdown 
 
 ## Language level and terms
 
-Because our docs can be localized into many languages other than English, topics should be written at what's called the "fifth-grade" reading level, or what a typical 11-12-year-old child would understand. In other words, avoid using college-level words if possible.
+Because content can be localized into many languages other than English, topics should be written at what's called the "fifth-grade" reading level, or what a typical 11-12-year-old child would understand. In other words, avoid using college-level words if possible.
 
 To keep the tone more casual, use contractions like "you'll" and "don't".
 
@@ -98,7 +101,7 @@ With boldface used for UI elements, use *italics* for emphasis in the text.
 
 ### Tables
 
-Use standard markdown tables, starting with "| heading | heading | heading |", followed by "| --- | --- | --- |", followed by your rows. The row with "---" is necessary for Microsoft Docs to read the markdown as a table.
+Use standard markdown tables, starting with "| heading | heading | heading |", followed by "| --- | --- | --- |", followed by your rows. The row with "---" is necessary for Microsoft Learn to read the markdown as a table.
 
 Items in the first column are bolded by default, so you don't need to do that explicitly.
 
@@ -130,7 +133,7 @@ Markdown and HTML are ignored within inline code.
 
 ### Code blocks
 
-Code blocks on Microsoft Docs are delineated by with three grave accents (backticks), ```, at the beginning and the end. You do not need to indent code blocks unless they are contained within a list.
+Code blocks on Microsoft Learn are delineated by with three grave accents (backticks), ```, at the beginning and the end. You do not need to indent code blocks unless they are contained within a list.
 
 The opening ``` should be followed by a language code for proper syntax coloring, such as "xml", "json", "csharp", etc. Use "cli" for command-line examples and "output" for command-line results.
 
@@ -138,7 +141,7 @@ The only case when you should use ``` without a language tag is when creating a 
 
 ### Callouts
 
-Microsoft Docs uses blockquotes for callouts, that is, lines starting with ">".
+Microsoft Learn uses blockquotes for callouts, that is, lines starting with ">".
 
 Callout sections with ">" only will appear with a solid gray line to the left. See [Creating NuGet packages](https://learn.microsoft.com/nuget/create-packages/creating-a-package) for examples.
 
@@ -155,10 +158,10 @@ You can also use one of the following callout tags on the first line that will c
 
 - In general, always use the title of the target page as the link text rather than words like "see here" or "this documentation".
 - Relative links to other pages in this docset should be in the form `../<folder>/<topic-file>.md` including the trailing `.md`.
-- Links to other markdown files on Microsoft Docs are case-insensitive (unlike links to files in GitHub, which are).
+- Links to other markdown files on Microsoft Learn are case-insensitive (unlike links to files in GitHub, which are).
 - If you're linking to another topic in the same folder, then `../<folder>/` can be omitted.
 - When using anchors, always remember to include the `.md` before the `#`.
-- When using external links, especially to Microsoft Docs (or msdn.microsoft.com for any older content), omit any language tag like "en-us" so that a reader in another language lands on a target page in that same language if it's available.
+- When using external links, especially to Microsoft Learn, omit any language tag like "en-us" so that a reader in another language lands on a target page in that same language if it's available.
 - Bare URLs are not automatically converted into links.
 
 ### Inline HTML


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
