### PR TITLE
Clarify what a package being available means

### DIFF
--- a/docs/api/package-base-address-resource.md
+++ b/docs/api/package-base-address-resource.md
@@ -36,8 +36,8 @@ All URLs found in the package content resource support the HTTP methods `GET` an
 
 ## Enumerate package versions
 
-If the client knows a package ID and wants to discover which package versions the package source has available, the
-client can construct a predictable URL to enumerate all package versions. Every version listen in this list must be available for download.
+If the client knows a package ID and wants to discover which package versions the package source has available, the client can construct a predictable URL to enumerate all package versions.
+Every version listen in this list must be available for download.
 This list is meant to be a "directory listing" for the package content API mentioned below.
 
 > [!Note]

--- a/docs/api/package-base-address-resource.md
+++ b/docs/api/package-base-address-resource.md
@@ -38,8 +38,7 @@ All URLs found in the package content resource support the HTTP methods `GET` an
 
 If the client knows a package ID and wants to discover which package versions the package source has available, the
 client can construct a predictable URL to enumerate all package versions. Every version listen in this list must be available for download.
-This list is meant to be a "directory
-listing" for the package content API mentioned below.
+This list is meant to be a "directory listing" for the package content API mentioned below.
 
 > [!Note]
 > This list contains both listed and unlisted package versions.

--- a/docs/api/package-base-address-resource.md
+++ b/docs/api/package-base-address-resource.md
@@ -37,7 +37,7 @@ All URLs found in the package content resource support the HTTP methods `GET` an
 ## Enumerate package versions
 
 If the client knows a package ID and wants to discover which package versions the package source has available, the client can construct a predictable URL to enumerate all package versions.
-Every version listen in this list must be available for download.
+Every version listed in this list must be available for download.
 This list is meant to be a "directory listing" for the package content API mentioned below.
 
 > [!Note]

--- a/docs/api/package-base-address-resource.md
+++ b/docs/api/package-base-address-resource.md
@@ -37,7 +37,9 @@ All URLs found in the package content resource support the HTTP methods `GET` an
 ## Enumerate package versions
 
 If the client knows a package ID and wants to discover which package versions the package source has available, the
-client can construct a predictable URL to enumerate all package versions. This list is meant to be a "directory
+client can construct a predictable URL to enumerate all package versions. Every version listen in this list must be available for download.
+
+This list is meant to be a "directory
 listing" for the package content API mentioned below.
 
 > [!Note]

--- a/docs/api/package-base-address-resource.md
+++ b/docs/api/package-base-address-resource.md
@@ -38,7 +38,6 @@ All URLs found in the package content resource support the HTTP methods `GET` an
 
 If the client knows a package ID and wants to discover which package versions the package source has available, the
 client can construct a predictable URL to enumerate all package versions. Every version listen in this list must be available for download.
-
 This list is meant to be a "directory
 listing" for the package content API mentioned below.
 


### PR DESCRIPTION
See motivation: https://github.com/NuGet/Home/issues/13930#issuecomment-2484174618. 


tldr; If a package content resource lists a package as available, it should be able to download. 
Being unavailable breaks the contract.