### PR TITLE
Update NuGet Audit docs for 6.12

### DIFF
--- a/docs/concepts/Auditing-Packages.md
+++ b/docs/concepts/Auditing-Packages.md
@@ -3,7 +3,7 @@ title: Auditing package dependencies for security vulnerabilities
 description: How to audit package dependencies for security vulnerabilities and acting on security audit reports.
 author: JonDouglas
 ms.author: jodou
-ms.date: 10/11/2023
+ms.date: 07/19/2024
 ms.topic: conceptual
 ---
 
@@ -16,23 +16,106 @@ This involves identifying vulnerabilities, evaluating risks, and making recommen
 The audit can include a review of the packages themselves, as well as any dependencies and their associated risks.
 The goal of the audit is to identify and mitigate any security vulnerabilities that could be exploited by attackers, such as code injection or cross-site scripting attacks.
 
-| Project Type | NuGet | .NET SDK | Visual Studio |
-|--------------|-------|----------|---------------|
-| PackageReference | 6.8 |  .NET 8 SDK (8.0.100) | Visual Studio 2022 17.8 |
-| packages.config | 6.10 | N/A | Visual Studio 2022 17.10 |
+We also have a [blog post](https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/) which discusses our recommended method for taking action when a package with a known vulnerability is found to be used by your project, and tools to help get more information.
+
+### Feature availability
+
+| NuGet | .NET SDK | Visual Studio | Feature |
+|-------|----------|---------------|---------|
+| 5.9 | .NET 5 SDK (5.0.200) | N/A | [`dotnet list package --vulnerable`](#dotnet-list-package---vulnerable) |
+| 6.8 | .NET 8 SDK (8.0.100) | Visual Studio 2022 17.8 | [NuGetAudit](#running-a-security-audit-with-restore) for PackageReference |
+| 6.10 | N/A | Visual Studio 2022 17.10 | [NuGetAudit](#running-a-security-audit-with-restore) for packages.config|
+| 6.11 | .NET 8 SDK (8.0.400) | Visual Studio 2022 17.11 | [NuGetAuditSuppress](#excluding-advisories) for PackageReference |
+| 6.12 | .NET 9 SDK (9.0.100) | Visual Studio 2022 17.12 | [Audit sources](#audit-sources). [NuGetAuditSuppress](#excluding-advisories) for packages.config. |
 
 ## Running a security audit with `restore`
 
 The `restore` command automatically runs when you do a common package operation such as loading a project for the first time, adding a new package, updating a package version, or removing a package from your project in your favorite IDE.
-A description of your dependencies is checked against a report of known vulnerabilities on the [GitHub Advisory Database](https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anuget).
-
-> [!IMPORTANT]
-> For Audit to check packages, a package source that provides a vulnerability database must be used.
-> NuGet.org's V3 URL is one such example (https://api.nuget.org/v3/index.json), but note that NuGet.org's V2 endpoint does not.
+Your dependencies are checked against a list of known vulnerabilities provided by your [audit sources](#audit-sources).
 
 1. On the command line, navigate to your project or solution directory.
 1. Run `restore` using your preferred tooling (i.e. dotnet, MSBuild, NuGet.exe, VisualStudio etc).
 1. Review the warnings and address the known security vulnerabilities.
+
+### Configuring NuGet Audit
+
+Audit can be configured via MSBuild properties in a `.csproj` or MSBuild file being evaluated as part of your project.
+We recommend that audit is configured at a repository level.
+
+| MSBuild Property | Default | Possible values | Notes |
+|------------------|---------|-----------------|-------|
+| NuGetAuditMode | all (1) | `direct` and `all` | If you'd like to audit both top-level and transitive dependencies, you can set the value to `all`. NuGetAuditMode is not applicable for packages.config projects |
+| NuGetAuditLevel | low | `low`, `moderate`, `high`, and `critical` | The minimum severity level to report. If you'd like to see `moderate`, `high`, and `critical` advisories (exclude `low`), set the value to `moderate` |
+| NuGetAudit | true | `true` and `false` | If you wish to not receive security audit reports, you can opt-out of the experience entirely by setting the value to `false` |
+
+(1) NuGetAuditMode defaulted to `direct` when it was introduced in the .NET 8.0.100 SDK and VS 17.8. In .NET 9.0.100 SDK and VS 17.12 the default changed to `all`.
+
+#### Audit Sources
+
+Restore downloads a server's [`VulnerabilityInfo` resource](../api/vulnerability-info.md) to check against the list of packages each project is using.
+The list of sources are defined by [the `auditSources` element in NuGet.Config](../reference/nuget-config-file.md#auditsources), and [warning NU1905](#warning-codes) is raised if any of the audit sources do not provide any vulnerability info.
+If `auditSources` is not defined or is cleared without adding any sources, then `packageSources` will be used and warning NU1905 is suppressed.
+
+Since a common mitigation for package substitution attacks is [to use a single package source that upstreams from nuget.org, so that NuGet is not configured to use nuget.org as a package source](Security-Best-Practices.md#nuget-feeds), audit sources can be used to use nuget.org (or any other source that provides vulnerability information) without also using it as a package source.
+
+The data source for nuget.org's vulnerability database is [GitHub Advisory Database](https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anuget).
+Note that the [V2 protocol is deprecated](../nuget-org/overview-nuget-org.md#api-endpoint-for-nugetorg), so if your nuget.config is still using the V2 endpoint, you must migrate to the V3 endpoint.
+
+```xml
+<configuration>
+    <auditSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </auditSources>
+</configuration>
+```
+
+Audit sources are available from NuGet 6.12, .NET 9.0.100 SDK, and Visual Studio 2022 17.12.
+Prior to this version, NuGet Audit will only use package sources to download vulnerability information.
+Audit sources are not used by `dotnet list package --vulnerable` at this time.
+
+#### Excluding advisories
+
+You can choose to exclude specific advisories from the audit report by adding a new `NuGetAuditSuppress` MSBuild item for each advisory.
+Define a `NuGetAuditSuppress` item with the `Include=` metadata set to the advisory URL you wish to suppress.
+
+```xml
+<ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/XXXX" />
+</ItemGroup>
+```
+
+Similar to the other NuGet audit configuration properties, `NuGetAuditSuppress` items can be defined at the project or repository level.
+
+`NuGetAuditSuppress` is available for PackageReference projects starting from NuGet 6.11, Visual Studio 17.11, and the .NET 8.0.400 SDK.
+It is available for packages.config with Visual Studio 17.12 and NuGet 6.12.
+
+### Warning codes
+
+| Warning Code | Reason |
+|--------------|----------|
+| [NU1900](../reference/errors-and-warnings/NU1900.md) | Error communicating with package source, while getting vulnerability information. |
+| [NU1901](../reference/errors-and-warnings/NU1901-NU1904.md) | Package with low severity detected |
+| [NU1902](../reference/errors-and-warnings/NU1901-NU1904.md) | Package with moderate severity detected |
+| [NU1903](../reference/errors-and-warnings/NU1901-NU1904.md) | Package with high severity detected |
+| [NU1904](../reference/errors-and-warnings/NU1901-NU1904.md) | Package with critical severity detected |
+| [NU1905](../reference/errors-and-warnings/NU1905.md) | An audit source does not provide a vulnerability database |
+
+You can customize your build to treat these warnings as errors to [treat warnings as errors, or treat warnings not as errors](/dotnet/csharp/language-reference/compiler-options/errors-warnings#warningsaserrors-and-warningsnotaserrors).
+For example, if you're already using `<TreatWarningsAsErrors>` to treat all (C#, NuGet, MSBuild, etc) warnings as errors, you can use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to prevent vulnerabilities discovered in the future from breaking your build.
+Alternatively, if you want to keep low and moderate vulnerabilities as warnings, but treat high and critical vulnerabilities as errors, and you're not using `TreatWarningsAsErrors`, you can use `<WarningsAsErrors>NU1903;NU1904</WarningsAsErrors>`.
+
+> [!NOTE]
+> MSBuild properties for message severity such as `NoWarn` and `TreatWarningsAsErrors` are not supported for packages.config projects.
+
+## `dotnet list package --vulnerable`
+
+Once a project is successfully restored, [`dotnet list package`](/dotnet/core/tools/dotnet-list-package) has a `--vulnerable` argument to filter the packages based on which packages have known vulnerabilities.
+Note that `--include-transitive` is not default, so should be included 
+
+## Actions when packages with known vulnerabilities are reported
+
+We also have a [blog post](https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/) which discusses our recommended method for taking action when a package with a known vulnerability is found to be used by your project, and tools to help get more information.
 
 ### Security vulnerabilities found with updates
 
@@ -73,53 +156,6 @@ On NuGet.org, you can navigate to the package details page and click `Report pac
 
 If no security vulnerabilities are found, this means that packages with known vulnerabilities were not found in your package graph at the present moment of time you checked.
 Since the advisory database can be updated at any time, we recommend regularly checking your `dotnet restore` output and ensuring the same in your continuous integration process.
-
-### Configuring NuGet audit
-
-Audit can be configured via MSBuild properties in a `.csproj` or MSBuild file being evaluated as part of your project.
-We recommend that audit is configured at a repository level.
-
-| MSBuild Property | Default | Possible values | Notes |
-|------------------|---------|-----------------|-------|
-| NuGetAuditMode | direct | `direct` and `all` | If you'd like to audit both top-level and transitive dependencies, you can set the value to `all`. NuGetAuditMode is not applicable for packages.config projects |
-| NuGetAuditLevel | low | `low`, `moderate`, `high`, and `critical` | If you'd like to see `moderate`, `high`, and `critical` advisories, set the value to `moderate` |
-| NuGetAudit | true | `true` and `false` | If you wish to not receive security audit reports, you can opt-out of the experience entirely by setting the value to `false` |
-
-### Excluding advisories
-
-You can choose to exclude specific advisories from the audit report by adding a new `NuGetAuditSuppress` MSBuild item for each advisory.
-Define a `NuGetAuditSuppress` item with the `Include=` metadata set to the advisory URL you wish to suppress.
-
-```xml
-<ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/XXXX" />
-</ItemGroup>
-```
-
-Similar to the other NuGet audit configuration properties, `NuGetAuditSuppress` items can be defined at the project or repository level.
-
-`NuGetAuditSuppress` is available for PackageReference projects starting from NuGet 6.11, Visual Studio 17.11, and the .NET 8.0.400 SDK.
-It is not currently available for packages.config projects.
-
-Additionally, you have the option to suppress warnings based on their severity.
-You can use `<NoWarn>` to suppress `NU1901`-`NU1904` warnings or use the `<NuGetAuditLevel>` functionality to ensure your audit reports are useful to your workflow.
-
-### Warning codes
-
-| Warning Code | Reason |
-|--------------|----------|
-| NU1900 | Error communicating with package source, while getting vulnerability information. |
-| NU1901 | Package with low severity detected |
-| NU1902 | Package with moderate severity detected |
-| NU1903 | Package with high severity detected |
-| NU1904 | Package with critical severity detected |
-
-You can customize your build to treat these warnings as errors to [treat warnings as errors, or treat warnings not as errors](/dotnet/csharp/language-reference/compiler-options/errors-warnings#warningsaserrors-and-warningsnotaserrors).
-For example, if you're already using `<TreatWarningsAsErrors>` to treat all (C#, NuGet, MSBuild, etc) warnings as errors, you can use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to prevent vulnerabilities discovered in the future from breaking your build.
-Alternatively, if you want to keep low and moderate vulnerabilities as warnings, but treat high and critical vulnerabilities as errors, and you're not using `TreatWarningsAsErrors`, you can use `<WarningsAsErrors>NU1903;NU1904</WarningsAsErrors>`.
-
-> [!NOTE]
-> MSBuild properties for message severity such as `NoWarn` and `TreatWarningsAsErrors` are not supported for packages.config projects.
 
 ## Summary
 

--- a/docs/reference/errors-and-warnings/NU1901-NU1904.md
+++ b/docs/reference/errors-and-warnings/NU1901-NU1904.md
@@ -3,7 +3,7 @@ title: NuGet Warnings NU1901, NU1902, NU1903, NU1904
 description: NU1901, NU1902, NU1903, NU1904 Warning codes
 author: zivkan
 ms.author: zivkan
-ms.date: 6/27/2023
+ms.date: 7/19/2024
 ms.topic: reference
 f1_keywords: 
   - NU1901
@@ -35,16 +35,23 @@ For more information, see [the documentation on auditing packages](../../concept
 
 ### Solution
 
+We have [a blog post](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) with more discussion about our recommended actions when your project uses a package with a known vulnerability, and tools that can help.
+
 Upgrading to a newer version of the package is likely to resolve the warning.
+If your project does not reference the package directly (it's a transitive package), [`dotnet nuget why`](/dotnet/core/tools/dotnet-nuget-why) can be used to understand which package caused it to be included in your project.
 You can check the URL provided by the vulnerability advisory to see what versions of the package have been fixed, or check your configured package source(s) to see what versions of the package are available.
 Visual Studio's package manager UI can show which package versions are affected and which do not have known vulnerabilities.
+
+If these warnings are causing restore to fail because you are using `TreatWarningsAsErrors`, you can add `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to allow these codes to remain as warnings.
 
 If you do not wish to be notified of vulnerabilities that are less severe than a level you are comfortable with, you can edit the project file and add an MSBuild property `NuGetAuditLevel`, with value set to `low`, `moderate`, `high`, or `critical`.
 For example, `<NuGetAuditLevel>high</NuGetAuditLevel>`.
 
-If these warnings are causing restore to fail because you are using `TreatWarningsAsErrors`, you can add `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to allow these codes to remain as warnings.
+If you would like to suppress a specific advisory, add an MSBuild [NuGetAuditSuppress](../../concepts/Auditing-Packages.md#excluding-advisories) item.
+For example `<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g3q9-xf95-8hp5" />`.
 
 If you do not want NuGet to check for packages with known vulnerabilities during restore, add `<NuGetAudit>false</NuGetAudit>` inside a `<PropertyGroup>` in your project file, or a [`Directory.Build.props` file](/visualstudio/msbuild/customize-by-directory).
+If you would like to run NuGet Audit on developer machines, but disable it on CI pipelines, you can take advantage of MSBuild importing environment variables, and create a NuGetAudit environment variable set to `false` in your pipeline definition.
 
 > [!NOTE]
 > The initial release of NuGetAudit [does not provide a way to suppress specific advisories (URLs)](https://github.com/NuGet/Home/issues/11926).

--- a/docs/reference/errors-and-warnings/NU1905.md
+++ b/docs/reference/errors-and-warnings/NU1905.md
@@ -3,7 +3,7 @@ title: NuGet Warning NU1905
 description: NU1905 Warning codes
 author: zivkan
 ms.author: zivkan
-ms.date: 6/27/2023
+ms.date: 07/19/2024
 ms.topic: reference
 f1_keywords: 
   - NU1905
@@ -12,24 +12,20 @@ f1_keywords:
 # NuGet Warning NU1905
 
 ```text
-warning NU1905: NuGetAudit is enabled, but no package sources contain known vulnerability data.
+warning NU1905: Audit source 'Contoso' did not provide any vulnerability data.
 ```
 
 ### Issue
 
-`NuGetAudit` is explicitly enabled, but none of the configured package sources provide vulnerability information for NuGet to check against.
+A source specified in a [NuGet.Config `<auditSources>` element](../nuget-config-file.md#auditsources) did not provide a vulnerability database.
 
 ### Solution
 
-NuGet asks all configured package sources for vulnerability information.
-Any package source implementing [NuGet's V3 server API can provide the data via the VulnerabilityInfo resource](../../api/vulnerability-info.md), including by mirroring nuget.org's vulnerability data.
+Any NuGet source implementing [NuGet's V3 server API can provide vulnerability data via the `VulnerabilityInfo` resource](../../api/vulnerability-info.md), including by mirroring nuget.org's vulnerability data.
+Any source defined in a NuGet.Config `<auditSources>` element is expected to provide this resource, and this warning is raised when it is not.
 You can check if your package source administrators have a setting to enable vulnerability data.
 
 If you would like to treat this warning as an error, to cause build failures when vulnerability checks could not be performed, you can add `<WarningAsError>$(WarningAsError);NU1905</WarningAsError>` to your project file.
 If you are using `TreatWarningsAsErrors` to cause all warnings to be treated as errors, you can add `<NoWarn>$(NoWarn);NU1905</NoWarn>` to your project file to suppress this warning message, or `<WarningsNotAsErrors>NU1905</WarningsNotAsErrors>` to prevent this warning from being treated as an error.
-
-> [!NOTE]
-> There is [a request to get vulnerability data without adding nuget.org as a package source](https://github.com/NuGet/Home/issues/12698).
-> As a temporary mitigation, if your security policy allows it, you can use [Package Source Mapping](../../consume-packages/Package-Source-Mapping.md) to get all your packages from package sources other than nuget.org, so that adding nuget.org as a package source will only use it for vulnerability data.
 
 For more information, see [the documentation on auditing packages](../../concepts/Auditing-Packages.md).

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -124,7 +124,7 @@ Lists all known package sources. The order is ignored during restore operations 
 
 ```xml
 <packageSources>
-    <clear />    
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Contoso" value="https://contoso.com/packages/" />
     <add key="http-source" value="http://httpsourcetrusted/" allowInsecureConnections="true" />
@@ -137,6 +137,21 @@ Lists all known package sources. The order is ignored during restore operations 
 
 > [!Tip]
 > When `<clear />` is present for a given node, NuGet ignores previously defined configuration values for that node. [Read more about how settings are applied](../consume-packages/configuring-nuget-behavior.md#how-settings-are-applied).
+
+### auditSources
+
+Lists all known audit sources, which [NuGet Audit](../concepts/Auditing-Packages.md#running-a-security-audit-with-restore) will use during restore.
+If no audit sources are provided, restore will use package sources and suppress [NU1905](../reference/errors-and-warnings/NU1905.md).
+
+Audit sources support the same attributes as `packageSources` (`protocolVersion`, `allowInsecureConnections`), and sources that require authentication are configured with `packageSourceCredentials`, the same way as `packageSources`.
+
+**Example**:
+```xml
+<auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+</auditSources>
+```
 
 ### packageSourceCredentials
 


### PR DESCRIPTION
fixes: https://github.com/NuGet/Home/issues/13479

* Update the audit packages docs with info on all the NuGet 6.11 and 6.12 features, plus link to the NuGetAudit 2.0 blog.
   * Also add a mention of `dotnet list package --vulnerable` because the docs are under the "concepts" top level heading, and has a generic title, so the docs don't sound like it should be limited to the NuGetAudit on restore feature.
* Update the NU1901-NU1904 docs to mention the blog post, and `dotnet nuget why`
* Update NU1905. The warning code was originally used by the first implementation of NuGetAudit, but was removed before GA (although it did ship in the .NET SDK 8.0.100 and was removed in 8.0.101). so was unused until NuGet 6.12. Looks like I previously forgot to remove the docs from the ToC, hence why this PR doesn't add it to the ToC.
* Update nuget.config with audit sources info