### PR TITLE
Create Support Policy sections for NuGet.exe & NuGet SDK packages

### DIFF
--- a/docs/consume-packages/install-use-packages-nuget-cli.md
+++ b/docs/consume-packages/install-use-packages-nuget-cli.md
@@ -20,30 +20,6 @@ For most commands, the NuGet CLI tool uses the current directory, unless you spe
 
 For a complete list of commands and their arguments, see the [NuGet CLI reference](../reference/nuget-exe-cli-reference.md).
 
-## Support policy
-
-We are fully committed to supporting the most recent version of NuGet.exe.
-This means you can rely on us for bug fixes, updates, and enhancements exclusive to the version currently under development.
-
-NuGet.exe follows the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
-
-Here are steps you can take to leverage the NuGet Support Policy effectively:
-
-* Use the latest version of NuGet.exe.
-* Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
-* Watch for unlisted NuGet.exe versions in [tools.json](../api/tools-json.md).
-
-### Security Patch Releases
-
-We will release patched versions of NuGet.exe exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
-
-All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
-Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
-
-### NuGet.exe unlisting
-
-We will begin to remove links to deprecated and vulnerable versions of NuGet.exe from [tools.json](../api/tools-json.md) by March 31st, 2024.
-
 ## Prerequisites
 
 Download the NuGet CLI from [nuget.org](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe). Save the *nuget.exe* file to a suitable directory, and make sure the directory is in your PATH environment variable.

--- a/docs/consume-packages/install-use-packages-nuget-cli.md
+++ b/docs/consume-packages/install-use-packages-nuget-cli.md
@@ -25,13 +25,13 @@ For a complete list of commands and their arguments, see the [NuGet CLI referenc
 We are fully committed to supporting the most recent version of NuGet.exe.
 This means you can rely on us for bug fixes, updates, and enhancements exclusive to the version currently under development.
 
-NuGet.exe follows the [Microsoft Modern Lifecycle Policy](https://learn.microsoft.com/lifecycle/policies/modern).
+NuGet.exe follows the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
 
 Here are steps you can take to leverage the NuGet Support Policy effectively:
 
 * Use the latest version of NuGet.exe.
 * Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
-* Watch for unlisted NuGet.exe versions in [tool.json](https://learn.microsoft.com/nuget/api/tools-json).
+* Watch for unlisted NuGet.exe versions in [tool.json](../api/tools-json.md).
 
 ### Security Patch Releases
 
@@ -42,7 +42,7 @@ Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet
 
 ### NuGet.exe unlisting
 
-We will begin to remove links to deprecated and vulnerable versions of NuGet.exe from [tool.json](https://learn.microsoft.com/nuget/api/tools-json) by March 31st, 2024.
+We will begin to remove links to deprecated and vulnerable versions of NuGet.exe from [tool.json](../api/tools-json.md) by March 31st, 2024.
 
 ## Prerequisites
 

--- a/docs/consume-packages/install-use-packages-nuget-cli.md
+++ b/docs/consume-packages/install-use-packages-nuget-cli.md
@@ -31,7 +31,7 @@ Here are steps you can take to leverage the NuGet Support Policy effectively:
 
 * Use the latest version of NuGet.exe.
 * Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
-* Watch for unlisted NuGet.exe versions in [tool.json](../api/tools-json.md).
+* Watch for unlisted NuGet.exe versions in [tools.json](../api/tools-json.md).
 
 ### Security Patch Releases
 
@@ -42,7 +42,7 @@ Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet
 
 ### NuGet.exe unlisting
 
-We will begin to remove links to deprecated and vulnerable versions of NuGet.exe from [tool.json](../api/tools-json.md) by March 31st, 2024.
+We will begin to remove links to deprecated and vulnerable versions of NuGet.exe from [tools.json](../api/tools-json.md) by March 31st, 2024.
 
 ## Prerequisites
 

--- a/docs/consume-packages/install-use-packages-nuget-cli.md
+++ b/docs/consume-packages/install-use-packages-nuget-cli.md
@@ -20,6 +20,30 @@ For most commands, the NuGet CLI tool uses the current directory, unless you spe
 
 For a complete list of commands and their arguments, see the [NuGet CLI reference](../reference/nuget-exe-cli-reference.md).
 
+## Support policy
+
+We are fully committed to supporting the most recent version of NuGet.exe.
+This means you can rely on us for bug fixes, updates, and enhancements exclusive to the version currently under development.
+
+NuGet.exe follows the [Microsoft Modern Lifecycle Policy](https://learn.microsoft.com/lifecycle/policies/modern).
+
+Here are steps you can take to leverage the NuGet Support Policy effectively:
+
+* Use the latest version of NuGet.exe.
+* Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
+* Watch for unlisted NuGet.exe versions in [tool.json](https://learn.microsoft.com/nuget/api/tools-json).
+
+### Security Patch Releases
+
+We will release patched versions of NuGet.exe exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
+
+All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
+Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+
+### NuGet.exe unlisting
+
+We will begin to remove links to deprecated and vulnerable versions of NuGet.exe from [tool.json](https://learn.microsoft.com/nuget/api/tools-json) by March 31st, 2024.
+
 ## Prerequisites
 
 Download the NuGet CLI from [nuget.org](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe). Save the *nuget.exe* file to a suitable directory, and make sure the directory is in your PATH environment variable.

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -40,7 +40,7 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 ## Support policy
 
-Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/visualstudio/productinfo/vs-servicing).
+The Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/visualstudio/productinfo/vs-servicing).
 
 
 The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -42,8 +42,6 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.
 
-Out-of-support NuGet.exe versions will be unlisted from [tools.json](./api/tools-json.md).
-
 For more information on NuGet.exe's support policy, see the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
 
 ### Patch Releases
@@ -55,7 +53,7 @@ Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGe
 
 ### NuGet.exe unlisting
 
-Deprecated and vulnerable versions of NuGet.exe will be removed from [tools.json](./api/tools-json.md) in 2024.
+Out-of-support, deprecated, or vulnerable NuGet.exe versions will be unlisted from [tools.json](./api/tools-json.md).
 
 ## Visual Studio
 

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -46,7 +46,7 @@ Out-of-support NuGet.exe versions will be unlisted from [tools.json](../api/tool
 
 For more information on NuGet.exe's support policy, see the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
 
-### Security Patch Releases
+### Patch Releases
 
 Patched versions of NuGet.exe will be released exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -53,7 +53,7 @@ Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGe
 
 ### NuGet.exe unlisting
 
-Out-of-support, deprecated, or vulnerable NuGet.exe versions will be unlisted from [tools.json](./api/tools-json.md).
+Out-of-support, deprecated, or vulnerable NuGet.exe versions will be removed from [tools.json](./api/tools-json.md).
 
 ## Visual Studio
 

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -40,22 +40,15 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 ## Support policy
 
-We are fully committed to supporting the most recent version of NuGet.exe.
+The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.
 
-This means you can rely on us for bug fixes, updates, and enhancements exclusive to the version currently under development.
+Out-of-support NuGet.exe versions will be unlisted from [tools.json](../api/tools-json.md).
 
-NuGet.exe follows the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
-
-Here are steps you can take to leverage the NuGet Support Policy effectively:
-
-* Use the latest version of NuGet.exe.
-* Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
-
-* Watch for unlisted NuGet.exe versions in [tools.json](../api/tools-json.md).
+For more information on NuGet.exe's support policy, see the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
 
 ### Security Patch Releases
 
-We will release patched versions of NuGet.exe exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
+Patched versions of NuGet.exe will be released exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 
 All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
 Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -38,6 +38,32 @@ The [MSBuild CLI](reference/msbuild-targets.md) also restores and creates packag
 
 Package Manager Console commands work only within Visual Studio on Windows and don't work within other PowerShell environments.
 
+## Support policy
+
+We are fully committed to supporting the most recent version of NuGet.exe.
+
+This means you can rely on us for bug fixes, updates, and enhancements exclusive to the version currently under development.
+
+NuGet.exe follows the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
+
+Here are steps you can take to leverage the NuGet Support Policy effectively:
+
+* Use the latest version of NuGet.exe.
+* Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
+
+* Watch for unlisted NuGet.exe versions in [tools.json](../api/tools-json.md).
+
+### Security Patch Releases
+
+We will release patched versions of NuGet.exe exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
+
+All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
+Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+
+### NuGet.exe unlisting
+
+Deprecated and vulnerable versions of NuGet.exe will be removed from [tools.json](../api/tools-json.md) in 2024.
+
 ## Visual Studio
 
 In Visual Studio 2017 and later, the Visual Studio installer includes the NuGet Package Manager with any workload that employs .NET.

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -40,9 +40,14 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 ## Support policy
 
-The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.
+Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/visualstudio/productinfo/vs-servicing).
 
+
+The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.
 For more information on NuGet.exe's support policy, see the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
+
+
+The .NET SDK support policy can be found at [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
 
 ### Patch Releases
 

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -50,7 +50,7 @@ For more information on NuGet.exe's support policy, see the [Microsoft Modern Li
 
 Patched versions of NuGet.exe will be released exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 
-All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
+All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [MSRC's report page](https://aka.ms/opensource/security/create-report).
 Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
 
 ### NuGet.exe unlisting

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -42,7 +42,7 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.
 
-Out-of-support NuGet.exe versions will be unlisted from [tools.json](../api/tools-json.md).
+Out-of-support NuGet.exe versions will be unlisted from [tools.json](./api/tools-json.md).
 
 For more information on NuGet.exe's support policy, see the [Microsoft Modern Lifecycle Policy](https://aka.ms/lifecycle).
 
@@ -55,7 +55,7 @@ Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGe
 
 ### NuGet.exe unlisting
 
-Deprecated and vulnerable versions of NuGet.exe will be removed from [tools.json](../api/tools-json.md) in 2024.
+Deprecated and vulnerable versions of NuGet.exe will be removed from [tools.json](./api/tools-json.md) in 2024.
 
 ## Visual Studio
 

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -51,7 +51,7 @@ For more information on NuGet.exe's support policy, see the [Microsoft Modern Li
 Patched versions of NuGet.exe will be released exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 
 All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
-Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
 
 ### NuGet.exe unlisting
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -40,6 +40,12 @@ Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGe
 We do not guarantee API stability, as our team's responsibility is tooling, not libraries.
 See the [NuGet SDK documentation in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/docs/nuget-sdk.md) for more information.
 
+Here are steps you can take to leverage the NuGet Support Policy effectively:
+
+* Use the latest versions of NuGet Client SDK packages.
+* Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
+* Examine your project for dependencies on deprecated NuGet Client SDK packages.
+
 ### Security Patch Releases
 
 We will release patched versions of NuGet Client SDK packages exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -37,8 +37,6 @@ The most recent version of NuGet Client SDK is fully supported and can be relied
 
 The recommendation is to use the latest versions of NuGet Client SDK packages, and to examine your project for dependencies on deprecated NuGet Client SDK packages.
 
-Out-of-support NuGet Client SDK packages will be [deprecated on nuget.org](../nuget-org/Deprecate-packages.md#client-experience-for-deprecated-packages).
-
 ### Patch Releases
 
 Patched versions of NuGet Client SDK will be released exclusively when critical bugs or security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
@@ -51,7 +49,7 @@ See the [NuGet SDK documentation in the NuGet.Client repo](https://github.com/Nu
 
 ### Package Deprecation
 
-Older versions of NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET will be deprecated.
+Out-of-support NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET will be [deprecated on nuget.org](../nuget-org/Deprecate-packages.md#client-experience-for-deprecated-packages).
 
 NuGet's package maintenance approach will align with the [.NET Package Maintenance (deprecation)](https://github.com/dotnet/announcements/issues/217) guidance.
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -44,7 +44,7 @@ Out-of-support NuGet Client SDK packages will be [deprecated on nuget.org](../nu
 Patched versions of NuGet Client SDK will be released exclusively when critical bugs or security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 
 All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
-Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
 
 ### Package Deprecation
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -43,12 +43,15 @@ Out-of-support NuGet Client SDK packages will be [deprecated on nuget.org](../nu
 
 Patched versions of NuGet Client SDK will be released exclusively when critical bugs or security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 
-All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
+All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [MSRC's report page](https://aka.ms/opensource/security/create-report).
 Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+
+We do not guarantee API stability, as our team's responsibility is tooling, not libraries.
+See the [NuGet SDK documentation in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/docs/nuget-sdk.md) for more information.
 
 ### Package Deprecation
 
-As of January 31, 2024, older versions of NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET have been deprecated.
+Older versions of NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET will be deprecated.
 
 NuGet's package maintenance approach will align with the [.NET Package Maintenance (deprecation)](https://github.com/dotnet/announcements/issues/217) guidance.
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -33,29 +33,22 @@ You can find the source code for these packages in the [NuGet/NuGet.Client](http
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
 
 ## Support policy
+The most recent version of NuGet Client SDK is fully supported and can be relied on for bug fixes, updates, and enhancements.
 
-All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [MSRC's report page](https://aka.ms/opensource/security/create-report).
-Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+The recommendation is to use the latest versions of NuGet Client SDK packages, and to examine your project for dependencies on deprecated NuGet Client SDK packages.
 
-We do not guarantee API stability, as our team's responsibility is tooling, not libraries.
-See the [NuGet SDK documentation in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/docs/nuget-sdk.md) for more information.
+Out-of-support NuGet Client SDK packages will be [deprecated on nuget.org](../nuget-org/Deprecate-packages.md#client-experience-for-deprecated-packages).
 
-Here are steps you can take to leverage the NuGet Support Policy effectively:
+### Patch Releases
 
-* Use the latest versions of NuGet Client SDK packages.
-* Note that we will release patches when critical security fixes are required for an LTS version of either Visual Studio or the .NET SDK.
-* Examine your project for dependencies on deprecated NuGet Client SDK packages.
-
-### Security Patch Releases
-
-We will release patched versions of NuGet Client SDK packages exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
+Patched versions of NuGet Client SDK will be released exclusively when critical bugs or security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
 
 All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
 Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
 
 ### Package Deprecation
 
-As of January 31, 2024, we have deprecated older versions of NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET.
+As of January 31, 2024, older versions of NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET have been deprecated.
 
 NuGet's package maintenance approach will align with the [.NET Package Maintenance (deprecation)](https://github.com/dotnet/announcements/issues/217) guidance.
 

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -40,6 +40,19 @@ Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGe
 We do not guarantee API stability, as our team's responsibility is tooling, not libraries.
 See the [NuGet SDK documentation in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/docs/nuget-sdk.md) for more information.
 
+### Security Patch Releases
+
+We will release patched versions of NuGet Client SDK packages exclusively when critical security fixes are required for a long-term support (LTS) version of Visual Studio or .NET SDK.
+
+All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
+Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+
+### Package Deprecation
+
+As of January 31, 2024, we have deprecated older versions of NuGet Client SDK packages that are not tied to an LTS version of either Visual Studio or .NET.
+
+NuGet's package maintenance approach will align with the [.NET Package Maintenance (deprecation)](https://github.com/dotnet/announcements/issues/217) guidance.
+
 ## NuGet.Protocol
 
 Install the `NuGet.Protocol` package to interact with HTTP and folder-based NuGet package feeds:

--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -33,6 +33,7 @@ You can find the source code for these packages in the [NuGet/NuGet.Client](http
 > For documentation on the NuGet server protocol, please refer to the [NuGet Server API](~/api/overview.md).
 
 ## Support policy
+
 The most recent version of NuGet Client SDK is fully supported and can be relied on for bug fixes, updates, and enhancements.
 
 The recommendation is to use the latest versions of NuGet Client SDK packages, and to examine your project for dependencies on deprecated NuGet Client SDK packages.


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/2660

Adapted the verbiage from the relevant blog post: https://devblogs.microsoft.com/nuget/announcing-nuget-exe-and-nuget-client-sdk-packages-support-policy-keeping-you-informed-and-secure/