### PR TITLE
Release notes 6.12 improvements

### DIFF
--- a/docs/release-notes/NuGet-6.12.md
+++ b/docs/release-notes/NuGet-6.12.md
@@ -35,19 +35,19 @@ NuGet 6.12.0 is available in the .NET 9.0.100 SDK.
 
 * Add new graph resolution algorithm for better performance with large graphs - [#13692](https://github.com/NuGet/Home/issues/13692)
 
-* Owner profile hyperlinks needed in Details Pane of PM UI - [#13686](https://github.com/NuGet/Home/issues/13686)
+* NuGetAudit raises warnings for vulnerable transitive packages by default when the .NET 9 SDK is installed [#13293](https://github.com/NuGet/Home/issues/13293)
+
+* Change NuGetAuditMode default from direct to all, raising warnings for vulnerable transitive packages for non-SDK style projects - [#13584](https://github.com/NuGet/Home/issues/13584)
 
 * Audit security vulnerabilities without adding nuget.org as package source - [#12698](https://github.com/NuGet/Home/issues/12698)
 
-* Deprecate SHA-1 fingerprints usage in NuGet Sign commands in favor of SHA-2 family fingerprints [#13891](https://github.com/NuGet/Home/issues/13891)
+* Owner profile hyperlinks needed in Details Pane of PM UI - [#13686](https://github.com/NuGet/Home/issues/13686)
 
-* Deprecate http usage: Promote from warning to error - [#13289](https://github.com/NuGet/Home/issues/13289)
+* Deprecate SHA-1 fingerprints usage in NuGet Sign commands in favor of SHA-2 family fingerprints [#13891](https://github.com/NuGet/Home/issues/13891)
 
 ### Breaking changes
 
-* NuGetAudit should check transitive packages by default when the .NET 9 SDK is installed [#13293](https://github.com/NuGet/Home/issues/13293)
-
-* Change NuGetAuditMode default to all for non-SDK style projects - [#13584](https://github.com/NuGet/Home/issues/13584)
+* Deprecate http usage: Promote from warning to error - [#13289](https://github.com/NuGet/Home/issues/13289)
 
 ### Issues fixed in this release
 


### PR DESCRIPTION
- Move NuGet Audit changes to What's new.
- Clarify that NuGet Audit changes means new warnings.
- Move http deprecation warning to error to breaking changes, because it's an actual breaking change 