### PR TITLE
Update NuGetAuditSuppress info in NU1901-4 docs

### DIFF
--- a/docs/reference/errors-and-warnings/NU1901-NU1904.md
+++ b/docs/reference/errors-and-warnings/NU1901-NU1904.md
@@ -47,14 +47,7 @@ For example, `<NuGetAuditLevel>high</NuGetAuditLevel>`.
 
 If you would like to suppress a specific advisory, add an MSBuild [NuGetAuditSuppress](../../concepts/Auditing-Packages.md#excluding-advisories) item.
 For example `<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g3q9-xf95-8hp5" />`.
+`NuGetAuditSuppress` is available from VS 17.11 and .NET 8.0.400 SDK for projects using `PackageReference`, and from VS 17.12 for projects using `packages.config`.
 
 If you do not want NuGet to check for packages with known vulnerabilities during restore, add `<NuGetAudit>false</NuGetAudit>` inside a `<PropertyGroup>` in your project file, or a [`Directory.Build.props` file](/visualstudio/msbuild/customize-by-directory).
 If you would like to run NuGet Audit on developer machines, but disable it on CI pipelines, you can take advantage of MSBuild importing environment variables, and create a NuGetAudit environment variable set to `false` in your pipeline definition.
-
-> [!NOTE]
-> The initial release of NuGetAudit [does not provide a way to suppress specific advisories (URLs)](https://github.com/NuGet/Home/issues/11926).
-> It is a feature we intend on adding based on prioritization of other improvements.
->
-> As a mitigation, you can add an appropriate `NoWarn` to your `PackageReference` declarations.
-> For example, `<PackageReference Include="Contoso.Library" Version="1.0.0" NoWarn="NU1901" />`.
-> However, be aware that this will prevent new vulnerabilities of the same severity from being reported to you.


### PR DESCRIPTION
fixes: https://github.com/NuGet/Client.Engineering/issues/2899

I checked the auditing packages page already has the good information, so it doesn't need an update, just the NU1901-4 warning code page.