### PR TITLE
Update NuGet Client SDK docs to include all published packages

### DIFF
--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -25,7 +25,7 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.Credentials`](https://www.nuget.org/packages/NuGet.Credentials) - NuGet client's authentication models.
 * [`NuGet.DependencyResolver.Core`](https://www.nuget.org/packages/NuGet.DependencyResolver.Core) - NuGet's PackageReference dependency resolver implementation.
 * [`NuGet.Frameworks`](https://www.nuget.org/packages/NuGet.Frameworks) - NuGet's understanding of target frameworks.
-* [`NuGet.LibraryModel`](https://www.nuget.org/packages/NuGet.Frameworks) - NuGet's types and interfaces for understanding dependencies.
+* [`NuGet.LibraryModel`](https://www.nuget.org/packages/NuGet.LibraryModel) - NuGet's types and interfaces for understanding dependencies.
 * [`NuGet.Localization`](https://www.nuget.org/packages/NuGet.Localization) - NuGet localization package.
 * [`NuGet.PackageManagement`](https://www.nuget.org/packages/NuGet.PackageManagement) - NuGet Package Management functionality for Visual Studio installation flow.
 * [`NuGet.Packaging.Core`](https://www.nuget.org/packages/NuGet.Packaging.Core) - The (former home to) core data structures for `NuGet.Packaging`.

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -11,13 +11,6 @@ ms.topic: conceptual
 
 The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.Indexing`](https://www.nuget.org/packages/NuGet.Indexing) - NuGet's indexing library for the Visual Studio client search functionality.
-* [`NuGet.VisualStudio.Contracts`](https://www.nuget.org/packages/NuGet.VisualStudio.Contracts) - This package contains RPC contracts for NuGet’s Visual Studio Service Broker extensibility APIs.
-* [`NuGet.VisualStudio`](https://www.nuget.org/packages/NuGet.VisualStudio) - This package provides APIs for invoking NuGet services in Visual Studio.
-* [`Microsoft.Build.NuGetSdkResolver`](https://www.nuget.org/packages/Microsoft.Build.NuGetSdkResolver) - MSBuild SDK resolver for NuGet packages.
-* [`NuGet.Build.Tasks.Console`](https://www.nuget.org/packages/NuGet.Build.Tasks.Console) - NuGet Build tasks for MSBuild and dotnet restore.
-* [`NuGet.Build.Tasks.Pack`](https://www.nuget.org/packages/NuGet.Build.Tasks.Pack) - NuGet tasks for MSBuild and dotnet pack.
-* [`NuGet.Build.Tasks`](https://www.nuget.org/packages/NuGet.Build.Tasks) - NuGet tasks for MSBuild and dotnet restore.
-* [`NuGet.CommandLine.XPlat`](https://www.nuget.org/packages/NuGet.CommandLine.XPlat) - NuGet executable wrapper for the dotnet CLI nuget functionality.
 * [`NuGet.Commands`](https://www.nuget.org/packages/NuGet.Commands) - Complete commands common to command-line and GUI NuGet clients.
 * [`NuGet.Common`](https://www.nuget.org/packages/NuGet.Common) - Common utilities and interfaces for all NuGet libraries.
 * [`NuGet.Configuration`](https://www.nuget.org/packages/NuGet.Configuration) - NuGet's configuration settings implementation.
@@ -27,7 +20,6 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.LibraryModel`](https://www.nuget.org/packages/NuGet.LibraryModel) - NuGet's types and interfaces for understanding dependencies.
 * [`NuGet.Localization`](https://www.nuget.org/packages/NuGet.Localization) - NuGet localization package.
 * [`NuGet.PackageManagement`](https://www.nuget.org/packages/NuGet.PackageManagement) - NuGet Package Management functionality for Visual Studio installation flow.
-* [`NuGet.Packaging.Core`](https://www.nuget.org/packages/NuGet.Packaging.Core) - The (former home to) core data structures for `NuGet.Packaging`.
 * [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Provides a set of APIs to interact with `.nupkg` and `.nuspec` files from a stream. `NuGet.Protocol` depends on this package.
 * [`NuGet.ProjectModel`](https://www.nuget.org/packages/NuGet.ProjectModel) - NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.
 * [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Provides a set of APIs interact with HTTP and file-based NuGet feeds.

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -10,6 +10,7 @@ ms.topic: conceptual
 # NuGet Client SDK
 
 The *NuGet Client SDK* refers to a group of NuGet packages:
+
 * [`NuGet.Indexing`](https://www.nuget.org/packages/NuGet.Indexing) - NuGet's indexing library for the Visual Studio client search functionality.
 * [`NuGet.Commands`](https://www.nuget.org/packages/NuGet.Commands) - Complete commands common to command-line and GUI NuGet clients.
 * [`NuGet.Common`](https://www.nuget.org/packages/NuGet.Common) - Common utilities and interfaces for all NuGet libraries.
@@ -106,7 +107,7 @@ Create a package, set metadata, and add dependencies using [`NuGet.Packaging`](h
 > It is strongly recommended that NuGet packages are created using the official NuGet tooling and **not** using this
 > low-level API. There are a variety of characteristics important for a well-formed package and the latest version of
 > tooling helps incorporate these best practices.
-> 
+>
 > For more information about creating NuGet packages, see the overview of the
 > [package creation workflow](../create-packages/overview-and-workflow.md) and the documentation for official pack
 > tooling (for example, [using the dotnet CLI](../create-packages/creating-a-package-dotnet-cli.md)).
@@ -123,9 +124,9 @@ Read a package from a file stream using [`NuGet.Packaging`](https://www.nuget.or
 
 You can find examples and documentation for some of the API in the following blog series by Dave Glick, published 2016:
 
-- [Exploring the NuGet v3 Libraries, Part 1: Introduction and concepts](http://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-1)
-- [Exploring the NuGet v3 Libraries, Part 2: Searching for packages](http://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-2)
-- [Exploring the NuGet v3 Libraries, Part 3: Installing packages](http://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-3)
+* [Exploring the NuGet v3 Libraries, Part 1: Introduction and concepts](http://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-1)
+* [Exploring the NuGet v3 Libraries, Part 2: Searching for packages](http://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-2)
+* [Exploring the NuGet v3 Libraries, Part 3: Installing packages](http://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-3)
 
 > [!Note]
 > These blog posts were written shortly after the **3.4.3** version of the NuGet client SDK packages were released.
@@ -133,4 +134,4 @@ You can find examples and documentation for some of the API in the following blo
 
 Martin Björkström did a follow-up blog post to Dave Glick's blog series where he introduces a different approach on using the NuGet Client SDK to install NuGet packages:
 
-- [Revisiting the NuGet v3 Libraries](https://martinbjorkstrom.com/posts/2018-09-19-revisiting-nuget-client-libraries)
+* [Revisiting the NuGet v3 Libraries](https://martinbjorkstrom.com/posts/2018-09-19-revisiting-nuget-client-libraries)

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -10,7 +10,6 @@ ms.topic: conceptual
 # NuGet Client SDK
 
 The *NuGet Client SDK* refers to a group of NuGet packages:
-* [`NuGet.CommandLine`](https://www.nuget.org/packages/NuGet.CommandLine) - NuGet Command Line Interface.
 * [`NuGet.Indexing`](https://www.nuget.org/packages/NuGet.Indexing) - NuGet's indexing library for the Visual Studio client search functionality.
 * [`NuGet.VisualStudio.Contracts`](https://www.nuget.org/packages/NuGet.VisualStudio.Contracts) - This package contains RPC contracts for NuGet’s Visual Studio Service Broker extensibility APIs.
 * [`NuGet.VisualStudio`](https://www.nuget.org/packages/NuGet.VisualStudio) - This package provides APIs for invoking NuGet services in Visual Studio.

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -28,7 +28,6 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.Versioning`](https://www.nuget.org/packages/NuGet.Versioning) - NuGet's implementation of Semantic Versioning.
 
 You can find the source code for these packages in the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
-You can find the source code for these examples on the [NuGet.Protocol.Samples](https://github.com/NuGet/Samples/tree/main/NuGetProtocolSamples) project on GitHub.
 
 > [!Note]
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
@@ -40,6 +39,8 @@ Install the `NuGet.Protocol` package to interact with HTTP and folder-based NuGe
 ```ps1
 dotnet add package NuGet.Protocol
 ```
+
+You can find the source code for these examples on the [NuGet.Protocol.Samples](https://github.com/NuGet/Samples/tree/main/NuGetProtocolSamples) project on GitHub.
 
 > [!Tip]
 > `Repository.Factory` is defined in the `NuGet.Protocol.Core.Types` namespace, and the `GetCoreV3` method is an extension method defined in the `NuGet.Protocol` namespace. Therefore, you will need to add `using` statements for both namespaces.

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -10,9 +10,30 @@ ms.topic: conceptual
 # NuGet Client SDK
 
 The *NuGet Client SDK* refers to a group of NuGet packages:
-
-* [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Used to interact with HTTP and file-based NuGet feeds
-* [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Used to interact with NuGet packages. `NuGet.Protocol` depends on this package
+* [`NuGet.CommandLine`](https://www.nuget.org/packages/NuGet.CommandLine) - NuGet Command Line Interface.
+* [`NuGet.Indexing`](https://www.nuget.org/packages/NuGet.Indexing) - NuGet's indexing library for the Visual Studio client search functionality.
+* [`NuGet.VisualStudio.Contracts`](https://www.nuget.org/packages/NuGet.VisualStudio.Contracts) - This package contains RPC contracts for NuGet’s Visual Studio Service Broker extensibility APIs.
+* [`NuGet.VisualStudio`](https://www.nuget.org/packages/NuGet.VisualStudio) - This package provides APIs for invoking NuGet services in Visual Studio.
+* [`Microsoft.Build.NuGetSdkResolver`](https://www.nuget.org/packages/Microsoft.Build.NuGetSdkResolver) - MSBuild SDK resolver for NuGet packages.
+* [`NuGet.Build.Tasks.Console`](https://www.nuget.org/packages/NuGet.Build.Tasks.Console) - NuGet Build tasks for MSBuild and dotnet restore.
+* [`NuGet.Build.Tasks.Pack`](https://www.nuget.org/packages/NuGet.Build.Tasks.Pack) - NuGet tasks for MSBuild and dotnet pack.
+* [`NuGet.Build.Tasks`](https://www.nuget.org/packages/NuGet.Build.Tasks) - NuGet tasks for MSBuild and dotnet restore.
+* [`NuGet.CommandLine.XPlat`](https://www.nuget.org/packages/NuGet.CommandLine.XPlat) - NuGet executable wrapper for the dotnet CLI nuget functionality.
+* [`NuGet.Commands`](https://www.nuget.org/packages/NuGet.Commands) - Complete commands common to command-line and GUI NuGet clients.
+* [`NuGet.Common`](https://www.nuget.org/packages/NuGet.Common) - Common utilities and interfaces for all NuGet libraries.
+* [`NuGet.Configuration`](https://www.nuget.org/packages/NuGet.Configuration) - NuGet's configuration settings implementation.
+* [`NuGet.Credentials`](https://www.nuget.org/packages/NuGet.Credentials) - NuGet client's authentication models.
+* [`NuGet.DependencyResolver.Core`](https://www.nuget.org/packages/NuGet.DependencyResolver.Core) - NuGet's PackageReference dependency resolver implementation.
+* [`NuGet.Frameworks`](https://www.nuget.org/packages/NuGet.Frameworks) - NuGet's understanding of target frameworks.
+* [`NuGet.LibraryModel`](https://www.nuget.org/packages/NuGet.Frameworks) - NuGet's types and interfaces for understanding dependencies.
+* [`NuGet.Localization`](https://www.nuget.org/packages/NuGet.Localization) - NuGet localization package.
+* [`NuGet.PackageManagement`](https://www.nuget.org/packages/NuGet.PackageManagement) - NuGet Package Management functionality for Visual Studio installation flow.
+* [`NuGet.Packaging.Core`](https://www.nuget.org/packages/NuGet.Packaging.Core) - The (former home to) core data structures for `NuGet.Packaging`.
+* [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Used to interact with NuGet packages. `NuGet.Protocol` depends on this package.
+* [`NuGet.ProjectModel`](https://www.nuget.org/packages/NuGet.ProjectModel) - NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.
+* [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Used to interact with HTTP and file-based NuGet feeds.
+* [`NuGet.Resolver`](https://www.nuget.org/packages/NuGet.Resolver) - NuGet's dependency resolver for packages.config based projects.
+* [`NuGet.Versioning`](https://www.nuget.org/packages/NuGet.Versioning) - NuGet's implementation of Semantic Versioning.
 
 You can find the source code for these packages in the [NuGet/NuGet.Client](https://github.com/NuGet/NuGet.Client) GitHub repository.
 You can find the source code for these examples on the [NuGet.Protocol.Samples](https://github.com/NuGet/Samples/tree/main/NuGetProtocolSamples) project on GitHub.

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -29,9 +29,9 @@ The *NuGet Client SDK* refers to a group of NuGet packages:
 * [`NuGet.Localization`](https://www.nuget.org/packages/NuGet.Localization) - NuGet localization package.
 * [`NuGet.PackageManagement`](https://www.nuget.org/packages/NuGet.PackageManagement) - NuGet Package Management functionality for Visual Studio installation flow.
 * [`NuGet.Packaging.Core`](https://www.nuget.org/packages/NuGet.Packaging.Core) - The (former home to) core data structures for `NuGet.Packaging`.
-* [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Used to interact with NuGet packages. `NuGet.Protocol` depends on this package.
+* [`NuGet.Packaging`](https://www.nuget.org/packages/NuGet.Packaging) - Provides a set of APIs to interact with `.nupkg` and `.nuspec` files from a stream. `NuGet.Protocol` depends on this package.
 * [`NuGet.ProjectModel`](https://www.nuget.org/packages/NuGet.ProjectModel) - NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.
-* [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Used to interact with HTTP and file-based NuGet feeds.
+* [`NuGet.Protocol`](https://www.nuget.org/packages/NuGet.Protocol) - Provides a set of APIs interact with HTTP and file-based NuGet feeds.
 * [`NuGet.Resolver`](https://www.nuget.org/packages/NuGet.Resolver) - NuGet's dependency resolver for packages.config based projects.
 * [`NuGet.Versioning`](https://www.nuget.org/packages/NuGet.Versioning) - NuGet's implementation of Semantic Versioning.
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3175

[NuGet Client SDK docs](https://learn.microsoft.com/nuget/reference/nuget-client-sdk) docs do not list all the packages that are published by the NuGet team.

The list of packages that are currently published by the NuGet Client team can be found in the [source code](https://github.com/NuGet/NuGet.Client/blob/dev/scripts/utils/EnsureAllPackagesExist.ps1) or at https://www.nuget.org/profiles/nuget. The list of packages in the source code will not match with the list of packages that have already been published by the NuGet account on nuget.org. This is because a few of the packages were either deprecated or published by the server team.

Credit to @zivkan for raising awareness about this internally.