### PR TITLE
Clarify support for icons from folder-based source

### DIFF
--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -201,7 +201,7 @@ For example, you would add the following to your nuspec when creating a package 
 For the MSBuild equivalent, take a look at [Packing an icon image file](msbuild-targets.md#packing-an-icon-image-file).
 
 > [!Tip]
-> You can specify both `icon` and `iconUrl` to maintain backward compatibility with sources that do not support `icon`. Visual Studio will support `icon` for packages coming from a folder-based source in a future release.
+> To maintain backward compatibility with clients and sources that don't yet support `icon`, specify both `icon` and `iconUrl`. Visual Studio supports `icon` for packages coming from a folder-based source.
 
 #### readme
 


### PR DESCRIPTION
This tip appears to be out of date. I'm updating the verbiage to better match the tip on this page: https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/reference/msbuild-targets.md#packageicon

The PR changing that page was https://github.com/NuGet/docs.microsoft.com-nuget/pull/2271