### PR TITLE
Add link to experimental tool NuGetSolver

### DIFF
--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -7,9 +7,9 @@ ms.date: 1/16/2024
 ms.topic: include
 ---
 
-> [!Tip Experimental automated solution tool from Microsoft DevLabs, not officially supported]
+> [!Tip]
 
-> Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
+> Experimental automated solution tool from Microsoft DevLabs, not officially supported. Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
 [Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
 

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -9,7 +9,7 @@ ms.topic: include
 
 > [!Tip]
 
-> Experimental automated solution tool from Microsoft DevLabs, not officially supported. Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
+> Alternative solution: Use NuGetSolver, our automated experimental tool from Microsoft DevLabs(not officially supported by NuGet) for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
 [Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
 

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -9,7 +9,7 @@ ms.topic: include
 
 > [!Tip]
 
-> Alternative solution: Use NuGetSolver, our automated experimental tool from Microsoft DevLabs(not officially supported by NuGet) for solving dependency conflicts, to help you find solutions to problems like this automatically!
+> **Alternative solution**: Use NuGetSolver, our automated experimental tool from Microsoft DevLabs(not officially supported by NuGet) for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
 [Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
 

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -9,7 +9,5 @@ ms.topic: include
 
 > [!Tip]
 
-> **Alternative solution**: Use NuGetSolver, an automated experimental tool from Microsoft DevLabs(not officially supported by NuGet) for solving dependency conflicts, to help you find solutions to problems like this automatically!
-If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
-[Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
+> **Alternative solution**: NuGetSolver is a Visual Studio Extension developed by Microsoft DevLabs, designed to assist in resolving dependency conflicts. It automates the process of identifying and addressing these issues. For further details, visit the [NuGetSolver](https://marketplace.visualstudio.com/items?itemName=vsext.NuGetSolver) page on the Visual Studio Marketplace and we'd love to hear your feedback about your experience.
 

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -7,8 +7,9 @@ ms.date: 1/16/2024
 ms.topic: include
 ---
 
-Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
+> [!Experimental automated solution tool from Microsoft DevLabs, not officially supported]
+
+> Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
 [Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
 
----

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -7,9 +7,7 @@ ms.date: 1/16/2024
 ms.topic: include
 ---
 
-> [!Tip]
-
-Experimental automated solution tool from Microsoft DevLabs, not officially supported
+> [!Tip Experimental automated solution tool from Microsoft DevLabs, not officially supported]
 
 > Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -1,0 +1,14 @@
+---
+title: Include
+description: Suggest NuGetSolver experimental tool.
+author: ErickYondon
+ms.author: eryondon
+ms.date: 1/16/2024
+ms.topic: include
+---
+
+Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
+If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
+[Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
+
+---

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -9,7 +9,7 @@ ms.topic: include
 
 > [!Tip]
 
-> **Alternative solution**: Use NuGetSolver, our automated experimental tool from Microsoft DevLabs(not officially supported by NuGet) for solving dependency conflicts, to help you find solutions to problems like this automatically!
+> **Alternative solution**: Use NuGetSolver, an automated experimental tool from Microsoft DevLabs(not officially supported by NuGet) for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.
 [Learn more about how you can try out NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/#usage-recommendations-and-known-constraints) and we'd love to hear your feedback about your experience.
 

--- a/docs/includes/nugetsolver-tool.md
+++ b/docs/includes/nugetsolver-tool.md
@@ -7,7 +7,9 @@ ms.date: 1/16/2024
 ms.topic: include
 ---
 
-> [!Experimental automated solution tool from Microsoft DevLabs, not officially supported]
+> [!Tip]
+
+Experimental automated solution tool from Microsoft DevLabs, not officially supported
 
 > Use NuGetSolver, our experimental tool for solving dependency conflicts, to help you find solutions to problems like this automatically!
 If you're using Visual Studio 2022, and have nuget.org as your only source, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/) can help free your dependency graph of resolver warnings/errors.

--- a/docs/reference/errors-and-warnings/NU1107.md
+++ b/docs/reference/errors-and-warnings/NU1107.md
@@ -29,5 +29,7 @@ To install a specific version, see the information for the tool that you're usin
 - [nuget.exe CLI](../../consume-packages/install-use-packages-nuget-cli.md#install-a-specific-version-of-a-package)
 - [Package Manager Console](../ps-reference/ps-ref-install-package.md)
 
+Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.
+
 ### Note
 Early versions of Visual Studio 2017 may have reported this as a warning (NU1607).

--- a/docs/reference/errors-and-warnings/NU1107.md
+++ b/docs/reference/errors-and-warnings/NU1107.md
@@ -18,7 +18,7 @@ f1_keywords:
 ### Issue
 Unable to resolve dependency constraints between packages. Two different packages are asking for two different versions of 'PackageA'. The project needs to choose which version of 'PackageA' to use.
 
-### Solution
+### Solution 1
 Install/reference 'PackageA' directly (in the project file) with the exact version that you choose.
 Generally, picking the higher version is the right choice.
 
@@ -29,7 +29,8 @@ To install a specific version, see the information for the tool that you're usin
 - [nuget.exe CLI](../../consume-packages/install-use-packages-nuget-cli.md#install-a-specific-version-of-a-package)
 - [Package Manager Console](../ps-reference/ps-ref-install-package.md)
 
-Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.
+### Solution 2
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]
 
 ### Note
 Early versions of Visual Studio 2017 may have reported this as a warning (NU1607).

--- a/docs/reference/errors-and-warnings/NU1107.md
+++ b/docs/reference/errors-and-warnings/NU1107.md
@@ -18,7 +18,7 @@ f1_keywords:
 ### Issue
 Unable to resolve dependency constraints between packages. Two different packages are asking for two different versions of 'PackageA'. The project needs to choose which version of 'PackageA' to use.
 
-### Solution 1
+### Solution
 Install/reference 'PackageA' directly (in the project file) with the exact version that you choose.
 Generally, picking the higher version is the right choice.
 
@@ -29,7 +29,6 @@ To install a specific version, see the information for the tool that you're usin
 - [nuget.exe CLI](../../consume-packages/install-use-packages-nuget-cli.md#install-a-specific-version-of-a-package)
 - [Package Manager Console](../ps-reference/ps-ref-install-package.md)
 
-### Solution 2
 [!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]
 
 ### Note

--- a/docs/reference/errors-and-warnings/NU1202.md
+++ b/docs/reference/errors-and-warnings/NU1202.md
@@ -18,4 +18,5 @@ f1_keywords:
 A dependency package doesn't contain any assets compatible with the project.
 
 ### Solution
-Change the project's target framework to one that the package supports.
+- Change the project's target framework to one that the package supports.
+- Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.

--- a/docs/reference/errors-and-warnings/NU1202.md
+++ b/docs/reference/errors-and-warnings/NU1202.md
@@ -17,8 +17,7 @@ f1_keywords:
 ### Issue
 A dependency package doesn't contain any assets compatible with the project.
 
-### Solution 1
+### Solution
 Change the project's target framework to one that the package supports.
 
-### Solution 2
 [!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]

--- a/docs/reference/errors-and-warnings/NU1202.md
+++ b/docs/reference/errors-and-warnings/NU1202.md
@@ -17,6 +17,8 @@ f1_keywords:
 ### Issue
 A dependency package doesn't contain any assets compatible with the project.
 
-### Solution
-- Change the project's target framework to one that the package supports.
-- Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.
+### Solution 1
+Change the project's target framework to one that the package supports.
+
+### Solution 2
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]

--- a/docs/reference/errors-and-warnings/NU1605.md
+++ b/docs/reference/errors-and-warnings/NU1605.md
@@ -12,8 +12,6 @@ f1_keywords:
 
 # NuGet Warning NU1605
 
-[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]
-
 ## Example 1
 
 <pre>Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Reference the package directly from the project to select a different version.<br/>  
@@ -99,3 +97,4 @@ This specific error (with Microsoft.NETCore.App package) is improved by moving y
 > Your project may be upgrading this warning to an error by setting `TreatWarningsAsErrors` to `true`.
 > While not recommended, as you are more likely to encounter runtime issues, you may choose to [suppress](../../consume-packages/Package-References-in-Project-Files.md#suppressing-nuget-warnings) this warning.
 
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]

--- a/docs/reference/errors-and-warnings/NU1605.md
+++ b/docs/reference/errors-and-warnings/NU1605.md
@@ -12,8 +12,6 @@ f1_keywords:
 
 # NuGet Warning NU1605
 
-[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]
-
 ## Example 1
 
 <pre>Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Reference the package directly from the project to select a different version.<br/>  
@@ -98,3 +96,5 @@ This specific error (with Microsoft.NETCore.App package) is improved by moving y
 > While NU1605 is considered a warning by the NuGet tooling, the [.NET SDK](/dotnet/core/sdk) opts into treating this warning as an error through `WarningsAsErrors`.
 > Your project may be upgrading this warning to an error by setting `TreatWarningsAsErrors` to `true`.
 > While not recommended, as you are more likely to encounter runtime issues, you may choose to [suppress](../../consume-packages/Package-References-in-Project-Files.md#suppressing-nuget-warnings) this warning.
+
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]

--- a/docs/reference/errors-and-warnings/NU1605.md
+++ b/docs/reference/errors-and-warnings/NU1605.md
@@ -12,7 +12,7 @@ f1_keywords:
 
 # NuGet Warning NU1605
 
-Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]
 
 ## Example 1
 

--- a/docs/reference/errors-and-warnings/NU1605.md
+++ b/docs/reference/errors-and-warnings/NU1605.md
@@ -12,6 +12,8 @@ f1_keywords:
 
 # NuGet Warning NU1605
 
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]
+
 ## Example 1
 
 <pre>Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Reference the package directly from the project to select a different version.<br/>  
@@ -97,4 +99,3 @@ This specific error (with Microsoft.NETCore.App package) is improved by moving y
 > Your project may be upgrading this warning to an error by setting `TreatWarningsAsErrors` to `true`.
 > While not recommended, as you are more likely to encounter runtime issues, you may choose to [suppress](../../consume-packages/Package-References-in-Project-Files.md#suppressing-nuget-warnings) this warning.
 
-[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]

--- a/docs/reference/errors-and-warnings/NU1605.md
+++ b/docs/reference/errors-and-warnings/NU1605.md
@@ -12,6 +12,8 @@ f1_keywords:
 
 # NuGet Warning NU1605
 
+Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.
+
 ## Example 1
 
 <pre>Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Reference the package directly from the project to select a different version.<br/>  

--- a/docs/reference/errors-and-warnings/NU1701.md
+++ b/docs/reference/errors-and-warnings/NU1701.md
@@ -17,8 +17,7 @@ f1_keywords:
 ### Issue
 `PackageTargetFallback` / `AssetTargetFallback` was used to select assets from a package. The warning let users know that the assets may not be 100% compatible.
 
-### Solution 1
+### Solution
 Change the project's target framework to one that the package supports.
 
-### Solution 2
 [!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]

--- a/docs/reference/errors-and-warnings/NU1701.md
+++ b/docs/reference/errors-and-warnings/NU1701.md
@@ -18,4 +18,5 @@ f1_keywords:
 `PackageTargetFallback` / `AssetTargetFallback` was used to select assets from a package. The warning let users know that the assets may not be 100% compatible.
 
 ### Solution
-Change the project's target framework to one that the package supports.
+- Change the project's target framework to one that the package supports.
+- Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.

--- a/docs/reference/errors-and-warnings/NU1701.md
+++ b/docs/reference/errors-and-warnings/NU1701.md
@@ -17,6 +17,8 @@ f1_keywords:
 ### Issue
 `PackageTargetFallback` / `AssetTargetFallback` was used to select assets from a package. The warning let users know that the assets may not be 100% compatible.
 
-### Solution
-- Change the project's target framework to one that the package supports.
-- Give our new experimental one-click tool, [NuGetSolver](https://devblogs.microsoft.com/nuget/introducing-nugetsolver-a-powerful-tool-for-resolving-nuget-dependency-conflicts-in-visual-studio/), a try. This tool can automatically fix this problem if you’re using VS2022 with nuget.org. Please provide us with feedback. Based on the feedback received, we will decide whether to officially support this new tool and incorporate it into the NuGet package manager.
+### Solution 1
+Change the project's target framework to one that the package supports.
+
+### Solution 2
+[!INCLUDE [nugetsolver-tool](../../includes/nugetsolver-tool.md)]


### PR DESCRIPTION
Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/3211
Add link to NuGet docs for NuGetSolver tool with clear indication of it's experimental tool, not officially supported.