### PR TITLE
Add JetBrains Space to the ecosystem links

### DIFF
--- a/docs/policies/Ecosystem.md
+++ b/docs/policies/Ecosystem.md
@@ -35,6 +35,7 @@ Many other individuals and companies have made significant contributions to the 
 - [Chocolatey](https://chocolatey.org/)
 - [CoApp](http://coapp.org/)
 - [JetBrains ReSharper](https://resharper-plugins.jetbrains.com/)
+- [JetBrains Space](https://www.jetbrains.com/space/)
 - [JetBrains TeamCity](https://www.jetbrains.com/teamcity/)
 - [Klondike](https://github.com/themotleyfool/Klondike)
 - [MinimalNugetServer](https://github.com/TanukiSharp/MinimalNugetServer)


### PR DESCRIPTION
JetBrains Space provides provides ability to [host NuGet feeds](https://www.jetbrains.com/help/space/nuget-feed.html) as well as an ability to [build .NET projects](https://www.jetbrains.com/help/space/net-core.html).