### PR TITLE
Remove references to VisualStudioAccountProvider in NuGet-Credential-Providers-for-Visual-Studio

### DIFF
--- a/docs/reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md
+++ b/docs/reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md
@@ -31,7 +31,6 @@ The NuGet Visual Studio Extension 3.6+ implements an internal CredentialService 
 During credential acquisition, the credential service will try credential providers in the following order, stopping as soon as credentials are acquired:
 
 1. Credentials will be fetched from NuGet configuration files (using the built-in `SettingsCredentialProvider`).
-1. If the package source is on Visual Studio Team Services, the `VisualStudioAccountProvider` will be used.
 1. All other plug-in Visual Studio credential providers will be tried sequentially.
 1. Try to use all NuGet cross platform credential providers sequentially.
 1. If no credentials have been acquired yet, the user will be prompted for credentials using a standard basic authentication dialog.

--- a/docs/reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md
+++ b/docs/reference/extensibility/NuGet-Credential-Providers-for-Visual-Studio.md
@@ -31,7 +31,7 @@ The NuGet Visual Studio Extension 3.6+ implements an internal CredentialService 
 During credential acquisition, the credential service will try credential providers in the following order, stopping as soon as credentials are acquired:
 
 1. Credentials will be fetched from NuGet configuration files (using the built-in `SettingsCredentialProvider`).
-1. All other plug-in Visual Studio credential providers will be tried sequentially.
+1. Visual Studio credential providers will be tried sequentially.
 1. Try to use all NuGet cross platform credential providers sequentially.
 1. If no credentials have been acquired yet, the user will be prompted for credentials using a standard basic authentication dialog.
 


### PR DESCRIPTION
Removing reference to `VisualStudioAccountProvider` since it has been deleted from the repo.

https://github.com/NuGet/Home/issues/8577