### PR TITLE
.NET Core CLI is now just .NET CLI

### DIFF
--- a/docs/reference/errors-and-warnings/NU1105.md
+++ b/docs/reference/errors-and-warnings/NU1105.md
@@ -23,7 +23,7 @@ The project file exists but no restore information was provided for it. Ensure y
 
 From the command line this could mean that the file is corrupt or that the `NuGet.targets` are not imported.
 To import the `NuGet.targets`, usually it's recommended to import the `Microsoft.Common.targets`.
-To restore projects in solution using [.NET Core CLI](../../consume-packages/install-use-packages-dotnet-cli.md) use:
+To restore projects in solution using [.NET CLI](../../consume-packages/install-use-packages-dotnet-cli.md) use:
 ```dotnetcli
 dotnet restore MySolution.sln
 ```


### PR DESCRIPTION
Relates to 
- [dotnet/AspNetCore.Docs#32703](https://github.com/dotnet/AspNetCore.Docs/pull/32703)
- [dotnet/docs#41191](https://github.com/dotnet/docs/issues/41191)
---
I think I should also update the [tabs](https://github.com/search?q=repo%3ANuGet%2Fdocs.microsoft.com-nuget+core-cli&type=code) but there are some cross-references on the [docs repo](https://github.com/dotnet/docs/blob/main/docs/core/tutorials/testing-library-with-visual-studio.md?plain=1#L394) so I'll wait for input.