### PR TITLE
Add alternative syntax for minimum version inclusive range

### DIFF
--- a/docs/concepts/Package-Versioning.md
+++ b/docs/concepts/Package-Versioning.md
@@ -104,6 +104,7 @@ When referring to package dependencies, NuGet supports using interval notation f
 | Notation | Applied rule | Description |
 |----------|--------------|-------------|
 | 1.0 | x ≥ 1.0 | Minimum version, inclusive |
+| [1.0,) | x ≥ 1.0 | Minimum version, inclusive |
 | (1.0,) | x > 1.0 | Minimum version, exclusive |
 | [1.0] | x == 1.0 | Exact version match |
 | (,1.0] | x ≤ 1.0 | Maximum version, inclusive |


### PR DESCRIPTION
From what I can tell, there are two equivalent syntaxes for defining a minimum version (inclusive) - `1.0` and `[1.0,)`. This causes some confusion when tools are configured to use one syntax, but developers are more familiar with the other (examples: [1](https://stackoverflow.com/q/73976129/4051181), [2](https://stackoverflow.com/q/74052349/4051181)). 

Only one of these syntaxes is listed in the documentation. This PR adds the other one.