### PR TITLE
[METADATA UPDATE] Global metadata changes

### DIFF
--- a/docs/api/symbol-package-publish-resource.md
+++ b/docs/api/symbol-package-publish-resource.md
@@ -5,7 +5,6 @@ ms.author: cmanu
 manager: skofman
 ms.date: 10/30/2018
 ms.topic: reference
-ms.prod: nuget
 ms.technology: null
 description: The publish service allows clients to publish new symbol packages.
 keywords: NuGet API push symbol package

--- a/docs/create-packages/Symbol-Packages-snupkg.md
+++ b/docs/create-packages/Symbol-Packages-snupkg.md
@@ -5,7 +5,6 @@ ms.author: jodou
 manager: skofman
 ms.date: 10/30/2018
 ms.topic: reference
-ms.prod: nuget
 ms.technology: null
 description: How to create NuGet symbol packages (snupkg).
 keywords: NuGet symbol packages, NuGet package debugging, supporting NuGet debugging, package symbols, symbol package conventions

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -33,13 +33,13 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
+      "ms.service": "nuget",
       "feedback_system": "GitHub",
       "feedback_github_repo": "NuGet/docs.microsoft.com-nuget",
       "feedback_product_url": "https://github.com/NuGet/Home/issues/",
       "breadcrumb_path": "~/_breadcrumb/toc.yml",
       "ROBOTS": "INDEX,FOLLOW",
       "ms.topic": "conceptual",
-      "ms.prod": "nuget",
       "author": "JonDouglas",
       "ms.author": "jodou",
       "ms.reviewer": [


### PR DESCRIPTION
This Pull Request was generated automatically as part of a global effort to improve metadata quality. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about these metadata updates, please contact docs-allowlist-mgmt@microsoft.com. If you are not the correct contact for this content and repository, please notify Metadata-Management@microsoft.com.

Fixing[#587128 Remove ms.prod value nuget](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/587128)

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update.Please notify Metadata-Management@microsoft.com if you would like Pull Requests for metadata updates to merge automatically in future.

After you accept changes of metadata used in reports and they're merged, standard dashboards and reports will reflect new values, so you'll need to use new filter values.If you have any custom dashboards or Kusto queries, you might need to update those also.



**Why we make metadata updates**
Metadata updates are a normal part of business.For example, we update our metadata to reflect a new product name when a product is rebranded.Metadata updates require content to be updated because some metadata values(slugs) are included in the content(YAML header).
For metadata used internally, these updates make reports cleaner, easier to use, more consistent, and more reflective of current business.For metadata exposed to Learn Platform users, these updates ensure our users are exposed to up-to-date information consistent with their overall Microsoft experience.

**Frequently Asked Questions**
Why does this Pull Request appear to be made by the Repository Owner? We open Pull Requests two different ways.For Git Repos with a permissioned Service Account, we open the request from our org's Service Account.For Git Repos that we either do not have Service Account permission for or the repo is in Azure Dev Ops(ADO) we are able to open the Pull Requests in an automated way, but only with the PR creator as the Repo owner.