### PR TITLE
update the step to find the pack option in project context menu

### DIFF
--- a/docs/quickstart/create-and-publish-a-package-using-visual-studio.md
+++ b/docs/quickstart/create-and-publish-a-package-using-visual-studio.md
@@ -96,7 +96,7 @@ To create a NuGet package from your project, follow these steps:
 
 1. Select **Build** > **Configuration Manager**, and then set the **Active solution configuration** to **Release**.
 
-1. Select the AppLogger project in **Solution Explorer**, and then select **Pack**.
+1. Select the AppLogger project in **Solution Explorer**, then select **Pack**.
 
     Visual Studio builds the project and creates the *.nupkg* file.
 

--- a/docs/quickstart/create-and-publish-a-package-using-visual-studio.md
+++ b/docs/quickstart/create-and-publish-a-package-using-visual-studio.md
@@ -96,7 +96,7 @@ To create a NuGet package from your project, follow these steps:
 
 1. Select **Build** > **Configuration Manager**, and then set the **Active solution configuration** to **Release**.
 
-1. Select the AppLogger project in **Solution Explorer**, and then select **Build** > **Pack**.
+1. Select the AppLogger project in **Solution Explorer**, and then select **Pack**.
 
     Visual Studio builds the project and creates the *.nupkg* file.
 


### PR DESCRIPTION
In visual studio, **Pack** is not an option under **Build**, so having the step as **Build** >  **Pack** is misleading.

The image below is from Visual Studio version 17.4.3

![image](https://user-images.githubusercontent.com/43586181/213911311-68a575e4-74dd-4686-9846-0343687af384.png)
