### PR TITLE
Add the Native Target Framework

### DIFF
--- a/docs/reference/target-frameworks.md
+++ b/docs/reference/target-frameworks.md
@@ -89,6 +89,7 @@ Universal Windows Platform | uap | uap [uap10.0] |
 | | | net6.0 |
 Tizen | tizen | tizen3 |
 | | | tizen4 |
+| Native | native | native |
 
 ## Deprecated frameworks
 


### PR DESCRIPTION
In the Blog Post (https://devblogs.microsoft.com/nuget/native-support/#native-target-framework) it is precisely stated that you should specify the "native" target framework, when developing C++ Win32 applications.