### PR TITLE
Distinguish case sensitivity for NuGet.Config keys

### DIFF
--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -47,7 +47,7 @@ A `NuGet.Config` file is a simple XML text file containing key/value pairs as de
 Settings are managed using the NuGet CLI [config command](../reference/cli-reference/cli-ref-config.md):
 - By default, changes are made to the user-level config file. (On Mac/Linux, the location of user-level config file varies by tooling)
 - To change settings in a different file, use the `-configFile` switch. In this case files can use any filename.
-- Keys are always case sensitive.
+- Keys are case sensitive when being referenced. New keys must be unique regardless of casing (case insensitive) .
 - Elevation is required to change settings in the computer-level settings file.
 
 > [!Warning]


### PR DESCRIPTION
"always" case sensitive is misleading, as it makes it sound like adding a new key with a different case should be acceptable.
My goal is to clarify that keys are referenced in a case-sensitive manner.
Adding "nuget.org" and "nuGet.org" though should be denied by NuGet tooling as they are not unique (case-insensitive).