### PR TITLE
Update creating-a-package-msbuild.md for NuGet.Build.Tasks.Pack version

### DIFF
--- a/docs/create-packages/creating-a-package-msbuild.md
+++ b/docs/create-packages/creating-a-package-msbuild.md
@@ -3,7 +3,7 @@ title: Create a NuGet package using MSBuild
 description: A detailed guide to the process of designing and creating a NuGet package using MSBuild, including key decision points like files and versioning.
 author: JonDouglas
 ms.author: jodou
-ms.date: 07/14/2022
+ms.date: 08/17/2023
 ms.topic: conceptual
 ---
 
@@ -86,7 +86,7 @@ If you are using MSBuild with a non-SDK-style project and PackageReference, add 
    ```xml
    <ItemGroup>
      <!-- ... -->
-     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="5.2.0"/>
+     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.7.0" PrivateAssets="all" Pack="false" />
      <!-- ... -->
    </ItemGroup>
    ```

--- a/docs/create-packages/creating-a-package-msbuild.md
+++ b/docs/create-packages/creating-a-package-msbuild.md
@@ -90,6 +90,9 @@ If you are using MSBuild with a non-SDK-style project and PackageReference, add 
      <!-- ... -->
    </ItemGroup>
    ```
+   
+   > [!NOTE]
+   > [Consider using the latest version of this package available.](https://www.nuget.org/packages/nuget.build.tasks.pack)
 
 2. Open a Developer command prompt (In the **Search** box, type **Developer command prompt**).
 

--- a/docs/create-packages/creating-a-package-msbuild.md
+++ b/docs/create-packages/creating-a-package-msbuild.md
@@ -86,7 +86,7 @@ If you are using MSBuild with a non-SDK-style project and PackageReference, add 
    ```xml
    <ItemGroup>
      <!-- ... -->
-     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.7.0" PrivateAssets="all" Pack="false" />
+     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.7.0" PrivateAssets="all" />
      <!-- ... -->
    </ItemGroup>
    ```


### PR DESCRIPTION
Fixes #3124 

Update reference of including NuGet package to current version and private assets.

Page would now look like:

![image](https://github.com/NuGet/docs.microsoft.com-nuget/assets/24302614/ea56e908-471d-4866-89e1-56b20aa40f77)

Added Note based on PR feedback to point to package on NuGet.org