### PR TITLE
clarified instructions for certificates stored in hardware

### DIFF
--- a/docs/create-packages/Sign-a-Package.md
+++ b/docs/create-packages/Sign-a-Package.md
@@ -28,6 +28,8 @@ You can use self-issued certificates for testing purposes. However, packages sig
 
 ## Export the certificate file
 
+* If your certificate is stored in a hardware token, you don't need to export the certificate. Instead, specify the SHA-1 certificate fingerprint (thumbprint) by using the option `--certificate-fingerprint <SHA-1fingerprint>` (replacing `--certificate-path <PathToTheCertificate>`)
+
 * You can export an existing certificate to a binary DER format by using the Certificate Export Wizard.
 
   ![Certificate Export Wizard](../reference/media/CertificateExportWizard.png)


### PR DESCRIPTION
The documentation says to export the certificate, but this introduces errors when the certificate is stored in a hardware token. You just need to specify the certificate fingerprint, no need to export. See issue https://github.com/dotnet/runtime/issues/100414