### PR TITLE
Add a reminder about the breaking change of temp folder renaming on Linux in release notes

### DIFF
--- a/docs/release-notes/NuGet-5.11.md
+++ b/docs/release-notes/NuGet-5.11.md
@@ -28,7 +28,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. e.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 5.11.3
 

--- a/docs/release-notes/NuGet-5.11.md
+++ b/docs/release-notes/NuGet-5.11.md
@@ -28,7 +28,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 5.11.3
 

--- a/docs/release-notes/NuGet-5.11.md
+++ b/docs/release-notes/NuGet-5.11.md
@@ -28,7 +28,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. e.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 5.11.3
 

--- a/docs/release-notes/NuGet-5.11.md
+++ b/docs/release-notes/NuGet-5.11.md
@@ -27,6 +27,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 5.11.3
 
 * [Security]: Microsoft Security Advisory CVE-2022-41032 | .NET Elevation of Privilege Vulnerability - [#12149](https://github.com/NuGet/Home/issues/12149)

--- a/docs/release-notes/NuGet-6.0.md
+++ b/docs/release-notes/NuGet-6.0.md
@@ -25,6 +25,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 6.0.3
 
 * [Security]: Microsoft Security Advisory CVE-2022-41032 | .NET Elevation of Privilege Vulnerability - [#12149](https://github.com/NuGet/Home/issues/12149)

--- a/docs/release-notes/NuGet-6.0.md
+++ b/docs/release-notes/NuGet-6.0.md
@@ -26,7 +26,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.0.3
 

--- a/docs/release-notes/NuGet-6.0.md
+++ b/docs/release-notes/NuGet-6.0.md
@@ -26,7 +26,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.0.3
 

--- a/docs/release-notes/NuGet-6.2.md
+++ b/docs/release-notes/NuGet-6.2.md
@@ -25,7 +25,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.2.2
 

--- a/docs/release-notes/NuGet-6.2.md
+++ b/docs/release-notes/NuGet-6.2.md
@@ -24,6 +24,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 6.2.2
 
 * [Security]: Microsoft Security Advisory CVE 2022-41032 | .NET Elevation of Privilege Vulnerability - [#12149](https://github.com/NuGet/Home/issues/12149)

--- a/docs/release-notes/NuGet-6.2.md
+++ b/docs/release-notes/NuGet-6.2.md
@@ -25,7 +25,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.2.2
 

--- a/docs/release-notes/NuGet-6.3.md
+++ b/docs/release-notes/NuGet-6.3.md
@@ -23,6 +23,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 6.3.1
 
 * [Security]: Microsoft Security Advisory CVE-2022-41032 | .NET Elevation of Privilege Vulnerability - [#12149](https://github.com/NuGet/Home/issues/12149)

--- a/docs/release-notes/NuGet-6.3.md
+++ b/docs/release-notes/NuGet-6.3.md
@@ -24,7 +24,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.3.1
 

--- a/docs/release-notes/NuGet-6.3.md
+++ b/docs/release-notes/NuGet-6.3.md
@@ -24,7 +24,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.3.1
 

--- a/docs/release-notes/NuGet-6.4.md
+++ b/docs/release-notes/NuGet-6.4.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.4
 

--- a/docs/release-notes/NuGet-6.4.md
+++ b/docs/release-notes/NuGet-6.4.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.4
 

--- a/docs/release-notes/NuGet-6.4.md
+++ b/docs/release-notes/NuGet-6.4.md
@@ -22,6 +22,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 6.4
 
 * Central package management is considered production ready and the preview message has been removed - [#11950](https://github.com/NuGet/Home/issues/11950)

--- a/docs/release-notes/NuGet-6.5.md
+++ b/docs/release-notes/NuGet-6.5.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.5
 

--- a/docs/release-notes/NuGet-6.5.md
+++ b/docs/release-notes/NuGet-6.5.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.5
 

--- a/docs/release-notes/NuGet-6.5.md
+++ b/docs/release-notes/NuGet-6.5.md
@@ -22,6 +22,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 6.5
 
 * Manage packages in the Directory.Packages.props file for CPM projects - [#11890](https://github.com/NuGet/Home/issues/11890)

--- a/docs/release-notes/NuGet-6.6.md
+++ b/docs/release-notes/NuGet-6.6.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>`. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.6
 

--- a/docs/release-notes/NuGet-6.6.md
+++ b/docs/release-notes/NuGet-6.6.md
@@ -23,7 +23,7 @@ NuGet distribution vehicles:
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
 > [!NOTE]
-> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+> There is a behavior breaking change on Linux. The temp folder location, where NuGet stores temporary files during its various operations, has changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
 
 ## Summary: What's New in 6.6
 

--- a/docs/release-notes/NuGet-6.6.md
+++ b/docs/release-notes/NuGet-6.6.md
@@ -22,6 +22,9 @@ NuGet distribution vehicles:
 
 * [Security]: Microsoft Security Advisory CVE-2023-29337 | NuGet Client Remote Code Execution Vulnerability - [#12653](https://github.com/NuGet/Home/issues/12653)
 
+> [!NOTE]
+> There is a behavior breaking change on Linux. The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux. E.g. for user User1, the temp folder will be `/tmp/NuGetScratchUser1`.
+
 ## Summary: What's New in 6.6
 
 * [Epic]: Central Package Management improvements for 17.6 - [#12413](https://github.com/NuGet/Home/issues/12413)


### PR DESCRIPTION
Fix: https://github.com/NuGet/Home/issues/12655

There is a breaking change, "The temp folder where NuGet stores temporary files during its various operations is changed from `/tmp/NuGetScratch` to `/tmp/NuGetScratch<username>` on Linux.".
We'd better remind people in release notes.