### PR TITLE
[NuGet.org FAQ] DNS failures from V3 API, for Alpine Linux customers.

### DIFF
--- a/docs/nuget-org/nuget-org-faq.yml
+++ b/docs/nuget-org/nuget-org-faq.yml
@@ -86,7 +86,7 @@ sections:
           > [!Note]
           > These environment variables are available since [.NET CLI](https://learn.microsoft.com/nuget/reference/dotnet-commands) (.NET SDK) 6.0.100, [NuGet CLI](https://learn.microsoft.com/nuget/reference/nuget-exe-cli-reference) 6.0, Visual Studio 2022 version 17.0 and corresponding MSBuild version. See [NuGet Release Notes](https://learn.microsoft.com/nuget/release-notes/).
 
-          > [!Important]
+          > [!Important] 
           > NuGet.org recommends Alpine Linux users to upgrade to Alpine Linux 3.18.0 or newer. These versions support TCP fallback in the DNS resolver. If you use older versions of Alpine Linux that only support DNS over UDP, you may encounter DNS failures when accessing the [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
 
           If that version of NuGet client continues to fail, [contact support](https://www.nuget.org/policies/Contact) and provide additional connection troubleshooting information including:

--- a/docs/nuget-org/nuget-org-faq.yml
+++ b/docs/nuget-org/nuget-org-faq.yml
@@ -87,7 +87,7 @@ sections:
           > These environment variables are available since [.NET CLI](https://learn.microsoft.com/nuget/reference/dotnet-commands) (.NET SDK) 6.0.100, [NuGet CLI](https://learn.microsoft.com/nuget/reference/nuget-exe-cli-reference) 6.0, Visual Studio 2022 version 17.0 and corresponding MSBuild version. See [NuGet Release Notes](https://learn.microsoft.com/nuget/release-notes/).
 
           > [!Important]
-          > NuGet.org suggests Alpine Linux customers migrate to Alpine Linux 3.18.0 or newer version, which supports TCP fallback in DNS resolver. Older versions of Alpine Linux that only support DNS over UDP may meet DNS failures from NuGet.org [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
+          > NuGet.org recommends that Alpine Linux customers migrate to Alpine Linux 3.18.0 or a newer version. These newer versions support TCP fallback in the DNS resolver. Older versions of Alpine Linux that only support DNS over UDP may experience DNS failures from the [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
 
           If that version of NuGet client continues to fail, [contact support](https://www.nuget.org/policies/Contact) and provide additional connection troubleshooting information including:
 

--- a/docs/nuget-org/nuget-org-faq.yml
+++ b/docs/nuget-org/nuget-org-faq.yml
@@ -87,7 +87,7 @@ sections:
           > These environment variables are available since [.NET CLI](https://learn.microsoft.com/nuget/reference/dotnet-commands) (.NET SDK) 6.0.100, [NuGet CLI](https://learn.microsoft.com/nuget/reference/nuget-exe-cli-reference) 6.0, Visual Studio 2022 version 17.0 and corresponding MSBuild version. See [NuGet Release Notes](https://learn.microsoft.com/nuget/release-notes/).
 
           > [!Important]
-          > NuGet.org recommends that Alpine Linux customers migrate to Alpine Linux 3.18.0 or a newer version. These newer versions support TCP fallback in the DNS resolver. Older versions of Alpine Linux that only support DNS over UDP may experience DNS failures from the [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
+          > NuGet.org recommends that Alpine Linux customers migrate to Alpine Linux 3.18.0 or a newer version. These newer versions support TCP fallback in DNS resolver. Older versions of Alpine Linux that only support DNS over UDP may experience DNS failures from [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
 
           If that version of NuGet client continues to fail, [contact support](https://www.nuget.org/policies/Contact) and provide additional connection troubleshooting information including:
 

--- a/docs/nuget-org/nuget-org-faq.yml
+++ b/docs/nuget-org/nuget-org-faq.yml
@@ -87,7 +87,7 @@ sections:
           > These environment variables are available since [.NET CLI](https://learn.microsoft.com/nuget/reference/dotnet-commands) (.NET SDK) 6.0.100, [NuGet CLI](https://learn.microsoft.com/nuget/reference/nuget-exe-cli-reference) 6.0, Visual Studio 2022 version 17.0 and corresponding MSBuild version. See [NuGet Release Notes](https://learn.microsoft.com/nuget/release-notes/).
 
           > [!Important]
-          > NuGet.org recommends that Alpine Linux customers migrate to Alpine Linux 3.18.0 or a newer version. These newer versions support TCP fallback in DNS resolver. Older versions of Alpine Linux that only support DNS over UDP may experience DNS failures from [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
+          > NuGet.org recommends Alpine Linux users to upgrade to Alpine Linux 3.18.0 or newer. These versions support TCP fallback in the DNS resolver. If you use older versions of Alpine Linux that only support DNS over UDP, you may encounter DNS failures when accessing the [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
 
           If that version of NuGet client continues to fail, [contact support](https://www.nuget.org/policies/Contact) and provide additional connection troubleshooting information including:
 

--- a/docs/nuget-org/nuget-org-faq.yml
+++ b/docs/nuget-org/nuget-org-faq.yml
@@ -86,6 +86,9 @@ sections:
           > [!Note]
           > These environment variables are available since [.NET CLI](https://learn.microsoft.com/nuget/reference/dotnet-commands) (.NET SDK) 6.0.100, [NuGet CLI](https://learn.microsoft.com/nuget/reference/nuget-exe-cli-reference) 6.0, Visual Studio 2022 version 17.0 and corresponding MSBuild version. See [NuGet Release Notes](https://learn.microsoft.com/nuget/release-notes/).
 
+          > [!Important]
+          > NuGet.org suggests Alpine Linux customers migrate to Alpine Linux 3.18.0 or newer version, which supports TCP fallback in DNS resolver. Older versions of Alpine Linux that only support DNS over UDP may meet DNS failures from NuGet.org [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
+
           If that version of NuGet client continues to fail, [contact support](https://www.nuget.org/policies/Contact) and provide additional connection troubleshooting information including:
 
           - The package sources you're using

--- a/docs/nuget-org/nuget-org-faq.yml
+++ b/docs/nuget-org/nuget-org-faq.yml
@@ -86,7 +86,7 @@ sections:
           > [!Note]
           > These environment variables are available since [.NET CLI](https://learn.microsoft.com/nuget/reference/dotnet-commands) (.NET SDK) 6.0.100, [NuGet CLI](https://learn.microsoft.com/nuget/reference/nuget-exe-cli-reference) 6.0, Visual Studio 2022 version 17.0 and corresponding MSBuild version. See [NuGet Release Notes](https://learn.microsoft.com/nuget/release-notes/).
 
-          > [!Important] 
+          > [!Important]
           > NuGet.org recommends Alpine Linux users to upgrade to Alpine Linux 3.18.0 or newer. These versions support TCP fallback in the DNS resolver. If you use older versions of Alpine Linux that only support DNS over UDP, you may encounter DNS failures when accessing the [V3 API](https://learn.microsoft.com/nuget/nuget-org/overview-nuget-org#api-endpoint-for-nugetorg).
 
           If that version of NuGet client continues to fail, [contact support](https://www.nuget.org/policies/Contact) and provide additional connection troubleshooting information including:


### PR DESCRIPTION
Update NuGet.org FAQ about DNS failures from V3 API, for Alpine Linux customers.