### PR TITLE
Fix link in NU1901-4 docs

### DIFF
--- a/docs/reference/errors-and-warnings/NU1901-NU1904.md
+++ b/docs/reference/errors-and-warnings/NU1901-NU1904.md
@@ -35,7 +35,7 @@ For more information, see [the documentation on auditing packages](../../concept
 
 ### Solution
 
-We have [a blog post](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) with more discussion about our recommended actions when your project uses a package with a known vulnerability, and tools that can help.
+We have [a blog post](https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/) with more discussion about our recommended actions when your project uses a package with a known vulnerability, and tools that can help.
 
 Upgrading to a newer version of the package is likely to resolve the warning.
 If your project does not reference the package directly (it's a transitive package), [`dotnet nuget why`](/dotnet/core/tools/dotnet-nuget-why) can be used to understand which package caused it to be included in your project.


### PR DESCRIPTION
I was a little trigger happy merging my previous PR, and didn't notice the warning from the docs bot. This PR fixes the link in the NU1901-4 docs, actually pointing to the right place now.