### PR TITLE
Add mention for nuget.exe spec default to MIT License

### DIFF
--- a/docs/reference/cli-reference/cli-ref-spec.md
+++ b/docs/reference/cli-reference/cli-ref-spec.md
@@ -11,7 +11,7 @@ ms.topic: reference
 
 **Applies to:** package creation &bullet; **Supported versions:** all
 
-Generates a `.nuspec` file for a new package. If run in the same folder as a project file (`.csproj`, `.vbproj`, `.fsproj`), `spec` creates a tokenized `.nuspec` file. For additional information, see [Creating a Package](../../create-packages/creating-a-package.md).
+Generates a `.nuspec` file for a new package. If run in the same folder as a project file (`.csproj`, `.vbproj`, `.fsproj`), `spec` creates a tokenized `.nuspec` file, that defaults to the MIT License. For additional information, see [Creating a Package](../../create-packages/creating-a-package.md).
 
 ## Usage
 


### PR DESCRIPTION
Acknowledging that nuget.exe spec with version 6.0.0 of the client, yields a .nuspec that defaults to MIT license. This PR fixes #2704 