### PR TITLE
Fix header

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -57,7 +57,6 @@
       "searchScope": [
         "NuGet"
       ],
-      "uhfHeaderId": []
     },
     "fileMetadata": {},
     "template": [],


### PR DESCRIPTION
Removing duplicate uhfHeaderId field in docfx file; hopefully this will allow the header to show properly.