### PR TITLE
Update `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` documentation

### DIFF
--- a/docs/reference/Signed-Package-Verification-Options.md
+++ b/docs/reference/Signed-Package-Verification-Options.md
@@ -24,10 +24,13 @@ For NuGet users, symptoms of this issue are that the NuGet operation will typica
 > [!Note]
 > This option is available starting from NuGet 6.0.0 and only applies to the Windows-specific failure described above.  The option does not apply to any other scenario and has no effect on Linux or macOS.
 
-You can opt-in to an experimental, automatic retry for untrusted root failures on Windows by setting an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively. There are no default values; you need to pick retry values that are sensible for you.
+You can opt in to an experimental, automatic retry for untrusted root failures on Windows by setting an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively. There are no default values; you need to pick retry values that are sensible for you.
 
 For example, setting the environment variable to a value of `3,1000` like so:
 
 <pre>set NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY=3,1000</pre>
 
 ...would try up to 4 times (initial try plus 3 retries) with 1 second (1,000 ms) between each try.
+
+> [!Note]
+> Starting with NuGet 6.8.0 and .NET 8 SDK (8.0.100), this option is enabled by default on Windows.  The environment variable does not need to be set explicitly unless you want to override the default retry value of `3,1000` or to opt out.  To opt out, set the environment variable with a value of `0`.

--- a/docs/reference/Signed-Package-Verification-Options.md
+++ b/docs/reference/Signed-Package-Verification-Options.md
@@ -23,14 +23,15 @@ For NuGet users, symptoms of this issue are that the NuGet operation will typica
 
 > [!Note]
 > This option is available starting from NuGet 6.0.0 and only applies to the Windows-specific failure described above.  The option does not apply to any other scenario and has no effect on Linux or macOS.
+>
+> Before NuGet 6.8.0 and .NET 8 SDK, this option is disabled by default.
+>
+> Starting with NuGet 6.8.0 and .NET 8 SDK, this option is enabled by default on Windows.  The environment variable does not need to be set explicitly unless you want to override the default value of `3,1000` or to opt out.  To opt out, set the environment variable with a value of `0`.
 
-You can opt in to an experimental, automatic retry for untrusted root failures on Windows by setting an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively. There are no default values; you need to pick retry values that are sensible for you.
+You enable an experimental, automatic retry for untrusted root failures on Windows by setting an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively. You should pick values that are sensible for you.
 
 For example, setting the environment variable to a value of `3,1000` like so:
 
 <pre>set NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY=3,1000</pre>
 
 ...would try up to 4 times (initial try plus 3 retries) with 1 second (1,000 ms) between each try.
-
-> [!Note]
-> Starting with NuGet 6.8.0 and .NET 8 SDK (8.0.100), this option is enabled by default on Windows.  The environment variable does not need to be set explicitly unless you want to override the default retry value of `3,1000` or to opt out.  To opt out, set the environment variable with a value of `0`.

--- a/docs/reference/Signed-Package-Verification-Options.md
+++ b/docs/reference/Signed-Package-Verification-Options.md
@@ -28,7 +28,7 @@ For NuGet users, symptoms of this issue are that the NuGet operation will typica
 >
 > Starting with NuGet 6.8.0 and .NET 8 SDK, this option is enabled by default on Windows.  The environment variable does not need to be set explicitly unless you want to override the default value of `3,1000` or to opt out.  To opt out, set the environment variable with a value of `0`.
 
-You enable an experimental, automatic retry for untrusted root failures on Windows by setting an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively. You should pick values that are sensible for you.
+You can enable an experimental, automatic retry for untrusted root failures on Windows by setting an environment variable named `NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY` with a value consisting of 2 comma-delimited positive integers representing retry count and sleep interval in milliseconds, respectively. You should pick values that are sensible for you.
 
 For example, setting the environment variable to a value of `3,1000` like so:
 


### PR DESCRIPTION
Resolve https://github.com/NuGet/docs.microsoft.com-nuget/issues/3133.

This change updates documentation to note that the option was enabled by default starting with NuGet 6.8.0 / .NET 8 SDK.