### PR TITLE
Correct the _nuget.config_ file, to include the outer XML. The XML declaration and the top-level `configuration` node.

### DIFF
--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -96,7 +96,8 @@ _From the Visual Studio Options Dialog_
   </packageSources>
   
   <!-- Define mappings by adding package patterns beneath the target source. -->
-  <!-- Contoso.* packages and NuGet.Common will be restored from contoso.com, everything else from nuget.org. -->
+  <!-- Contoso.* packages and NuGet.Common will be restored from contoso.com,
+       everything else from nuget.org. -->
   <packageSourceMapping>
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
     <packageSource key="nuget.org">

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -3,7 +3,7 @@ title: Package Source Mapping
 description: Describes package source mapping functionality and how to onboard
 author: nkolev92
 ms.author: nikolev
-ms.date: 03/15/2022
+ms.date: 10/18/2023
 ms.topic: conceptual
 f1_keywords: 
   - "vs.toolsoptionspages.nuget_package_manager.package_source_mapping"
@@ -84,27 +84,30 @@ _From the Visual Studio Options Dialog_
   * Add as many patterns as you find necessary.
 
 ```xml
-<!-- Define the package sources, nuget.org and contoso.com. -->
-<!-- `clear` ensures no additional sources are inherited from another config file. -->
-<packageSources>
-  <clear />
-  <!-- `key` can be any identifier for your source. -->
-  <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  <add key="contoso.com" value="https://contoso.com/packages/" />
-</packageSources>
-
-<!-- Define mappings by adding package patterns beneath the target source. -->
-<!-- Contoso.* packages and NuGet.Common will be restored from contoso.com, everything else from nuget.org. -->
-<packageSourceMapping>
-  <!-- key value for <packageSource> should match key values from <packageSources> element -->
-  <packageSource key="nuget.org">
-    <package pattern="*" />
-  </packageSource>
-  <packageSource key="contoso.com">
-    <package pattern="Contoso.*" />
-    <package pattern="NuGet.Common" />
-  </packageSource>
-</packageSourceMapping>
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Define the package sources, nuget.org and contoso.com. -->
+  <!-- `clear` ensures no additional sources are inherited from another config file. -->
+  <packageSources>
+    <clear />
+    <!-- `key` can be any identifier for your source. -->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="contoso.com" value="https://contoso.com/packages/" />
+  </packageSources>
+  
+  <!-- Define mappings by adding package patterns beneath the target source. -->
+  <!-- Contoso.* packages and NuGet.Common will be restored from contoso.com, everything else from nuget.org. -->
+  <packageSourceMapping>
+    <!-- key value for <packageSource> should match key values from <packageSources> element -->
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="contoso.com">
+      <package pattern="Contoso.*" />
+      <package pattern="NuGet.Common" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
 ```
 
 Package Source Mapping settings are applied following [nuget.config precedence rules](configuring-nuget-behavior.md#how-settings-are-applied) when multiple `nuget.config` files at various levels (machine-level, user-level, repo-level) are present.


### PR DESCRIPTION
Correct the _nuget.config_ file, to include the outer XML. The XML declaration and the top-level `configuration` node.

Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3081
Fixes https://github.com/dotnet/docs/issues/37624

This is the second time I've ended up on this article, tried copying and pasting the code and it didn't work. I figured, let's just add the outer element to make this example complete.