### PR TITLE
Add GitHub stale issues bot

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,34 @@
+# See https://github.com/marketplace/actions/close-stale-issues
+# Mark issues as stale if they're open with no activity for 1 day
+# Closed marked issues after 3 days.
+  
+name: close-stale-issues
+
+on:
+  schedule:
+    - cron: "0 0 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Thanks for sharing your feedback. We apologize for our delayed response. Due to the sheer volume of feedback in our repo, we have decided to prioritize the newest issues and are automatically closing our oldest issues with an Issues bot. If you believe your feedback is still actionable, then either respond directly in this issue or open a new documentation issue and we’ll review. If no activity occurs in the next 14 days, this issue will be closed.'
+          close-issue-message: 'This issue is closed. If you feel this issue has been closed in error, please submit a new comment on the issue, and we will review it.'
+          stale-issue-label: 'stale'
+          close-issue-label: 'auto-close'
+          exempt-issue-labels: 'exempt'
+          remove-stale-when-updated: true
+          days-before-close: 14
+          days-before-issue-stale: 180
+          days-before-pr-stale: -1
+          operations-per-run: 500

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -35,7 +35,7 @@
     "globalMetadata": {
       "ms.service": "nuget",
       "uhfHeaderId": "MSDocsHeader-DotNet",
-      "feedback_system": "GitHub",
+      "feedback_system": "Standard",
       "feedback_github_repo": "NuGet/docs.microsoft.com-nuget",
       "feedback_product_url": "https://github.com/NuGet/Home/issues/",
       "breadcrumb_path": "~/_breadcrumb/toc.yml",


### PR DESCRIPTION
Bot is set to run each Wednesday night at midnight. It adds a "stale" label and a message to inactive issues (180+ days of inactivity), and will close the issue in 14 days if no further activity is recorded.