### PR TITLE
Adding CLI command to create a Directory.Packages.props

### DIFF
--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -38,6 +38,11 @@ Central package management applies to all `<PackageReference>`-based MSBuild pro
 To get started with central package management, you must create a `Directory.Packages.props` file at the root of your repository and set the MSBuild property
 `ManagePackageVersionsCentrally` to `true`.
 
+Creating a new `Directory.Packages.props` using the dotnet CLI:
+``` shell
+dotnet new packagesprops
+```
+
 Inside, you then define each of the respective package versions required of your projects using `<PackageVersion />` elements that define the package ID and
 version.
 

--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -38,7 +38,7 @@ Central package management applies to all `<PackageReference>`-based MSBuild pro
 To get started with central package management, you must create a `Directory.Packages.props` file at the root of your repository and set the MSBuild property
 `ManagePackageVersionsCentrally` to `true`.
 
-Creating a new `Directory.Packages.props` using the dotnet CLI:
+You can create it manually or you can use the dotnet CLI:
 ``` shell
 dotnet new packagesprops
 ```


### PR DESCRIPTION
I just stumbled upon a CLI command to create a ready-to-go `Directory.Packages.props` file.

It makes sense to mention how to create this file 