### PR TITLE
Update NU1604.md

### DIFF
--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -12,6 +12,35 @@ f1_keywords:
 
 # NuGet Warning NU1604
 
+## Missing Package Version
+
+> Project dependency 'PackageA' does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.
+
+### Issue
+
+A project dependency doesn't define a version.<br/><br/>This means that restore used the lowest available version. Each restore will float downwards trying to find a lower version that can be used. This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
+
+### Solution
+
+Find the `PackageReference` item that does not define the `Version` attribute and add it:
+
+For example change from:
+
+> `<PackageReference Include="PackageA" />`
+
+to:
+
+> `<PackageReference Include="PackageA" Version="9.0.0" />`
+
+If the project is using [NuGet's Central Package Management (CPM)](../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+
+> `<PackageVersion Include="PackageA" />`
+
+to:
+> `<PackageVersion Include="PackageA" Version="9.0.0" />`
+
+## Missing Inclusive Lower Bound
+
 > Project dependency 'PackageA' (&lt;= 9.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.
 
 ### Issue
@@ -32,3 +61,10 @@ or
 > `<PackageReference Version="9.0.0" />`
 
 which implies a lower bound.
+
+If the project is using [NuGet's Central Package Management (CPM)](../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+
+> `<PackageVersion Include="PackageA" Version="(9.0.0, )" />`
+
+to:
+> `<PackageVersion Include="PackageA" Version="9.0.0" />`

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -19,6 +19,7 @@ f1_keywords:
 ### Issue
 
 A project dependency doesn't define a version.
+
 This means that restore used the lowest available version.
 Each restore will float downwards trying to find a lower version that can be used.
 This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
@@ -53,6 +54,7 @@ If a version is specified in a `<PackageVersion />` item and you still receive t
 
 ### Issue
 A project dependency doesn't define a lower bound.
+
 This means that restore did not find the *best match*. Each restore will float downwards trying to find a lower version that can be used.
 This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
 

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -32,7 +32,7 @@ to:
 
 > `<PackageReference Include="PackageA" Version="9.0.0" />`
 
-If the project is using [NuGet's Central Package Management (CPM)](../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+If the project is using [NuGet's Central Package Management (CPM)](../../../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
 
 > `<PackageVersion Include="PackageA" />`
 

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -52,7 +52,8 @@ If a version is specified in a `<PackageVersion />` item and you still receive t
 > Project dependency 'PackageA' (&lt;= 9.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.
 
 ### Issue
-A project dependency doesn't define a lower bound.<br/><br/>This means that restore did not find the *best match*. Each restore will float downwards trying to find a lower version that can be used.
+A project dependency doesn't define a lower bound.
+This means that restore did not find the *best match*. Each restore will float downwards trying to find a lower version that can be used.
 This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
 
 ### Solution

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -45,7 +45,7 @@ to:
 If a version is specified in a `<PackageVersion />` item and you still receive this warning, verify you've correctly [onboarded to central package management](../../consume-packages/Central-Package-Management.md#enabling-central-package-management).
 
 > [!Note]
-> When using CPM and the file `Directory.Packages.Props` is invalid, NU1604 is raised.
+> When using CPM and the file `Directory.Packages.props` is invalid, NU1604 is raised.
 
 ## Missing Inclusive Lower Bound
 

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -32,7 +32,7 @@ to:
 
 > `<PackageReference Include="PackageA" Version="9.0.0" />`
 
-If the project is using [NuGet's Central Package Management (CPM)](../../../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+If the project is using [NuGet's Central Package Management (CPM)](../../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
 
 > `<PackageVersion Include="PackageA" />`
 
@@ -62,7 +62,7 @@ or
 
 which implies a lower bound.
 
-If the project is using [NuGet's Central Package Management (CPM)](../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+If the project is using [NuGet's Central Package Management (CPM)](../../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
 
 > `<PackageVersion Include="PackageA" Version="(9.0.0, )" />`
 

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -32,7 +32,7 @@ to:
 
 > `<PackageReference Include="PackageA" Version="9.0.0" />`
 
-If the project is using [NuGet's Central Package Management (CPM)](../../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+If the project is using [NuGet's Central Package Management (CPM)](../../consume-packages/Central-Package-Management.md), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
 
 > `<PackageVersion Include="PackageA" />`
 
@@ -62,7 +62,7 @@ or
 
 which implies a lower bound.
 
-If the project is using [NuGet's Central Package Management (CPM)](../../consume-packages/Central-Package-Management), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
+If the project is using [NuGet's Central Package Management (CPM)](../../consume-packages/Central-Package-Management.md), you need to update the `<PackageVersion />` item in `Directory.Packages.props` and change from:
 
 > `<PackageVersion Include="PackageA" Version="(9.0.0, )" />`
 

--- a/docs/reference/errors-and-warnings/NU1604.md
+++ b/docs/reference/errors-and-warnings/NU1604.md
@@ -18,7 +18,10 @@ f1_keywords:
 
 ### Issue
 
-A project dependency doesn't define a version.<br/><br/>This means that restore used the lowest available version. Each restore will float downwards trying to find a lower version that can be used. This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
+A project dependency doesn't define a version.
+This means that restore used the lowest available version.
+Each restore will float downwards trying to find a lower version that can be used.
+This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
 
 ### Solution
 
@@ -39,12 +42,18 @@ If the project is using [NuGet's Central Package Management (CPM)](../../consume
 to:
 > `<PackageVersion Include="PackageA" Version="9.0.0" />`
 
+If a version is specified in a `<PackageVersion />` item and you still receive this warning, verify you've correctly [onboarded to central package management](../../consume-packages/Central-Package-Management.md#enabling-central-package-management).
+
+> [!Note]
+> When using CPM and the file `Directory.Packages.Props` is invalid, NU1604 is raised.
+
 ## Missing Inclusive Lower Bound
 
 > Project dependency 'PackageA' (&lt;= 9.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.
 
 ### Issue
-A project dependency doesn't define a lower bound.<br/><br/>This means that restore did not find the *best match*. Each restore will float downwards trying to find a lower version that can be used. This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
+A project dependency doesn't define a lower bound.<br/><br/>This means that restore did not find the *best match*. Each restore will float downwards trying to find a lower version that can be used.
+This means that restore goes online to check all sources each time instead of using the packages that already exist in the user package folder.
 
 ### Solution
 Update the project's `PackageReference` `Version` attribute to include a lower bound.


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/9496
Fixes: https://github.com/NuGet/Home/issues/13500

This adds information about a `<PackageReference />` missing a version all together which is the much more common case.  