### PR TITLE
Fix CentralPackageVersionOverrideEnabled

### DIFF
--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -153,12 +153,12 @@ defined centrally.
 </Project>
 ```
 
-You can disable this feature by setting the MSBuild property `EnablePackageVersionOverride` to `false` in a project or in a `Directory.Packages.props` or
+You can disable this feature by setting the MSBuild property `CentralPackageVersionOverrideEnabled` to `false` in a project or in a `Directory.Packages.props` or
 `Directory.Build.props` import file:
 
 ```xml
 <PropertyGroup>
-  <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
+  <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
Fix references to `EnablePackageVersionOverride` as the correct property name `CentralPackageVersionOverrideEnabled`

Fixes https://github.com/NuGet/Home/issues/12445
Fixes https://github.com/NuGet/docs.microsoft.com-nuget/issues/2878