### PR TITLE
deprecate SHA-1 usage in nuget.exe sign command

### DIFF
--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -29,7 +29,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 - **`-CertificateFingerprint`**
 
-  Specifies the SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
+  Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
 
   > [!NOTE]
   > Starting with `NuGet.exe 6.12`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -29,7 +29,11 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 - **`-CertificateFingerprint`**
 
-  Specifies the SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
+  Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
+
+  > [!NOTE]
+  > Starting with `NuGet.exe 6.12`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.
+  > The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).
 
 - **`-CertificatePassword`**
 

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -34,7 +34,7 @@ where `<package(s)>` is one or more `.nupkg` files.
   Starting with `NuGet.exe 6.12`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
 
-  All previous versions of the NuGet.exe continue to accept only SHA-1 certificate fingerprint.
+  All the previous versions of the NuGet.exe continue to accept only SHA-1 certificate fingerprint.
 
 - **`-CertificatePassword`**
 

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -29,11 +29,11 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 - **`-CertificateFingerprint`**
 
-  Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
+  Specifies the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 
   > [!NOTE]
   > Starting with `NuGet.exe 6.12`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.
-  > The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).
+  > SHA-1 is considered insecure and should no longer be used.
 
 - **`-CertificatePassword`**
 

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -29,7 +29,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 - **`-CertificateFingerprint`**
 
-  Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
+  Specifies the fingerprint to be used to search for the certificate in a local certificate store.
 
   Starting with NuGet.exe 6.12, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -29,11 +29,12 @@ where `<package(s)>` is one or more `.nupkg` files.
 
 - **`-CertificateFingerprint`**
 
-  Specifies the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
+  Specifies the SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
 
   > [!NOTE]
   > Starting with `NuGet.exe 6.12`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.
   > SHA-1 is considered insecure and should no longer be used.
+  > The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).
 
 - **`-CertificatePassword`**
 

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -31,7 +31,7 @@ where `<package(s)>` is one or more `.nupkg` files.
 
   Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
 
-  Starting with `NuGet.exe 6.12`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
+  Starting with NuGet.exe 6.12, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
 
   All the previous versions of the NuGet.exe continue to accept only SHA-1 certificate fingerprint.

--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -31,10 +31,10 @@ where `<package(s)>` is one or more `.nupkg` files.
 
   Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
 
-  > [!NOTE]
-  > Starting with `NuGet.exe 6.12`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.
-  > SHA-1 is considered insecure and should no longer be used.
-  > The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).
+  Starting with `NuGet.exe 6.12`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
+  However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
+
+  All previous versions of the NuGet.exe continue to accept only SHA-1 certificate fingerprint.
 
 - **`-CertificatePassword`**
 


### PR DESCRIPTION
Tracking: https://github.com/NuGet/Client.Engineering/issues/2994

Starting with .NET 9 Preview 7 and NuGet.exe 6.12, NuGet sign commands will raise a NU3043 warning if an invalid value or SHA-1 hash is passed for the certificate fingerprint option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).