### PR TITLE
Update Index.md with NuGet 6.5 Release Notes

### DIFF
--- a/docs/release-notes/Index.md
+++ b/docs/release-notes/Index.md
@@ -11,6 +11,8 @@ ms.topic: conceptual
 
 [Known Issues](../release-notes/known-issues.md)
 
+[NuGet 6.5](../release-notes/NuGet-6.5.md)
+
 [NuGet 6.4](../release-notes/NuGet-6.4.md)
 
 [NuGet 6.3](../release-notes/NuGet-6.3.md)


### PR DESCRIPTION
Adds the NuGet 6.5 Release Notes link to the index page.