### PR TITLE
Edit install-and-use-a-package-using-the-dotnet-cli.md -- remove source of warning

### DIFF
--- a/docs/quickstart/install-and-use-a-package-using-the-dotnet-cli.md
+++ b/docs/quickstart/install-and-use-a-package-using-the-dotnet-cli.md
@@ -67,8 +67,8 @@ You can install NuGet packages into a .NET project. For this walkthrough, create
     {
         public class Account
         {
-            public string Name { get; set; }
-            public string Email { get; set; }
+            public string? Name { get; set; }
+            public string? Email { get; set; }
             public DateTime DOB { get; set; }
         }
         internal class Program


### PR DESCRIPTION
### Example code leads to warnings
The sample code
```csharp
public class Account
{
    public string Name { get; set; }
    public string Email { get; set; }
    ...
}
```
leads to warnings:
```
$ dotnet run
Nuget.Quickstart/Program.cs(7,23): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider declaring the property as nullable. [Nuget.Quickstart/Nuget.Quickstart.csproj]
Nuget.Quickstart/Program.cs(8,23): warning CS8618: Non-nullable property 'Email' must contain a non-null value when exiting constructor. Consider declaring the property as nullable. [Nuget.Quickstart/Nuget.Quickstart.csproj]
```

This commit applies a small edit (i.e. add `?` after `string`) so that `dotnet run` does not warn. 

The warnings are not a big deal. They are a small distraction. I propose this edit in case it is worth removing the small distraction for the users of the tutorial.


### Alternative edits 

This commit uses `?` since 
 - I saw this syntax in earlier tutorials (e.g. [add-and-run-unit-test-methods](https://learn.microsoft.com/en-us/dotnet/core/tutorials/testing-library-with-visual-studio-code?pivots=dotnet-8-0#add-and-run-unit-test-methods) and [create-a-class-library-project](https://learn.microsoft.com/en-us/dotnet/core/tutorials/library-with-visual-studio-code?pivots=dotnet-8-0#create-a-class-library-project))
 - it is a small change

Suppose that it is worth removing the source of the warnings but that using `?` is dispreferred. I found these alternative ways to remove the source of the warnings:
1.
```csharp
public class Account
{
    public string Name { get; set; }
    public string Email { get; set; }
    ...
}
```
-> 
```csharp
public class Account
{
    public string Name { get; set; } = string.Empty;
    public string Email { get; set; } = string.Empty;
    ...
}
```

2. in `Nuget.Quickstart.csproj`
```
  <PropertyGroup>
    ...
    <Nullable>enable</Nullable>
  </PropertyGroup>
```
-> 
```
  <PropertyGroup>
    ...
    <Nullable>disable</Nullable>
  </PropertyGroup>
```
or
```
  <PropertyGroup>
    ...
  </PropertyGroup>
```
(i.e. remove `<Nullable>enable</Nullable>`).