### PR TITLE
Update VS extensibility docs

### DIFF
--- a/docs/visual-studio-extensibility/nuget-api-in-visual-studio.md
+++ b/docs/visual-studio-extensibility/nuget-api-in-visual-studio.md
@@ -744,6 +744,8 @@ public interface IRegistryKey
         /// <param name="project">The project to check for NuGet package.</param>
         /// <param name="id">The id of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id);
 
@@ -754,6 +756,8 @@ public interface IRegistryKey
         /// <param name="id">The id of the package to check.</param>
         /// <param name="version">The version of the package to check.</param>
         /// <returns><c>true</c> if the package is install. <c>false</c> otherwise.</returns>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalled(Project project, string id, SemanticVersion version);
 
@@ -769,6 +773,8 @@ public interface IRegistryKey
         /// when client project compiles against this assembly, the compiler would attempt to bind against
         /// the other overload which accepts SemanticVersion and would require client project to reference NuGet.Core.
         /// </remarks>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead, and check the specific package you're interested in")]
         bool IsPackageInstalledEx(Project project, string id, string versionString);
 
@@ -776,6 +782,8 @@ public interface IRegistryKey
         /// Get the list of NuGet packages installed in the specified project.
         /// </summary>
         /// <param name="project">The project to get NuGet packages from.</param>
+        /// <exception cref="InvalidOperationException">A "project not nominated" exception will be thrown if the project system has not yet told NuGet about the project.
+        /// You can use <see cref="IVsNuGetProjectUpdateEvents"/> or Microsoft.VisualStudio.OperationProgress to be notified when the project is ready.</exception>
         [Obsolete("This method can cause UI delays if called on the UI thread. Use INuGetProjectService.GetInstalledPackagesAsync in the NuGet.VisualStudio.Contracts package instead")]
         IEnumerable<IVsPackageMetadata> GetInstalledPackages(Project project);
     }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2697

* Update XMLDoc for `IVsPackageInstallerServices`
* Add note about solution load & SDK style projects, explaining to wait until project is loaded before calling NuGet APIs.