### PR TITLE
Correct RestoreIgnoreFailedSources example

### DIFF
--- a/docs/reference/msbuild-targets.md
+++ b/docs/reference/msbuild-targets.md
@@ -460,7 +460,7 @@ Project file:
 
 ```xml
 <PropertyGroup>
-    <RestoreIgnoreFailedSource>true</RestoreIgnoreFailedSource>
+    <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
It's `RestoreIgnoreFailedSources` not `RestoreIgnoreFailedSource`, so corrected the example:
![image](https://user-images.githubusercontent.com/8766776/206302678-c29be927-b2f8-4ba6-9129-2f52e5615ba8.png)
