### PR TITLE
document security best practices for managing credentials.

### DIFF
--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -121,6 +121,8 @@ When using multiple public & private NuGet source feeds, a package can be downlo
 
 For more information to secure your package feeds, see [3 Ways to Mitigate Risk When Using Private Package Feeds](https://azure.microsoft.com/resources/3-ways-to-mitigate-risk-using-private-package-feeds/).
 
+When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
+
 ### Client trust policies
 
 **📦 Package Consumer**

--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -121,7 +121,7 @@ When using multiple public & private NuGet source feeds, a package can be downlo
 
 For more information to secure your package feeds, see [3 Ways to Mitigate Risk When Using Private Package Feeds](https://azure.microsoft.com/resources/3-ways-to-mitigate-risk-using-private-package-feeds/).
 
-When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials) for guidance.
+When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 
 ### Client trust policies
 

--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -119,7 +119,7 @@ For more information about Dependabot alerts & security updates, [see the follow
 
 When using multiple public & private NuGet source feeds, a package can be downloaded from any of the feeds. To ensure your build is predictable and secure from known attacks such as [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610), knowing what specific feed(s) your packages are coming from is a best practice. You can use a single feed or private feed with upstreaming capabilities for protection.
 
-For more information to secure your package feeds, see [3 Ways to Mitigate Risk When Using Private Package Feeds](https://azure.microsoft.com/resources/3-ways-to-mitigate-risk-using-private-package-feeds/).
+For more information to secure your package feeds, see [3 Ways to Mitigate Risk When Using Private Package Feeds](https://azure.microsoft.com/resources/3-ways-to-mitigate-risk-using-private-package-feeds/en-us/).
 
 When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 

--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -121,7 +121,7 @@ When using multiple public & private NuGet source feeds, a package can be downlo
 
 For more information to secure your package feeds, see [3 Ways to Mitigate Risk When Using Private Package Feeds](https://azure.microsoft.com/resources/3-ways-to-mitigate-risk-using-private-package-feeds/).
 
-When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
+When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials) for guidance.
 
 ### Client trust policies
 

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -100,7 +100,7 @@ For more information about valid authentication types, see [the docs on package 
 See [the *nuget.config* file reference doc section on package source credentials](../reference/nuget-config-file.md#packagesourcecredentials) for more information, including syntax.
 However, it's easier to use [`dotnet nuget update source`](/dotnet/core/tools/dotnet-nuget-update-source) on the command line to set the credentials.
 
-> [!CAUTION]
+> [!WARNING]
 > Take care when setting credentials in *nuget.config* files, especially when saving the credential as plain text.
 > If the credential is written to a *nuget.config* file that is in source control, there is an increased risk of accidentally leaking the secret.
 >

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -54,7 +54,7 @@ If these options are not feasible, you can store the credentials in the *nuget.c
 However, this option should only be used in environments where no other secure option is available.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-    > [!CAUTION]
+    > [!WARNING]
     > Storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control, is risky as it increases the chances of accidental credential leaks.
     > If you must store credentials in the *nuget.config* file, consider using one of the more secure options mentioned above.
 

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -18,39 +18,38 @@ For HTTP feeds, NuGet will make an unauthenticated request, and if the server re
 
 ## Security best practices for managing credentials
 
-Although NuGet searches for credentials in the above-mentioned order, we recommend the following order to manage credentials for authenticating with private feeds in a secure manner:
+Although NuGet searches for credentials in the order mentioned above, we recommend the following sequence for securely managing credentials when authenticating with private feeds:
 
 1. **Credential Provider**: It is highly recommended to use a credential provider whenever possible.
-This avoids storing secrets in plain text and reduces the risk of accidentally leaking secrets via source control.
-Additionally, it typically reduces the number of places you need to update when a credential expires or changes.
-If the credential provider supports single sign-on, it may reduce the number of times you need to login, or the number of places that credentials need to be saved.
-Refer to the [credential providers](#credential-providers) section for more information.
+This approach avoids storing secrets in plain text and minimizes the risk of accidentally exposing secrets through source control.
+Moreover, it generally reduces the number of places you need to update when a credential expires or changes.
+If the credential provider supports single sign-on, it may decrease the frequency of logins or the number of places where credentials need to be saved. Refer to the [credential providers](#credential-providers) section for more information.
 
-1. **Encrypted Credentials**: If a credential provider is not available, consider using encrypted credentials.
-This provides an additional layer of security by storing the credentials in an encrypted format.
-Refer to the [credentials in *nuget.config* files](#credentials-in-nugetconfig-files) section for more information.
+1. **Encrypted Credentials in nuget.config**: If a credential provider is not available, you should consider using encrypted credentials.
+This method provides an extra layer of security by storing the credentials in an encrypted format.
+For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-    > [!NOTE]
-    > :warning: **WARNING** :warning: Encrypted passwords are only supported on Windows, and only can be decrypted when used on the same machine and via the same user as the original encryption.
+  > [!NOTE]
+  > :warning: **WARNING** :warning: Be aware that encrypted passwords are only supported on Windows. Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
-1. **Credentials in nuget.config with Environment Variable Macros**: If encrypted credentials are not feasible, you can store the credentials in the *nuget.config* file using environment variable macros.
-This allows you to reference environment variables that contain the actual credentials.
-Refer to the [credentials in *nuget.config* files](#credentials-in-nugetconfig-files) section for more information.
+1. **Using Environment Variable Macros in nuget.config**: If using encrypted credentials is not possible, consider storing the credentials in the *nuget.config* file with environment variable macros.
+This method allows you to reference environment variables that hold the actual credentials.
+For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-1. **Directly Using Environment Variables**: As a fallback option, you can directly use environment variables to store the credentials
-However, keep in mind that this approach may provide less visibility and control compared to using environment variable macros in the *nuget.config* file.
-Refer to the [credentials in environment variables](#credentials-in-environment-variables) section for more information.
+1. **Using Environment Variables Directly**: As a fallback option, you can store the credentials directly in environment variables.
+However, be aware that this method may offer less visibility and control compared to using environment variable macros in the *nuget.config* file.
+For more information, refer to the section on [credentials in environment variables](#credentials-in-environment-variables).
 
-1. **Clear Text Credentials in NuGet.Config**: It is highly recommended to always use one of the other options mentioned above.
-If none of the above options are feasible, you can store the credentials in the *nuget.config* file.
-This option is only provided for compatibility and use in environments where no other secure option is available.
-Refer to the [credentials in *nuget.config* files](#credentials-in-nugetconfig-files) section for more information.
+1. **Clear Text Credentials in NuGet.Config**: It is highly recommended to use one of the previously mentioned options.
+If these options are not feasible, you can store the credentials in the *nuget.config* file.
+However, this option should only be used in environments where no other secure option is available.
+For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-    > [!NOTE]
-    > :warning: **WARNING** :warning: Avoid storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control.
-    > This increases the risk of accidentally leaking the credentials. If you must store credentials in the *nuget.config* file, consider using one of the previous options for added security.
+  > [!NOTE]
+  > :warning: **WARNING** :warning: Storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control, is risky as it increases the chances of accidental credential leaks.
+  > If you must store credentials in the *nuget.config* file, consider using one of the more secure options mentioned above.
 
-By following these best practices, you can ensure the secure authentication of private feeds while minimizing the risk of exposing sensitive information.
+By adhering to these best practices, you can securely authenticate private feeds while minimizing the risk of sensitive information exposure.
 
 The credentials you need to use are determined by the package source.
 Therefore, unless you're using a credential provider, you should check with your package source for what credentials to use.

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -36,7 +36,7 @@ Refer to the [credential providers](#credential-providers) section for more info
 This approach provides an extra layer of security by storing the credentials in an encrypted format.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-    > [!CAUTION]
+    > [!NOTE]
     > Be aware that encrypted passwords are only supported on Windows. 
     > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -23,14 +23,16 @@ Although NuGet searches for credentials in the order mentioned above, we recomme
 1. **Credential Provider**: It is highly recommended to use a credential provider whenever possible.
 This approach avoids storing secrets in plain text and minimizes the risk of accidentally exposing secrets through source control.
 Moreover, it generally reduces the number of places you need to update when a credential expires or changes.
-If the credential provider supports single sign-on, it may decrease the frequency of logins or the number of places where credentials need to be saved. Refer to the [credential providers](#credential-providers) section for more information.
+If the credential provider supports single sign-on, it may decrease the frequency of logins or the number of places where credentials need to be saved.
+Refer to the [credential providers](#credential-providers) section for more information.
 
 1. **Encrypted Credentials in nuget.config**: If a credential provider is not available, you should consider using encrypted credentials.
 This method provides an extra layer of security by storing the credentials in an encrypted format.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
     > [!NOTE]
-    > :warning: **WARNING** :warning: Be aware that encrypted passwords are only supported on Windows. Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
+    > :warning: **WARNING** :warning: Be aware that encrypted passwords are only supported on Windows. 
+    > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
 1. **Using Environment Variable Macros in nuget.config**: If using encrypted credentials is not possible, consider storing the credentials in the *nuget.config* file with environment variable macros.
 This method allows you to reference environment variables that hold the actual credentials.

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -36,8 +36,8 @@ Refer to the [credential providers](#credential-providers) section for more info
 This approach provides an extra layer of security by storing the credentials in an encrypted format.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-    > [!NOTE]
-    > :warning: **WARNING** :warning: Be aware that encrypted passwords are only supported on Windows. 
+    > [!CAUTION]
+    > Be aware that encrypted passwords are only supported on Windows. 
     > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
 1. **Using Environment Variable Macros in nuget.config**: If using encrypted credentials is not possible, consider storing the credentials in the *nuget.config* file with environment variable macros.
@@ -54,8 +54,8 @@ If these options are not feasible, you can store the credentials in the *nuget.c
 However, this option should only be used in environments where no other secure option is available.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-    > [!NOTE]
-    > :warning: **WARNING** :warning: Storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control, is risky as it increases the chances of accidental credential leaks.
+    > [!CAUTION]
+    > Storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control, is risky as it increases the chances of accidental credential leaks.
     > If you must store credentials in the *nuget.config* file, consider using one of the more secure options mentioned above.
 
 By adhering to these best practices, you can securely authenticate private feeds while minimizing the risk of sensitive information exposure.
@@ -100,8 +100,7 @@ For more information about valid authentication types, see [the docs on package 
 See [the *nuget.config* file reference doc section on package source credentials](../reference/nuget-config-file.md#packagesourcecredentials) for more information, including syntax.
 However, it's easier to use [`dotnet nuget update source`](/dotnet/core/tools/dotnet-nuget-update-source) on the command line to set the credentials.
 
-> [!NOTE]
-> :warning: **WARNING** :warning:
+> [!CAUTION]
 > Take care when setting credentials in *nuget.config* files, especially when saving the credential as plain text.
 > If the credential is written to a *nuget.config* file that is in source control, there is an increased risk of accidentally leaking the secret.
 >

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -27,7 +27,7 @@ If the credential provider supports single sign-on, it may decrease the frequenc
 Refer to the [credential providers](#credential-providers) section for more information.
 
 1. **Encrypted Credentials in nuget.config**: If a credential provider is not available, you should consider using encrypted credentials.
-This method provides an extra layer of security by storing the credentials in an encrypted format.
+This approach provides an extra layer of security by storing the credentials in an encrypted format.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
     > [!NOTE]
@@ -35,11 +35,12 @@ For more information, refer to the section on [credentials in *nuget.config* fil
     > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
 1. **Using Environment Variable Macros in nuget.config**: If using encrypted credentials is not possible, consider storing the credentials in the *nuget.config* file with environment variable macros.
-This method allows you to reference environment variables that hold the actual credentials.
+This approach allows you to reference environment variables that contain the actual credentials. 
+It enhances transparency and helps end users understand how their credentials are configured.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
 1. **Using Environment Variables Directly**: As a fallback option, you can store the credentials directly in environment variables.
-However, be aware that this method may offer less visibility and control compared to using environment variable macros in the *nuget.config* file.
+However, be aware that this approach may offer less visibility and control compared to using environment variable macros in the *nuget.config* file.
 For more information, refer to the section on [credentials in environment variables](#credentials-in-environment-variables).
 
 1. **Clear Text Credentials in NuGet.Config**: It is highly recommended to use one of the previously mentioned options.

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -16,6 +16,12 @@ For HTTP feeds, NuGet will make an unauthenticated request, and if the server re
 1. [Credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 1. [Use a NuGet credential provider, if your package source provides one](#credential-providers).
 
+The credentials you need to use are determined by the package source.
+Therefore, unless you're using a credential provider, you should check with your package source for what credentials to use.
+It is very common for package sources to forbid you from using your password (that you log into the website with) with NuGet.
+Typically you need to create a Personal Access Token to use as NuGet's password, but you should check the documentation for the NuGet server you're using.
+Some package sources, such as Azure DevOps and GitHub, have scoped access tokens, so you may need to ensure that any tokens you create include the required scope.
+
 ## Security best practices for managing credentials
 
 Although NuGet searches for credentials in the order mentioned above, we recommend the following sequence for securely managing credentials when authenticating with private feeds:
@@ -53,12 +59,6 @@ For more information, refer to the section on [credentials in *nuget.config* fil
     > If you must store credentials in the *nuget.config* file, consider using one of the more secure options mentioned above.
 
 By adhering to these best practices, you can securely authenticate private feeds while minimizing the risk of sensitive information exposure.
-
-The credentials you need to use are determined by the package source.
-Therefore, unless you're using a credential provider, you should check with your package source for what credentials to use.
-It is very common for package sources to forbid you from using your password (that you log into the website with) with NuGet.
-Typically you need to create a Personal Access Token to use as NuGet's password, but you should check the documentation for the NuGet server you're using.
-Some package sources, such as Azure DevOps and GitHub, have scoped access tokens, so you may need to ensure that any tokens you create include the required scope.
 
 ## Credentials in environment variables
 

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -29,8 +29,8 @@ If the credential provider supports single sign-on, it may decrease the frequenc
 This method provides an extra layer of security by storing the credentials in an encrypted format.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-  > [!NOTE]
-  > :warning: **WARNING** :warning: Be aware that encrypted passwords are only supported on Windows. Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
+    > [!NOTE]
+    > :warning: **WARNING** :warning: Be aware that encrypted passwords are only supported on Windows. Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
 1. **Using Environment Variable Macros in nuget.config**: If using encrypted credentials is not possible, consider storing the credentials in the *nuget.config* file with environment variable macros.
 This method allows you to reference environment variables that hold the actual credentials.
@@ -45,9 +45,9 @@ If these options are not feasible, you can store the credentials in the *nuget.c
 However, this option should only be used in environments where no other secure option is available.
 For more information, refer to the section on [credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 
-  > [!NOTE]
-  > :warning: **WARNING** :warning: Storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control, is risky as it increases the chances of accidental credential leaks.
-  > If you must store credentials in the *nuget.config* file, consider using one of the more secure options mentioned above.
+    > [!NOTE]
+    > :warning: **WARNING** :warning: Storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control, is risky as it increases the chances of accidental credential leaks.
+    > If you must store credentials in the *nuget.config* file, consider using one of the more secure options mentioned above.
 
 By adhering to these best practices, you can securely authenticate private feeds while minimizing the risk of sensitive information exposure.
 

--- a/docs/consume-packages/consuming-packages-authenticated-feeds.md
+++ b/docs/consume-packages/consuming-packages-authenticated-feeds.md
@@ -16,11 +16,41 @@ For HTTP feeds, NuGet will make an unauthenticated request, and if the server re
 1. [Credentials in *nuget.config* files](#credentials-in-nugetconfig-files).
 1. [Use a NuGet credential provider, if your package source provides one](#credential-providers).
 
-> [!NOTE]
-> We recommend using a credential provider when possible.
-> Using a credential provider avoids secrets in the *nuget.config* file, reducing risk of accidentally leaking secrets via source control.
-> Additionally, it typically reduces the number of places you need to update when a credential expires or changes.
-> If the credential provider supports single sign-on, it may reduce the number of times you need to login, or the number of places that credentials need to be saved.
+## Security best practices for managing credentials
+
+Although NuGet searches for credentials in the above-mentioned order, we recommend the following order to manage credentials for authenticating with private feeds in a secure manner:
+
+1. **Credential Provider**: It is highly recommended to use a credential provider whenever possible.
+This avoids storing secrets in plain text and reduces the risk of accidentally leaking secrets via source control.
+Additionally, it typically reduces the number of places you need to update when a credential expires or changes.
+If the credential provider supports single sign-on, it may reduce the number of times you need to login, or the number of places that credentials need to be saved.
+Refer to the [credential providers](#credential-providers) section for more information.
+
+1. **Encrypted Credentials**: If a credential provider is not available, consider using encrypted credentials.
+This provides an additional layer of security by storing the credentials in an encrypted format.
+Refer to the [credentials in *nuget.config* files](#credentials-in-nugetconfig-files) section for more information.
+
+    > [!NOTE]
+    > :warning: **WARNING** :warning: Encrypted passwords are only supported on Windows, and only can be decrypted when used on the same machine and via the same user as the original encryption.
+
+1. **Credentials in nuget.config with Environment Variable Macros**: If encrypted credentials are not feasible, you can store the credentials in the *nuget.config* file using environment variable macros.
+This allows you to reference environment variables that contain the actual credentials.
+Refer to the [credentials in *nuget.config* files](#credentials-in-nugetconfig-files) section for more information.
+
+1. **Directly Using Environment Variables**: As a fallback option, you can directly use environment variables to store the credentials
+However, keep in mind that this approach may provide less visibility and control compared to using environment variable macros in the *nuget.config* file.
+Refer to the [credentials in environment variables](#credentials-in-environment-variables) section for more information.
+
+1. **Clear Text Credentials in NuGet.Config**: It is highly recommended to always use one of the other options mentioned above.
+If none of the above options are feasible, you can store the credentials in the *nuget.config* file.
+This option is only provided for compatibility and use in environments where no other secure option is available.
+Refer to the [credentials in *nuget.config* files](#credentials-in-nugetconfig-files) section for more information.
+
+    > [!NOTE]
+    > :warning: **WARNING** :warning: Avoid storing credentials in clear text in the *nuget.config* file, especially when saving the file in source control.
+    > This increases the risk of accidentally leaking the credentials. If you must store credentials in the *nuget.config* file, consider using one of the previous options for added security.
+
+By following these best practices, you can ensure the secure authentication of private feeds while minimizing the risk of exposing sensitive information.
 
 The credentials you need to use are determined by the package source.
 Therefore, unless you're using a credential provider, you should check with your package source for what credentials to use.
@@ -68,7 +98,8 @@ For more information about valid authentication types, see [the docs on package 
 See [the *nuget.config* file reference doc section on package source credentials](../reference/nuget-config-file.md#packagesourcecredentials) for more information, including syntax.
 However, it's easier to use [`dotnet nuget update source`](/dotnet/core/tools/dotnet-nuget-update-source) on the command line to set the credentials.
 
-> ![Warning]
+> [!NOTE]
+> :warning: **WARNING** :warning:
 > Take care when setting credentials in *nuget.config* files, especially when saving the credential as plain text.
 > If the credential is written to a *nuget.config* file that is in source control, there is an increased risk of accidentally leaking the secret.
 >

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -66,8 +66,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Indicates to store the password in unencrypted text instead of the default behavior of storing an encrypted form.
 
-  > [!Note]
-  > :warning: **WARNING** :warning:
+  > [!CAUTION]
   > Storing passwords in clear text is strongly discouraged.
   > For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](../../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -65,7 +65,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Indicates to store the password in unencrypted text instead of the default behavior of storing an encrypted form.
 
-  > [!CAUTION]
+  > [!WARNING]
   > Storing passwords in clear text is strongly discouraged.
   > For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](../../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -53,10 +53,9 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Specifies the password for authenticating with the source.
 
-  > [!Note]
-  > Make sure to add the sources' password under the same user context as the nuget.exe is later used to access the package source.
-  > The password will be stored encrypted in the config file and can only be decrypted in the same user context as it was encrypted.
-  > So for example when you use a build server to restore NuGet packages the password must be encrypted with the same Windows user under which the build server task will run.
+  > [!CAUTION]
+  > Be aware that encrypted passwords are only supported on Windows. 
+  > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
 - **`-src|-Source`**
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -53,6 +53,11 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Specifies the password for authenticating with the source.
 
+  > [!Note]
+  > Make sure to add the sources' password under the same user context as the nuget.exe is later used to access the package source.
+  > The password will be stored encrypted in the config file and can only be decrypted in the same user context as it was encrypted.
+  > So for example when you use a build server to restore NuGet packages the password must be encrypted with the same Windows user under which the build server task will run.
+
 - **`-src|-Source`**
 
   Path to the package(s) source.
@@ -60,6 +65,11 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 - **`-StorePasswordInClearText`**
 
   Indicates to store the password in unencrypted text instead of the default behavior of storing an encrypted form.
+
+  > [!Note]
+  > :warning: **WARNING** :warning:
+  > Storing passwords in clear text is strongly discouraged.
+  > For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](../../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 
 - **`-UserName`**
 
@@ -79,9 +89,6 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 - **`-Verbosity [normal|quiet|detailed]`**
 
   Specifies the amount of detail displayed in the output: `normal` (the default), `quiet`, or `detailed`.
-
-> [!Note]
-> Make sure to add the sources' password under the same user context as the nuget.exe is later used to access the package source. The password will be stored encrypted in the config file and can only be decrypted in the same user context as it was encrypted. So for example when you use a build server to restore NuGet packages the password must be encrypted with the same Windows user under which the build server task will run.
 
 Also see [Environment variables](cli-ref-environment-variables.md)
 

--- a/docs/reference/cli-reference/cli-ref-sources.md
+++ b/docs/reference/cli-reference/cli-ref-sources.md
@@ -53,7 +53,7 @@ where `<operation>` is one of *List, Add, Remove, Enable, Disable,* or *Update*,
 
   Specifies the password for authenticating with the source.
 
-  > [!CAUTION]
+  > [!NOTE]
   > Be aware that encrypted passwords are only supported on Windows. 
   > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -150,8 +150,7 @@ Optionally, valid authentication types can be specified with the `-validauthenti
 | cleartextpassword | The unencrypted password for the source. Note: environment variables can be used for improved security. |
 | validauthenticationtypes | Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful. |
 
-> [!NOTE]
-> :warning: **WARNING** :warning:
+> [!CAUTION]
 > Storing passwords in clear text is strongly discouraged.
 > Please note that encrypted passwords are only supported on Windows.
 > Furthermore, they can only be decrypted when used on the same machine and by the same user who originally encrypted them.
@@ -210,8 +209,7 @@ When using unencrypted passwords stored in an environment variable:
 ```
 
 When using unencrypted passwords.
-> [!NOTE]
-> :warning: **WARNING** :warning:
+> [!CAUTION]
 > Storing passwords in clear text is strongly discouraged.
 
 ```xml

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -153,7 +153,8 @@ Optionally, valid authentication types can be specified with the `-validauthenti
 > [!NOTE]
 > :warning: **WARNING** :warning:
 > Storing passwords in clear text is strongly discouraged.
-> Please note that encrypted passwords are only supported on Windows. Furthermore, they can only be decrypted when used on the same machine and by the same user who originally encrypted them.
+> Please note that encrypted passwords are only supported on Windows.
+> Furthermore, they can only be decrypted when used on the same machine and by the same user who originally encrypted them.
 > For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 
 > [!Tip]

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -209,7 +209,7 @@ When using unencrypted passwords stored in an environment variable:
 ```
 
 When using unencrypted passwords.
-> [!CAUTION]
+> [!WARNING]
 > Storing passwords in clear text is strongly discouraged.
 
 ```xml

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -143,16 +143,18 @@ Lists all known package sources. The order is ignored during restore operations 
 Stores usernames and passwords for sources, typically specified with the `-username` and `-password` switches with `nuget sources`. Passwords are encrypted by default unless the `-storepasswordincleartext` option is also used.
 Optionally, valid authentication types can be specified with the `-validauthenticationtypes` switch.
 
-> [!NOTE]
-> :warning: **WARNING** :warning:
-> Storing passwords in clear text is not recommended. Refer to the best security practices for [consuming packages from private feeds](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
-
 | Key | Value |
 | --- | --- |
 | username | The user name for the source in plain text. Note: environment variables can be used for improved security. |
 | password | The encrypted password for the source. Encrypted passwords are only supported on Windows, and only can be decrypted when used on the same machine and via the same user as the original encryption. |
 | cleartextpassword | The unencrypted password for the source. Note: environment variables can be used for improved security. |
 | validauthenticationtypes | Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful. |
+
+> [!NOTE]
+> :warning: **WARNING** :warning:
+> Storing passwords in clear text is strongly discouraged.
+> Please note that encrypted passwords are only supported on Windows. Furthermore, they can only be decrypted when used on the same machine and by the same user who originally encrypted them.
+> For more information on managing credentials securely, refer to our [security best practices for consuming packages from private feeds](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 
 > [!Tip]
 > If a non-encrypted password is passed for `password` the error message ["The parameter is incorrect" will occur](https://github.com/NuGet/Home/issues/3245).
@@ -170,6 +172,23 @@ In the config file, the `<packageSourceCredentials>` element contains child node
     <Test_x0020_Source>
         <add key="Username" value="user" />
         <add key="Password" value="..." />
+    </Test_x0020_Source>
+</packageSourceCredentials>
+```
+
+Additionally, valid authentication methods can be supplied.
+
+```xml
+<packageSourceCredentials>
+    <Contoso>
+        <add key="Username" value="user@contoso.com" />
+        <add key="Password" value="..." />
+        <add key="ValidAuthenticationTypes" value="basic" />
+    </Contoso>
+    <Test_x0020_Source>
+        <add key="Username" value="user" />
+        <add key="Password" value="..." />
+        <add key="ValidAuthenticationTypes" value="basic, negotiate" />
     </Test_x0020_Source>
 </packageSourceCredentials>
 ```
@@ -192,7 +211,7 @@ When using unencrypted passwords stored in an environment variable:
 When using unencrypted passwords.
 > [!NOTE]
 > :warning: **WARNING** :warning:
-> Storing passwords in clear text is not recommended.
+> Storing passwords in clear text is strongly discouraged.
 
 ```xml
 <packageSourceCredentials>
@@ -203,26 +222,6 @@ When using unencrypted passwords.
     <Test_x0020_Source>
         <add key="Username" value="user" />
         <add key="ClearTextPassword" value="hal+9ooo_da!sY" />
-    </Test_x0020_Source>
-</packageSourceCredentials>
-```
-
-Additionally, valid authentication methods can be supplied.
-> [!NOTE]
-> :warning: **WARNING** :warning:
-> Storing passwords in clear text is not recommended.
-
-```xml
-<packageSourceCredentials>
-    <Contoso>
-        <add key="Username" value="user@contoso.com" />
-        <add key="Password" value="..." />
-        <add key="ValidAuthenticationTypes" value="basic" />
-    </Contoso>
-    <Test_x0020_Source>
-        <add key="Username" value="user" />
-        <add key="ClearTextPassword" value="hal+9ooo_da!sY" />
-        <add key="ValidAuthenticationTypes" value="basic, negotiate" />
     </Test_x0020_Source>
 </packageSourceCredentials>
 ```

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -208,7 +208,7 @@ When using unencrypted passwords stored in an environment variable:
 </packageSourceCredentials>
 ```
 
-When using unencrypted passwords.
+When using unencrypted passwords:
 > [!WARNING]
 > Storing passwords in clear text is strongly discouraged.
 

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -154,7 +154,7 @@ Optionally, valid authentication types can be specified with the `-validauthenti
 > :warning: **WARNING** :warning:
 > Storing passwords in clear text is strongly discouraged.
 > Please note that encrypted passwords are only supported on Windows. Furthermore, they can only be decrypted when used on the same machine and by the same user who originally encrypted them.
-> For more information on managing credentials securely, refer to our [security best practices for consuming packages from private feeds](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
+> For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
 
 > [!Tip]
 > If a non-encrypted password is passed for `password` the error message ["The parameter is incorrect" will occur](https://github.com/NuGet/Home/issues/3245).

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -143,6 +143,10 @@ Lists all known package sources. The order is ignored during restore operations 
 Stores usernames and passwords for sources, typically specified with the `-username` and `-password` switches with `nuget sources`. Passwords are encrypted by default unless the `-storepasswordincleartext` option is also used.
 Optionally, valid authentication types can be specified with the `-validauthenticationtypes` switch.
 
+> [!NOTE]
+> :warning: **WARNING** :warning:
+> Storing passwords in clear text is not recommended. Refer to the best security practices for [consuming packages from private feeds](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
+
 | Key | Value |
 | --- | --- |
 | username | The user name for the source in plain text. Note: environment variables can be used for improved security. |
@@ -185,7 +189,10 @@ When using unencrypted passwords stored in an environment variable:
 </packageSourceCredentials>
 ```
 
-When using unencrypted passwords:
+When using unencrypted passwords.
+> [!NOTE]
+> :warning: **WARNING** :warning:
+> Storing passwords in clear text is not recommended.
 
 ```xml
 <packageSourceCredentials>
@@ -200,7 +207,10 @@ When using unencrypted passwords:
 </packageSourceCredentials>
 ```
 
-Additionally, valid authentication methods can be supplied:
+Additionally, valid authentication methods can be supplied.
+> [!NOTE]
+> :warning: **WARNING** :warning:
+> Storing passwords in clear text is not recommended.
 
 ```xml
 <packageSourceCredentials>

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -150,7 +150,7 @@ Optionally, valid authentication types can be specified with the `-validauthenti
 | cleartextpassword | The unencrypted password for the source. Note: environment variables can be used for improved security. |
 | validauthenticationtypes | Comma-separated list of valid authentication types for this source. Set this to `basic` if the server advertises NTLM or Negotiate and your credentials must be sent using the Basic mechanism, for instance when using a PAT with on-premises Azure DevOps Server. Other valid values include `negotiate`, `kerberos`, `ntlm`, and `digest`, but these values are unlikely to be useful. |
 
-> [!CAUTION]
+> [!WARNING]
 > Storing passwords in clear text is strongly discouraged.
 > Please note that encrypted passwords are only supported on Windows.
 > Furthermore, they can only be decrypted when used on the same machine and by the same user who originally encrypted them.


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/2583

Updated the documentation to include a warning about setting credentials in plain text and raise awareness about the lack of encrypted password support in non-Windows platforms.

After merging this PR, I will create a follow-up PR in the dotnet docs repo, adding similar warnings to the [dotnet nuget add source](https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-add-source) & [dotnet nuget update source](https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-update-source) docs.