### PR TITLE
Test fix to auto-close for stale-issues.yml

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'Thanks for sharing your feedback. We apologize for our delayed response. Due to the sheer volume of feedback in our repo, we have decided to prioritize the newest issues and are automatically closing our oldest issues with an Issues bot. If you believe your feedback is still actionable, then either respond directly in this issue or open a new documentation issue and we’ll review. If no activity occurs in the next 14 days, this issue will be closed.'


### PR DESCRIPTION
Stale issues marked as "stale" before 3/14/24, and still untouched since then, should have been auto-closed, but weren't. Testing this bug fix I found related to the bot.