### PR TITLE
Add doc for allowInsecureConnections

### DIFF
--- a/docs/reference/errors-and-warnings/NU1803.md
+++ b/docs/reference/errors-and-warnings/NU1803.md
@@ -21,7 +21,7 @@ You may need to do one of the following:
 
 - Correct the specified url. You may have mistyped the source url. Change the url to explicitly request the `HTTPS` version of the source.
 - Work with the owner of the source and ask them to migrate to `HTTPS`.
-- If you are absolutely certain the 'HTTP' server you are connecting to is trustworthy, you may opt out this warning by setting `allowInsecureConnections` to `true`` for this package source, in [Package source sections](..\nuget-config-file.md#package-source-sections) of NuGet.Config file. (Supported in NuGet 6.8+)
+- If you are absolutely certain the 'HTTP' server you are connecting to is trustworthy, you may opt out of this warning by setting `allowInsecureConnections` to `true` for this package source, in [Package source sections](..\nuget-config-file.md#package-source-sections) of your NuGet.Config file. (Supported in NuGet 6.8+)
 
 **Example**:
 

--- a/docs/reference/errors-and-warnings/NU1803.md
+++ b/docs/reference/errors-and-warnings/NU1803.md
@@ -21,5 +21,16 @@ You may need to do one of the following:
 
 - Correct the specified url. You may have mistyped the source url. Change the url to explicitly request the `HTTPS` version of the source.
 - Work with the owner of the source and ask them to migrate to `HTTPS`.
+- If you are absolutely certain the 'HTTP' server you are connecting to is trustworthy, you may opt out this warning by setting `allowInsecureConnections` to `true`` for this package source, in [Package source sections](..\nuget-config-file.md#package-source-sections) of NuGet.Config file. (Supported in NuGet 6.8+)
+
+**Example**:
+
+```xml
+<packageSources>
+    <clear />    
+    <add key="http-source1" value="http://httpsource1trusted/" allowInsecureConnections="true">
+    <add key="http-source2" value="http://httpsource2trusted/" protocolVersion="3" allowInsecureConnections="true">
+</packageSources>
+```
 
 To learn more, refer to the [HTTPS everywhere](https://devblogs.microsoft.com/nuget/https-everywhere) blog.

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -113,9 +113,12 @@ Note that the source URL for nuget.org is `https://api.nuget.org/v3/index.json`.
 
 Lists all known package sources. The order is ignored during restore operations and with any project using the PackageReference format. NuGet respects the order of sources for install and update operations with projects using `packages.config`.
 
-| Key | Value | protocolVersion |
-| --- | --- | --- |
-| (name to assign to the package source) | The path or URL of the package source. | The NuGet server protocol version to be used. The current version is "3". Defaults to version "2" when not pointing to a package source URL ending in `.json` (e.g. https://api.nuget.org/v3/index.json). Supported in [NuGet 3.0+](/nuget/release-notes/nuget-3.0.0). See [NuGet Server API](/nuget/api/overview) for more information about the version 3 protocol. |
+| XML Attribute | Purpose |
+| :-- | :-- |
+| **Key** | (name to assign to the package source) |
+| **Value** | The path or URL of the package source. |
+| **protocolVersion** | The NuGet server protocol version to be used. The current version is "3". Defaults to version "2" when not pointing to a package source URL ending in `.json` (e.g. https://api.nuget.org/v3/index.json). Supported in [NuGet 3.0+](/nuget/release-notes/nuget-3.0.0). See [NuGet Server API](/nuget/api/overview) for more information about the version 3 protocol. |
+| **allowInsecureConnections** | When false, or not specified, NuGet will emit a warning when the source uses http, rather than https. If you are confident that communication with this source will never be at risk of interception attacks, you can set the value to true to suppress the warning. Supported in NuGet 6.8+. |
 
 **Example**:
 
@@ -124,6 +127,7 @@ Lists all known package sources. The order is ignored during restore operations 
     <clear />    
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Contoso" value="https://contoso.com/packages/" />
+    <add key="http-source" value="http://httpsourcetrusted/" allowInsecureConnections="true" />
     <add key="Test Source" value="c:\packages" />
 </packageSources>
 ```


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3116

Add allowInsecureConnections property into the following docs:
https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#packagesources
https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1803

Spec: https://github.com/NuGet/Home/blob/dev/proposed/2023/InsecureConnectionsDisableCertificateValidation.md
We provided a way to opt-out of http warnings, by setting allowInsecureConnections to true in NuGet.Config, in NuGet 6.8.
The implementation PR is https://github.com/NuGet/NuGet.Client/pull/5411  (epic issue is https://github.com/NuGet/Home/issues/12785)