### PR TITLE
Create redirects for NuGetAudit NU codes

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -364,6 +364,26 @@
             "source_path": "docs/tools/ps-ref-update-package.md",
             "redirect_url": "/nuget/reference/ps-reference/ps-ref-update-package",
             "redirect_document_id": false
+        },
+        {
+            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1901",
+            "redirect_document_id": false
+        },
+        {
+            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1902",
+            "redirect_document_id": false
+        },
+        {
+            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1903",
+            "redirect_document_id": false
+        },
+        {
+            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1904",
+            "redirect_document_id": false
         }
     ]
 }

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -367,22 +367,22 @@
         },
         {
             "source_path": "docs/reference/errors-and-warnings/NU1901.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
+            "redirect_url": "/nuget/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
             "source_path": "docs/reference/errors-and-warnings/NU1902.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
+            "redirect_url": "/nuget/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
             "source_path": "docs/reference/errors-and-warnings/NU1903.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
+            "redirect_url": "/nuget/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
             "source_path": "docs/reference/errors-and-warnings/NU1904.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
+            "redirect_url": "/nuget/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         }
     ]

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -366,23 +366,23 @@
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1901",
+            "source_path": "docs/reference/errors-and-warnings/NU1901",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1902",
+            "source_path": "docs/reference/errors-and-warnings/NU1902",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1903",
+            "source_path": "docs/reference/errors-and-warnings/NU1903",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1901-NU1904.md",
-            "redirect_url": "docs/reference/errors-and-warnings/NU1904",
+            "source_path": "docs/reference/errors-and-warnings/NU1904",
+            "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         }
     ]

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -366,22 +366,22 @@
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1901",
+            "source_path": "docs/reference/errors-and-warnings/NU1901.md",
             "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1902",
+            "source_path": "docs/reference/errors-and-warnings/NU1902.md",
             "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1903",
+            "source_path": "docs/reference/errors-and-warnings/NU1903.md",
             "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         },
         {
-            "source_path": "docs/reference/errors-and-warnings/NU1904",
+            "source_path": "docs/reference/errors-and-warnings/NU1904.md",
             "redirect_url": "docs/reference/errors-and-warnings/NU1901-NU1904",
             "redirect_document_id": false
         }


### PR DESCRIPTION
I created a single NU1901-NU1904 page, rather than creating 4 separate pages.

But clicking on one of these NU codes in VS' Error List window takes you to a 404. This PR tries to fix: https://github.com/NuGet/Home/issues/13321