### PR TITLE
Update links and formatting in NuGet-Client-SDK support policy section.

### DIFF
--- a/docs/reference/NuGet-Client-SDK.md
+++ b/docs/reference/NuGet-Client-SDK.md
@@ -34,11 +34,11 @@ You can find the source code for these packages in the [NuGet/NuGet.Client](http
 
 ## Support policy
 
-All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [https://aka.ms/opensource/security/create-report].
-Also see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
+All security bugs should be reported to the Microsoft Security Response Center (MSRC) at [MSRC's report page](https://aka.ms/opensource/security/create-report).
+Also, see the [security policy in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/SECURITY.md).
 
 We do not guarantee API stability, as our team's responsibility is tooling, not libraries.
-See [https://github.com/NuGet/NuGet.Client/blob/dev/docs/nuget-sdk.md] for more information.
+See the [NuGet SDK documentation in the NuGet.Client repo](https://github.com/NuGet/NuGet.Client/blob/dev/docs/nuget-sdk.md) for more information.
 
 ## NuGet.Protocol
 


### PR DESCRIPTION
The links were not formatted properly in the current NuGet Client SDK support policy section (see below screenshot). https://learn.microsoft.com/nuget/reference/nuget-client-sdk#support-policy. Made some minor changes to the markdown so that the hyperlinks are more visible to the end user.

<img width="584" alt="image" src="https://github.com/NuGet/docs.microsoft.com-nuget/assets/52756182/1d3df01e-5c4d-44a0-b848-49f4a498a8d3">
