### PR TITLE
Replaced VS servicing link with a relative link.

### DIFF
--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -40,7 +40,7 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 ## Support policy
 
-The Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](https://aka.ms/vsservicing).
+The Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](/visualstudio/productinfo/vs-servicing).
 
 
 The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.

--- a/docs/install-nuget-client-tools.md
+++ b/docs/install-nuget-client-tools.md
@@ -40,7 +40,7 @@ Package Manager Console commands work only within Visual Studio on Windows and d
 
 ## Support policy
 
-The Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/visualstudio/productinfo/vs-servicing).
+The Visual Studio for Windows support policy can be found at [Visual Studio Product Lifecycle and Servicing](https://aka.ms/vsservicing).
 
 
 The most recent version of NuGet.exe is fully supported and can be relied on for bug fixes, updates, and enhancements.


### PR DESCRIPTION
Learn build has following suggestion to replace link to VS servicing doc with a relative link.

[docs/install-nuget-client-tools.md](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/install-nuget-client-tools.md)
Line 43, Column 62:  [Suggestion] Absolute link 'https://learn.microsoft.com/visualstudio/productinfo/vs-servicing' will be broken in isolated environments. Replace with a relative link.