### PR TITLE
Rewrite docs for authenticated feeds

### DIFF
--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -15,7 +15,6 @@ For HTTP feeds, NuGet will with make an unauthenticated request, and if the serv
 1. [An environment variable `NuGetPackageSourceCredentials_{name}`](#credentials-in-environment-variables).
 1. [Add credentials in a *nuget.config* file](#credentials-in-nugetconfig-files).
 1. [Use a NuGet credential provider, if your package source provides one](#credential-providers).
-1. [Interactive login](#interactive-login)
 
 We recommend using a credential provider when possible.
 Secrets wil not be saved in the *nuget.config* file, reducing risk of accidentally leaking secrets.
@@ -75,14 +74,24 @@ For more information, see [the *nuget.config* reference docs on using environmen
 NuGet has an extensibility model, allowing [plugins to provide NuGet credentials](../reference/extensibility/NuGet-Cross-Platform-Authentication-Plugin.md).
 The [path that credential providers must be installed](../reference/extensibility/NuGet-Cross-Platform-Plugins.md#plugin-installation-and-discovery), for NuGet to discover, is different for .NET Framework (NuGet.exe, MSBuild, and Visual Studio), and the .NET SDK (running on the .NET 5+ runtime).
 
-NuGet passes its "interactive mode" flag to credential providers, so if the credential provider is not able to silently obtain credentials, it may fail unless [interactive mode is specified](#interactive-login).
+NuGet has a concept of being run in interactive mode or non-interactive mode.
+When in non-interactive mode, credential providers are asked not to block NuGet.
+While in interactive mode, the credential provider may prompt you to log in.
+Different tools have different defaults, so interactive mode may need to be opt-in or opt-out, depending on your scenario.
+
+|Tool|Default|Toggle|
+|--|--|--|
+|`dotnet` CLI|non-interactive|`--interactive` argument. For example, `dotnet restore --interactive`.|
+|MSBuild|non-interactive|`NuGetInteractive` MSBuild property. For example, `msbuild -t:restore -p:NuGetInteractive=true`.|
+|NuGet.exe|interactive|`-NonInteractive` argument. For example, `nuget.exe restore -NonInteractive`.|
+|Visual Studio|interactive|not possible to run in non-interactive mode.|
+
+[NuGet.exe supports both V1 and V2 credential providers](../reference/extensibility/nuget-exe-Credential-Providers.md), while MSBuild and the .NET SDK only support the cross platform (V2) plugins.
 
 In Visual Studio, NuGet has a [Visual Studio Credential Provider interface](../reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md), which credential providers can use to provide a graphical login experience, or call Visual Studio APIs if necessary.
 NuGet in Visual Studio will fall back to the command line credential providers if it can't find a Visual Studio credential provider that handles the source.
 
-NuGet.exe supports both V1 and V2 credential providers, while MSBuild, the .NET SDK, and Visual Studio only support V2 plugins.
-
-Visual Studio 2017 version 17.9, and above, includes a credential provider for [Azure Artifacts](/azure/devops/artifacts/), that works within Visual Studio, MSBuild, and NuGet.exe.
+Visual Studio 2017 version 15.9, and above, includes a credential provider for [Azure Artifacts](/azure/devops/artifacts/), that works within Visual Studio, MSBuild, and NuGet.exe.
 However, the credential provider for the .NET SDK is not included by Visual Studio, so [must be installed separately](https://github.com/microsoft/artifacts-credprovider?tab=readme-ov-file#setup) to work with the `dotnet` CLI.
 
 ### List of credential providers
@@ -93,14 +102,3 @@ Until this is implemented, here is a list of credential providers we are aware o
 * [AWS CodeArtifact NuGet Credential Provider](https://docs.aws.amazon.com/codeartifact/latest/ug/nuget-cli.html#nuget-configure-cli)
 * [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider). This link is just for the command line credential provider.
 * [MyGet Credential Provider for Visual Studio](http://docs.myget.org/docs/reference/credential-provider-for-visual-studio).
-
-## Interactive login
-
-When NuGet can not find credentials from any of the previous steps, NuGet will pause restore and prompt for credentials when in interactive mode.
-
-|Tool|Default|Toggle|
-|--|--|--|
-|`dotnet` CLI|non-interactive|`--interactive` argument. For example, `dotnet restore --interactive`.|
-|MSBuild|non-interactive|`NuGetInteractive` MSBuild property. For example, `msbuild -t:restore -p:NuGetInteractive=true`.|
-|NuGet.exe|interactive|`-NonInteractive` argument. For example, `nuget.exe restore -NonInteractive`.|
-|Visual Studio|interactive|not possible to run without prompting.|

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -3,98 +3,104 @@ title: Consuming packages from authenticated feeds
 description: Consuming packages from authenticated feeds in all NuGet client scenarios
 author: nkolev92
 ms.author: nikolev
-ms.date: 02/28/2020
+ms.date: 12/22/2023
 ms.topic: conceptual
 ---
 
 # Consuming packages from authenticated feeds
 
-In addition to the nuget.org [public feed](https://api.nuget.org/v3/index.json), NuGet clients have the ability to interact with file feeds and private http feeds.
+Many NuGet operations, such as restore and install, require communication with one or more package sources, which [can be configured in *nuget.config* files](../reference/nuget-config-file.md#packagesources).
+For HTTP feeds, NuGet will with make an unauthenticated request, and if the server responds with an HTTP 401 response, NuGet will search for credentials in the following order:
 
+1. [An environment variable `NuGetPackageSourceCredentials_{name}`](#credentials-in-environment-variables).
+1. [Add credentials in a *nuget.config* file](#credentials-in-nugetconfig-files).
+1. [Use a NuGet credential provider, if your package source provides one](#credential-providers).
+1. [Interactive login](#interactive-login)
 
-To authenticate with private http feeds, the 2 approaches are:
+We recommend using a credential provider when possible.
+Secrets wil not be saved in the *nuget.config* file, reducing risk of accidentally leaking secrets.
+Additionally, it typically reduces the number of places you need to update when a credential expires or changes.
+If the credential provider supports single sign on, it may reduce the number of time you need to log in, or the number of places that credentials need to be saved.
 
-* Add credentials in the [NuGet.config](../reference/nuget-config-file.md#packagesourcecredentials)
-* Authenticate using one of the many extensibility models depending on the client used.
+The credentials you need to use are determined by the package source.
+Therefore, unless you're using a credential provider, you should check with your package source what credentials to use.
+It is very common for package sources to forbid using your password (that you log into the website with) with NuGet.
+Typically you need to create a Personal Access Token to use as NuGet's password, but you should check the documentation for the NuGet server you're using.
+Some package sources, such as Azure DevOps and GitHub, have scoped access tokens, so you may need to ensure that any tokens you create include the required scope.
 
-## NuGet clients' authentication extensibility
+## Credentials in environment variables
 
-For the various NuGet clients, the private feed provider itself is responsible for authentication.
-All NuGet clients have extensibility methods to support this. These are either a Visual Studio extension or a plugin that can communicate with NuGet to retrieve credentials.
+NuGet will search for an environment variable named `NuGetPackageSourceCredentials_{name}`, where `{name}` is the value of `key="name"` in your *nuget.config* file's package source.
+The value of the environment variable must be `Username={username};Password={password}`, and may optionally include `;ValidAuthenticationTypes={types}`.
+If the environment variable doesn't match NuGet's convention, NuGet will silently ignore the environment variable, and continue searching for credentials for the package source elsewhere.
 
-### Visual Studio
+For example, consider the following *nuget.config* file:
 
-In Visual Studio, NuGet exposes an interface that feed providers can implement and provide to their customers. For more details, please refer to the documentation on [how to create a Visual Studio credential provider](../reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md).
+```xml
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Contoso" value="https://nuget.contoso.com/v3/index.json" />
+  </packageSources>
+</configuration>
+```
 
-#### Available NuGet credential providers for Visual Studio
+In this case, the source name is `Contoso` and NuGet will look for the environment variable name `NuGetPackageSourceCredentials_Contoso`.
+Some platforms are case-sensitive, so take care about using the correct upper and lower case characters for the environment name and the source name, as defined in your *nuget.config* file.
 
-There is a credential provider built into Visual Studio to support Azure DevOps.
+If the username is `nugetUser` and the password is `secret123`, the environment variable's value should be set to `Username=nugetUser;Password=secret123`.
+If NuGet should only use this credential for HTTP Basic authentication, but not other authentication schemes, you can set the environment variable's value to `Username=nugetUser;Password=secret123;ValidAuthenticationTypes=Basic`.
+For more information about valid authentication types, see [the docs on package credentials in *nuget.config* files](../reference/nuget-config-file.md#packagesourcecredentials).
 
+Note that environment variables have restrictions on allowed characters, and different operating systems may have different restrictions.
+For example, spaces are not allowed.
+Therefore, you use this environment variable feature to specify NuGet credentials for package sources that use any characters that are invalid for your platform's environment variables.
+In such cases, you should rename the package source in your *nuget.config* file.
 
-Available plug-in credential providers include:
+## Credentials in *nuget.config* files
 
-* [MyGet Credential Provider for Visual Studio](http://docs.myget.org/docs/reference/credential-provider-for-visual-studio)
+*nuget.config* files can contain package source credentials.
+See [the *nuget.config* file reference doc section on package source credentials](../reference/nuget-config-file.md#packagesourcecredentials) for more information, including syntax.
+However, it's easier to use [`dotnet nuget update source`](/dotnet/core/tools/dotnet-nuget-update-source) on the command line to set the credentials.
 
-### nuget.exe
+> ![Warning]
+> Take care when setting credentials in *nuget.config* files, especially when saving the credential as plain text.
+> If the credential is written to a *nuget.config* file that is in source control, there is an increased risk of accidentally leaking the secret.
 
-When `nuget.exe` needs credentials to authenticate with a feed, it looks for them in the following manner:
+The username and plain text password in a *nuget.config* file can use an environment variable by adding `%` to the beginning and end of the environment variable name you would like to use.
+For more information, see [the *nuget.config* reference docs on using environment variables](../reference/nuget-config-file.md#using-environment-variables).
 
-1. Look for credentials in `NuGet.config` files.
-1. Use V2 plug-in credential providers
-1. Use V1 plug-in credential providers
-1. NuGet then prompts the user for credentials on the command line.
+## Credential providers
 
-#### nuget.exe and V2 credential providers
+NuGet has an extensibility model, allowing [plugins to provide NuGet credentials](../reference/extensibility/NuGet-Cross-Platform-Authentication-Plugin.md).
+The [path that credential providers must be installed](../reference/extensibility/NuGet-Cross-Platform-Plugins.md#plugin-installation-and-discovery), for NuGet to discover, is different for .NET Framework (NuGet.exe, MSBuild, and Visual Studio), and the .NET SDK (running on the .NET 5+ runtime).
 
-In version `4.8` NuGet defined a new authentication plugin mechanism, hereafter referred to as V2 credential providers.
-For the installation and discovery of those providers, refer to [NuGet cross platform plugins](../reference/extensibility/NuGet-Cross-Platform-Plugins.md#plugin-installation-and-discovery).
+NuGet passes its "interactive mode" flag to credential providers, so if the credential provider is not able to silently obtain credentials, it may fail unless [interactive mode is specified](#interactive-login).
 
-#### nuget.exe and V1 credential providers
+In Visual Studio, NuGet has a [Visual Studio Credential Provider interface](../reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md), which credential providers can use to provide a graphical login experience, or call Visual Studio APIs if necessary.
+NuGet in Visual Studio will fall back to the command line credential providers if it can't find a Visual Studio credential provider that handles the source.
 
-In version `3.3` NuGet introduced the first version of authentication plugins.
-For the installation and discovery of those providers refer to [nuget.exe credential providers](../reference/extensibility/nuget-exe-Credential-Providers.md#nugetexe-credential-provider-discovery)
+NuGet.exe supports both V1 and V2 credential providers, while MSBuild, the .NET SDK, and Visual Studio only support V2 plugins.
 
-#### Available credential providers for nuget.exe
+Visual Studio 2017 version 17.9, and above, includes a credential provider for [Azure Artifacts](/azure/devops/artifacts/), that works within Visual Studio, MSBuild, and NuGet.exe.
+However, the credential provider for the .NET SDK is not included by Visual Studio, so [must be installed separately](https://github.com/microsoft/artifacts-credprovider?tab=readme-ov-file#setup) to work with the `dotnet` CLI.
 
-* [Azure DevOps V2 Credential Providers](/azure/devops/artifacts/nuget/nuget-exe#add-a-feed-to-nuget-482-or-later) or [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
+### List of credential providers
 
-With Visual Studio 2017 version 15.9 and later, the Azure DevOps credential provider is bundled in Visual Studio.
-If `nuget.exe` uses MSBuild from that specific Visual Studio toolset, then the plugin will be discovered automatically.
+There is a [feature request to make credential providers installable via .NET tools](https://github.com/NuGet/Home/issues/12567), and this will likely make it easier to discover other credential providers.
+Until this is implemented, here is a list of credential providers we are aware of:
 
-### dotnet.exe
+* [AWS CodeArtifact NuGet Credential Provider](https://docs.aws.amazon.com/codeartifact/latest/ug/nuget-cli.html#nuget-configure-cli)
+* [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider). This link is just for the command line credential provider.
+* [MyGet Credential Provider for Visual Studio](http://docs.myget.org/docs/reference/credential-provider-for-visual-studio).
 
-When `dotnet.exe` needs credentials to authenticate with a feed, it looks for them in the following manner:
+## Interactive login
 
-1. Look for credentials in `NuGet.config` files.
-1. Use V2 plug-in credential providers
+When NuGet can not find credentials from any of the previous steps, NuGet will pause restore and prompt for credentials when in interactive mode.
 
-By default `dotnet.exe` is not interactive, so you might need to pass an `--interactive` flag to get the tool to block for authentication.
-
-#### dotnet.exe and V2 credential providers
-
-In version `2.2.100` of the SDK, NuGet defined an authentication plugin mechanism that works in all clients.
-For the installation and discovery of those providers, refer to [NuGet cross platform plugins](../reference/extensibility/NuGet-Cross-Platform-Plugins.md#plugin-installation-and-discovery).
-
-#### Available credential providers for dotnet.exe
-
-* [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-
-### MSBuild.exe
-
-When `MSBuild.exe` needs credentials to authenticate with a feed, it looks for them in the following manner:
-
-1. Look for credentials in `NuGet.config` files
-1. Use V2 plug-in credential providers
-
-By default `MSBuild.exe` is not interactive, so you might need to set the `/p:NuGetInteractive=true` property to get the tool to block for authentication.
-
-#### MSBuild.exe and V2 credential providers
-
-In Visual Studio 2019 Update 9, NuGet defined an authentication plugin mechanism that works in all clients.
-For the installation and discovery of those providers, refer to [NuGet cross platform plugins](../reference/extensibility/NuGet-Cross-Platform-Plugins.md#plugin-installation-and-discovery).
-
-#### Available credential providers for MSBuild.exe
-
-* [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-
-With Visual Studio 2017 Update 9 and later, the Azure DevOps credential provider is bundled in Visual Studio. No additional steps are required.
+|Tool|Default|Toggle|
+|--|--|--|
+|`dotnet` CLI|non-interactive|`--interactive` argument. For example, `dotnet restore --interactive`.|
+|MSBuild|non-interactive|`NuGetInteractive` MSBuild property. For example, `msbuild -t:restore -p:NuGetInteractive=true`.|
+|NuGet.exe|interactive|`-NonInteractive` argument. For example, `nuget.exe restore -NonInteractive`.|
+|Visual Studio|interactive|not possible to run without prompting.|

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -13,13 +13,14 @@ Many NuGet operations, such as restore and install, require communication with o
 For HTTP feeds, NuGet will with make an unauthenticated request, and if the server responds with an HTTP 401 response, NuGet will search for credentials in the following order:
 
 1. [An environment variable `NuGetPackageSourceCredentials_{name}`](#credentials-in-environment-variables).
-1. [Add credentials in a *nuget.config* file](#credentials-in-nugetconfig-files).
+1. [Credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 1. [Use a NuGet credential provider, if your package source provides one](#credential-providers).
 
-We recommend using a credential provider when possible.
-Secrets wil not be saved in the *nuget.config* file, reducing risk of accidentally leaking secrets.
-Additionally, it typically reduces the number of places you need to update when a credential expires or changes.
-If the credential provider supports single sign on, it may reduce the number of time you need to log in, or the number of places that credentials need to be saved.
+> [!NOTE]
+> We recommend using a credential provider when possible.
+> Secrets will not be saved in the *nuget.config* file, reducing risk of accidentally leaking secrets.
+> Additionally, it typically reduces the number of places you need to update when a credential expires or changes.
+> If the credential provider supports single sign on, it may reduce the number of time you need to log in, or the number of places that credentials need to be saved.
 
 The credentials you need to use are determined by the package source.
 Therefore, unless you're using a credential provider, you should check with your package source what credentials to use.
@@ -65,6 +66,9 @@ However, it's easier to use [`dotnet nuget update source`](/dotnet/core/tools/do
 > ![Warning]
 > Take care when setting credentials in *nuget.config* files, especially when saving the credential as plain text.
 > If the credential is written to a *nuget.config* file that is in source control, there is an increased risk of accidentally leaking the secret.
+>
+> As [NuGet accumulates settings from multiple files](../consume-packages/configuring-nuget-behavior.md), it is recommended to save credentials to your user *nuget.config* file.
+> We also recommend to save package sources in the solution (source code repository) *nuget.config* file, including a `<clear />` element, for build reliability.
 
 The username and plain text password in a *nuget.config* file can use an environment variable by adding `%` to the beginning and end of the environment variable name you would like to use.
 For more information, see [the *nuget.config* reference docs on using environment variables](../reference/nuget-config-file.md#using-environment-variables).

--- a/docs/reference/extensibility/nuget-exe-Credential-Providers.md
+++ b/docs/reference/extensibility/nuget-exe-Credential-Providers.md
@@ -9,9 +9,9 @@ ms.topic: conceptual
 
 # Authenticating feeds with nuget.exe credential providers
 
-In version `3.3` support was added for `nuget.exe` specific credential providers. Since then, in version `4.8` [support for credential providers](NuGet-Cross-Platform-Authentication-Plugin.md) that work across all command line scenarios (`nuget.exe`, `dotnet.exe`, `msbuild.exe`) was added.
+In version `3.3` support was added for `nuget.exe` specific (v1) credential providers. Since then, in version `4.8` [support for (v2) credential providers](NuGet-Cross-Platform-Authentication-Plugin.md) that work across all command line scenarios (`nuget.exe`, `dotnet.exe`, `msbuild.exe`) was added.
 
-See [Consuming Packages from authenticated feeds](../../consume-packages/consuming-packages-authenticated-feeds.md#nugetexe) for more details on all authentication approaches for `nuget.exe`
+See [Consuming Packages from authenticated feeds](../../consume-packages/consuming-packages-authenticated-feeds.md) for more details on all authentication approaches.
 
 ## nuget.exe credential provider discovery
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3185

This started off wanting to just add docs about the `NuGetPackageSourceCredentials_` environment variable.

But reading the docs, and trying to pretend I'm in inexperienced .NET developer, I thought the doc wasn't very clear. So, I tried rewriting the whole thing.  I hope my change is an improvement! 🤷 