### PR TITLE
Update F1 Keywords for VS Options to point to new Package Source Mappings page

### DIFF
--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -5,6 +5,8 @@ author: nkolev92
 ms.author: nikolev
 ms.date: 03/15/2022
 ms.topic: conceptual
+f1_keywords: 
+  - "vs.toolsoptionspages.nuget_package_manager.package_source_mapping"
 ---
 
 # Package Source Mapping


### PR DESCRIPTION
Opening Help from VS Options launches a certain Docs page. 
The new Package Source Mappings page opens the following URL, which today is a 404, as no keywords are associated with the query string keyword (see it in the URL below):  `VS.ToolsOptionsPages.NuGet_Package_Manager.Package_Source_Mapping`, the corresponding options page name.

This PR associates that keyword to the docs page.
https://msdn.microsoft.com/query/dev16.query?appId=Dev16IDEF1&l=EN-US&k=k(VS.ToolsOptionsPages.NuGet_Package_Manager.Package_Source_Mapping)&rd=true