### PR TITLE
Fix the name of the placeholder file

### DIFF
--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -825,11 +825,11 @@ C#-specific content for net45 and up
     /contentFiles/cs/net45/sample.cs
 ```
 
-Empty folders can use `.` to opt out of providing content for certain combinations of language and TxM, for example:
+Empty folders can use `_._` to opt out of providing content for certain combinations of language and TxM, for example:
 
 ```
 /contentFiles/vb/any/code.vb
-/contentFiles/cs/any/.
+/contentFiles/cs/any/_._
 ```
 
 #### Example contentFiles section


### PR DESCRIPTION
This doc should not reccomend that users create a `.` file.  That's a reserved directory alias for current directory.  I'd be surprised if that actually works, it would definitely confuse the build / extraction / etc.  I can't even create a file with this name.  The correct file name is `_._`.

cc @JonDouglas @zivkan 