### PR TITLE
Fix links in audit docs

### DIFF
--- a/docs/concepts/Auditing-Packages.md
+++ b/docs/concepts/Auditing-Packages.md
@@ -130,8 +130,8 @@ If security vulnerabilities are found and updates are available for the package,
 If a known vulnerability exists in a top-level package's transitive dependencies, you have these options:
 
 - Add the fixed package version as a direct package reference. **Note:** Be sure to remove this reference when a new package version update becomes available and be sure to maintain the defined attributes for the expected behavior.
-- Use [Central Package Management with the transitive pinning functionality](https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management#transitive-pinning).
-- [Suppress the advisory](https://learn.microsoft.com/nuget/concepts/auditing-packages#excluding-advisories) until it can be addressed.
+- Use [Central Package Management with the transitive pinning functionality](../consume-packages/Central-Package-Management.md#transitive-pinning).
+- [Suppress the advisory](#excluding-advisories) until it can be addressed.
 - File an issue in the top-level package's tracker to request an update.
 
 ### Security vulnerabilities found with no updates


### PR DESCRIPTION
https://github.com/NuGet/docs.microsoft.com-nuget/pull/3336 introduced links that violates the doc bot's validation rules

@JonDouglas the docs bot had commented about the links not being in the preferred format. In case you weren't aware how to fix those violations, please see this PR's diff