### PR TITLE
Specify correct version in the nuspec

### DIFF
--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -165,8 +165,8 @@ When you use the pack command to create a package, both packages will appear in 
 
 ```xml
       <group targetFramework="net6.0">
-        <dependency id="PackageA" version="6.12.1" exclude="Build,Analyzers" />
-        <dependency id="PackageB" version="6.12.1" exclude="Build,Analyzers" />
+        <dependency id="PackageA" version="1.0.0" exclude="Build,Analyzers" />
+        <dependency id="PackageB" version="2.0.0" exclude="Build,Analyzers" />
       </group>
 ```
 


### PR DESCRIPTION
It was meant to be 1.0.0 and 2.0.0 and not 6.12.1. 
The 6.12.1 is from an earlier version of the example.

Called out in https://github.com/NuGet/docs.microsoft.com-nuget/pull/3388#issuecomment-2655104573 

cc @johnterickson
