### PR TITLE
Suggest a more generally appropriate import tag

### DIFF
--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -92,7 +92,7 @@ Repository
 - Project1 will evaluate the `Directory.Packages.props` file in the `Repository\Solution1\` directory and it must manually import the next one if so desired.
   ```xml
   <Project>
-    <Import Project="..\Directory.Packages.props">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, Directory.Packages.props))\Directory.Packages.props" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, Directory.Packages.props))' != '' " />
     <ItemGroup>
       <PackageVersion Update="Newtonsoft.Json" Version="12.0.1" />
     </ItemGroup>


### PR DESCRIPTION
The sample import assumes the next parent level import comes from one directory above. My proposed change will work regardless of the number of directories that separate the two levels.