### PR TITLE
Improve documentation for Central Package Management

### DIFF
--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -18,7 +18,7 @@ Historically, NuGet package dependencies have been managed in one of two locatio
 - `packages.config` - An XML file used in older project types to maintain the list of packages referenced by the project.
 - `<PackageReference />` - An XML element used in MSBuild projects defines NuGet package dependencies.
 
-Starting with [NuGet 6.2](..\release-notes\NuGet-6.2.md), you can centrally manage your dependencies in your projects with the addition of a
+Starting with [NuGet 6.2](../release-notes/NuGet-6.2.md), you can centrally manage your dependencies in your projects with the addition of a
 `Directory.Packages.props` file and an MSBuild property.
 
 The feature is available across all NuGet integrated tooling, starting with the following versions.

--- a/docs/consume-packages/Central-Package-Management.md
+++ b/docs/consume-packages/Central-Package-Management.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Central Package Management
 description: Manage your dependencies in a central location and how you can get started with central package management.
 author: jondouglas
@@ -57,7 +57,7 @@ version.
 </Project>
 ```
 
-For each project, you then define a `<PackageReference />` but omit the `Version` attribute since the version will be attained from a corresponding
+For each project, you then define a `<PackageReference />` but omit the `Version` attribute since the version will be obtained from a corresponding
 `<PackageVersion />` item.
 
 ```xml
@@ -81,19 +81,24 @@ simplicity, only one `Directory.Packages.props` file is evaluated for a given pr
 What this means is that if you had multiple `Directory.Packages.props` files in your repository, the file that is closest to your project's directory will
 be evaluated for it. This allows you extra control at various levels of your repository.
 
-Here's an example, consider the following repository structure:
+Consider the following repository structure:
 
 ```
-Repository
- |-- Directory.Packages.props
- |-- Solution1
-     |-- Directory.Packages.props
-     |-- Project1
- |-- Solution2
-     |-- Project2
+📂 (root)
+ ├─📄 Directory.Packages.props
+ |
+ ├─📂Solution1
+ |  ├─ 📄Directory.Packages.props
+ |  |
+ |  └─ 📂 Project1
+ |      └─📄Project1.csproj
+ |
+ └─ 📂 Solution2
+    └─ 📂 Project2
+        └─ 📄 Project2.csproj
 ```
 
-- Project1 will evaluate the `Directory.Packages.props` file in the `Repository\Solution1\` directory and it must manually import the next one if so desired.
+- `Project1.csproj` will load the `Directory.Packages.props` file in the `Repository\Solution1\` directory first and it must manually import any parent ones if desired.
   ```xml
   <Project>
     <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
@@ -102,14 +107,14 @@ Repository
     </ItemGroup>
   </Project>
   ```
-- Project2 will evaluate the `Directory.Packages.props` file in the `Repository\` directory.
+- `Project2.csproj` will evaluate the `Directory.Packages.props` file in the root directory.
 
-**Note:** MSBuild will not automatically import each `Directory.Packages.props` for you, only the first one closest to the project.  If you have multiple
-`Directory.Packages.props`, you must import the parent one manually while the root `Directory.Packages.props` would not.
+**Note:** MSBuild will not automatically import each `Directory.Packages.props` for you, only the first one found in the project directory or any parent directory.  If you have multiple
+`Directory.Packages.props` files, you must import any files in parent directories manually.
 
 ## Get started
 
-To fully onboard your repository, consider taking these steps:
+To fully onboard your repository, follow these steps:
 
 1. Create a new file at the root of your repository named `Directory.Packages.props` that declares your centrally defined package versions and set
  the MSBuild property `ManagePackageVersionsCentrally` to `true`.
@@ -251,8 +256,3 @@ this warning, map your package sources with [package source mapping](https://aka
 ```
 There are 3 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source.
 ```
-
-
-
-> [!Note]
-> Central package management is in active development. We appreciate you trying it out and providing any feedback you may have at [NuGet/Home](https://github.com/nuget/home/issues).

--- a/docs/reference/errors-and-warnings/NU1008.md
+++ b/docs/reference/errors-and-warnings/NU1008.md
@@ -11,7 +11,7 @@ f1_keywords:
 
 # NuGet Error NU1008
 
-> The PackageReference items 'PackageName' cannot define a value for Version.  Projects using Central Package Management must define a Version value on a PackageVersion item.
+> The following PackageReference items cannot define a value for Version: PackageName.  Projects using Central Package Management must define a Version value on a PackageVersion item.
 
 ## Issue
 

--- a/docs/reference/errors-and-warnings/NU1008.md
+++ b/docs/reference/errors-and-warnings/NU1008.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageReference />` item is defined which specifies a value for the `Version` attribute:
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and a `<PackageReference />` item is defined which specifies a value for the `Version` attribute:
 
 ```xml
 <ItemGroup>
@@ -32,8 +32,8 @@ Alternatively, a `<PackageReference />` item is defined with a child `<Version /
 </ItemGroup>
 ```
 
-Projects configured to use [Central Package Management](..\..\consume-packages\Central-Package-Management.md) should not define a version on `<PackageReference />` items.
-The version should be defined in on a corresponding `<PackageVersion />` item with the same identifier in [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file instead.
+Projects configured to use [Central Package Management](../../consume-packages/Central-Package-Management.md) should not define a version on `<PackageReference />` items.
+The version should be defined in on a corresponding `<PackageVersion />` item with the same identifier in [Directory.Packages.props](../../consume-packages/Central-Package-Management.md#enabling-central-package-management) file instead.
 
 ## Solution
 
@@ -45,7 +45,7 @@ The version should be defined in on a corresponding `<PackageVersion />` item wi
   </ItemGroup>
   ```
 
-- Define a `<PackageVersion />` item that specifies the version in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file with the same identifier as the `<PackageReference />` item:
+- Define a `<PackageVersion />` item that specifies the version in the [Directory.Packages.props](../../consume-packages/Central-Package-Management.md#enabling-central-package-management) file with the same identifier as the `<PackageReference />` item:
 
   ```xml
   <ItemGroup>
@@ -53,25 +53,7 @@ The version should be defined in on a corresponding `<PackageVersion />` item wi
   </ItemGroup>
   ```
 
-
-**TODO: Discuss VersionOverride**
-
-
-Alternatively, you may override an individual package version by using the `VersionOverride` property on a `<PackageReference />` item.
-This overrides any `<PackageVersion />` defined centrally.
-
-    Example:
-
-    ```xml
-    <!-- In the project file. -->
-    <PackageReference Include="PackageName" VersionOverride="3.0.0" />
-    ```
-
-    ```xml
-    <!-- In the Directory.Packages.props -->
-    <PackageVersion Include="PackageName" Version="5.1.0" />
-    ```
-
+Alternatively, Central Package Management allows overriding centrally defined package versions. See [Overriding Package Versions](../../consume-packages/Central-Package-Management.md#overriding-package-versions) for more information.
 
 > [!NOTE]
 > Note that metadata such as [IncludeAssets, PrivateAssets etc.](../../consume-packages/Package-References-in-Project-Files.md#controlling-dependency-assets) should remain on the PackageReference item.

--- a/docs/reference/errors-and-warnings/NU1008.md
+++ b/docs/reference/errors-and-warnings/NU1008.md
@@ -11,49 +11,65 @@ f1_keywords:
 
 # NuGet Error NU1008
 
-> Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: PackageId.
+> The PackageReference items 'PackageName' cannot define a value for Version.  Projects using Central Package Management must define a Version value on a PackageVersion item.
 
-### Issue
+## Issue
 
-When using central package management, versions must be defined on the PackageVersion item.
-
-In your project file, you may see:
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageReference />` item is defined which specifies a value for the `Version` attribute:
 
 ```xml
-<!-- In the project file. -->
-<PackageReference Include="PackageId" Version="5.1.0" />
+<ItemGroup>
+  <PackageReference Include="PackageName" Version="5.1.0" />
+</ItemGroup>
 ```
 
-### Solution
+Alternatively, a `<PackageReference />` item is defined with a child `<Version />` element that has a value specified:
+```xml
+<ItemGroup>
+  <PackageReference Include="PackageName">
+    <Version>5.1.0</Version>
+  </PackageReference>
+</ItemGroup>
+```
 
-- Remove the version from the PackageId PackageReference.
-- You may need to add or update the PackageVersion item for PackageId in Directory.Packages.props
+Projects configured to use [Central Package Management](..\..\consume-packages\Central-Package-Management.md) should not define a version on `<PackageReference />` items.
+The version should be defined in on a corresponding `<PackageVersion />` item with the same identifier in [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file instead.
 
-    Example:
+## Solution
 
-    ```xml
-    <!-- In the project file. -->
-    <PackageReference Include="PackageId" />
-    ```
+- Remove the `Version` attribute or child `<Version />` element from the `<PackageReference />` item:
 
-    ```xml
-    <!-- In the Directory.Packages.props -->
-    <PackageVersion Include="PackageId" Version="5.1.0" />
-    ```
+  ```xml
+  <ItemGroup>
+    <PackageReference Include="PackageName" />
+  </ItemGroup>
+  ```
 
-- Alternatively, you may override an individual package version by using the `VersionOverride` property on a `<PackageReference />` item.
+- Define a `<PackageVersion />` item that specifies the version in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file with the same identifier as the `<PackageReference />` item:
+
+  ```xml
+  <ItemGroup>
+    <PackageVersion Include="PackageName" Version="5.0.1" />
+  </ItemGroup>
+  ```
+
+
+**TODO: Discuss VersionOverride**
+
+
+Alternatively, you may override an individual package version by using the `VersionOverride` property on a `<PackageReference />` item.
 This overrides any `<PackageVersion />` defined centrally.
 
     Example:
 
     ```xml
     <!-- In the project file. -->
-    <PackageReference Include="PackageId" VersionOverride="3.0.0" />
+    <PackageReference Include="PackageName" VersionOverride="3.0.0" />
     ```
 
     ```xml
     <!-- In the Directory.Packages.props -->
-    <PackageVersion Include="PackageId" Version="5.1.0" />
+    <PackageVersion Include="PackageName" Version="5.1.0" />
     ```
 
 

--- a/docs/reference/errors-and-warnings/NU1009.md
+++ b/docs/reference/errors-and-warnings/NU1009.md
@@ -11,12 +11,29 @@ f1_keywords:
 
 # NuGet Error NU1009
 
-> The packages PackageId are implicitly referenced. You do not typically need to reference them from your project or in your central package versions management file. For more information, see https://aka.ms/sdkimplicitrefs
+> The PackageReference items 'PackageName' are implicitly defined and cannot define a PackageVersion item.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item.
 
-### Issue
+## Issue
 
-Implicitly defined packages should not be managed centrally.
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageVersion />` item is defined in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file for a package that is [implicitly defined](https://aka.ms/sdkimplicitrefs).
+Implicitly defined packages are generally declared by an SDK to include packages on your behalf.
+For these packages, the owner of the SDK controls the version being used and a user should not define a version with [Central Package Management](..\..\consume-packages\Central-Package-Management.md).
 
-### Solution
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.NETCore.App" Version="9.0.0" IsImplicitlyDefined="true" />
+</ItemGroup>
+```
 
-Remove the PackageVersion for PackageId
+## Solution
+
+- Remove the `PackageVersion` item from the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file that corresponds to the implicitly defined package:
+
+  ```xml
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NETCore.App" Version="1.0.0" />
+  </ItemGroup>
+  ```
+
+> [!NOTE]
+> Some SDKs allow you to override the implicitly defined package version by setting a specific MSBuild property for that package and the SDK may have documentation on how to do so.

--- a/docs/reference/errors-and-warnings/NU1009.md
+++ b/docs/reference/errors-and-warnings/NU1009.md
@@ -15,9 +15,9 @@ f1_keywords:
 
 ## Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageVersion />` item is defined in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file for a package that is [implicitly defined](https://aka.ms/sdkimplicitrefs).
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and a `<PackageVersion />` item is defined in the [Directory.Packages.props](../../consume-packages/Central-Package-Management.md#enabling-central-package-management) file for a package that is [implicitly defined](https://aka.ms/sdkimplicitrefs).
 Implicitly defined packages are generally declared by an SDK to include packages on your behalf.
-For these packages, the owner of the SDK controls the version being used and a user should not define a version with [Central Package Management](..\..\consume-packages\Central-Package-Management.md).
+For these packages, the owner of the SDK controls the version being used and a user should not define a version with [Central Package Management](../../consume-packages/Central-Package-Management.md).
 
 ```xml
 <ItemGroup>
@@ -27,7 +27,7 @@ For these packages, the owner of the SDK controls the version being used and a u
 
 ## Solution
 
-- Remove the `PackageVersion` item from the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file that corresponds to the implicitly defined package:
+- Remove the `PackageVersion` item from the [Directory.Packages.props](../../consume-packages/Central-Package-Management.md#enabling-central-package-management) file that corresponds to the implicitly defined package:
 
   ```xml
   <ItemGroup>

--- a/docs/reference/errors-and-warnings/NU1009.md
+++ b/docs/reference/errors-and-warnings/NU1009.md
@@ -11,7 +11,7 @@ f1_keywords:
 
 # NuGet Error NU1009
 
-> The PackageReference items 'PackageName' are implicitly defined and cannot define a PackageVersion item.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item.
+> The following PackageReference items are implicitly defined and cannot define a PackageVersion item: PackageName.  Projects using Central Package Management require that implicit package versions be specified by the PackageReference item.
 
 ## Issue
 

--- a/docs/reference/errors-and-warnings/NU1010.md
+++ b/docs/reference/errors-and-warnings/NU1010.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageReference />` item is defined but a corresponding `<PackageVersion />` item with the same name is not defined in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file:
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and a `<PackageReference />` item is defined but a corresponding `<PackageVersion />` item with the same name is not defined in the [Directory.Packages.props](../../consume-packages/Central-Package-Management.md#enabling-central-package-management) file:
 
 ```xml
 <ItemGroup>
@@ -25,7 +25,7 @@ A project is configured to use NuGet [Central Package Management](..\..\consume-
 
 ## Solution
 
-- Define a `<PackageVersion />` item that specifies the version in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file with the same identifier as the `<PackageReference />` item:
+- Define a `<PackageVersion />` item that specifies the version in the [Directory.Packages.props](../../consume-packages/Central-Package-Management.md#enabling-central-package-management) file with the same identifier as the `<PackageReference />` item:
 
   ```xml
   <ItemGroup>

--- a/docs/reference/errors-and-warnings/NU1010.md
+++ b/docs/reference/errors-and-warnings/NU1010.md
@@ -11,12 +11,27 @@ f1_keywords:
 
 # NuGet Error NU1010
 
-> The PackageReference items PackageId do not have corresponding PackageVersion.
+> The PackageReference items 'PackageName' do not define a corresponding PackageVersion item. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names
 
-### Issue
+## Issue
 
-The PackageReference PackageId is missing a PackageVersion item.
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageReference />` item is defined but a corresponding `<PackageVersion />` item with the same name is not defined in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file:
 
-### Solution
+```xml
+<ItemGroup>
+  <PackageReference Include="PackageName" />
+</ItemGroup>
+```
 
-Add a PackageVersion item for PackageId in the [Directory.Packages.props](../../consume-packages/Central-Package-Management.md).
+## Solution
+
+- Define a `<PackageVersion />` item that specifies the version in the [Directory.Packages.props](..\..\consume-packages\Central-Package-Management.md#directorypackagesprops) file with the same identifier as the `<PackageReference />` item:
+
+  ```xml
+  <ItemGroup>
+    <PackageVersion Include="PackageName" Version="5.0.1" />
+  </ItemGroup>
+  ```
+- If a `<PackageVersion />` item is properly defined and this error occurs in Visual Studio, check the Error List window for errors related to loading the project or failed [design time builds](https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md).
+If Visual Studio is not able to successfully load the project or a design time build fails, NuGet may log this error because it does not have the required information to restore.
+Resolving these underlying issues should fix this error.

--- a/docs/reference/errors-and-warnings/NU1010.md
+++ b/docs/reference/errors-and-warnings/NU1010.md
@@ -11,7 +11,7 @@ f1_keywords:
 
 # NuGet Error NU1010
 
-> The PackageReference items 'PackageName' do not define a corresponding PackageVersion item. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names
+> The following PackageReference items do not define a corresponding PackageVersion item: PackageName. Projects using Central Package Management must declare PackageReference and PackageVersion items with matching names
 
 ## Issue
 

--- a/docs/reference/errors-and-warnings/NU1011.md
+++ b/docs/reference/errors-and-warnings/NU1011.md
@@ -11,7 +11,7 @@ f1_keywords:
 
 # NuGet Error NU1011
 
-> The PackageVersion items 'PackageName' cannot specify a floating version.
+> The following PackageVersion items cannot specify a floating version: PackageName.
 
 ## Issue
 

--- a/docs/reference/errors-and-warnings/NU1011.md
+++ b/docs/reference/errors-and-warnings/NU1011.md
@@ -11,27 +11,38 @@ f1_keywords:
 
 # NuGet Error NU1011
 
-> Centrally defined floating package versions are not allowed.
+> The PackageVersion items 'PackageName' cannot specify a floating version.
 
-### Issue
+## Issue
 
-By default, `<PackageVersion />` items cannot contain floating versions.  NuGet's central package management (CPM) is considered an enterprise-level feature which provides easier version
-management at scale as well as deterministic and secure restores.  The use of floating versions introduces the possibility for a bad package to be introduced into your build
-after it has been pushed to a feed.  This can lead to a situation where you made no changes in your repository but suddenly something is broken and there is no way for you to
-get back into a good state without removing the floating version or pushing a newer version of the package which is fixed.  Using non-floating versions means that every upgrade
-to a package is backed by a commit in your repository making it easy to determine what change caused the break and to revert a commit to get back into a good state.
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageVersion />` item is defined which specifies a [floating version](..\..\concepts\Package-Versioning.md#version-ranges) value for the `Version` attribute:
 
-The [Transitive Pinning](../../consume-packages/Central-Package-Management.md#transitive-pinning) feature is designed to allow you to explicitly override the transitive versions in your graph for more control. Using a floating version as an override could make restores of different projects end up with different versions for the package that is supposed to be pinned, thus going against the promise of using the central version.
+```xml
+<ItemGroup>
+  <PackageVersion Include="PackageName" Version="1.*" />
+</ItemGroup>
+```
+By default, `<PackageVersion />` items cannot specify floating versions.
+NuGet's [Central Package Management](..\..\consume-packages\Central-Package-Management.md) provides users the ability to manage package versions in a single location as well as deterministic and secure restores.
+The use of floating versions introduces the possibility for a bad package to be introduced into your build after it has been pushed to a feed.
+This can lead to a situation where you made no changes in your repository but suddenly something is broken due to a problem in a new package and there is no way for you to get back into a good state without removing the floating version or pushing a newer version of the package which is fixed.
+Using non-floating versions means that every upgrade to a package is backed by a commit in your repository, making it easy to determine what change caused the break and allows you to revert a commit to get back into a good state.
+
+Also, when using the [transitive pinning](../../consume-packages/Central-Package-Management.md#transitive-pinning) feature of [Central Package Management](..\..\consume-packages\Central-Package-Management.md), using a floating version as an override could make restores of different projects end up with different versions for the package that what is supposed to be pinned, thus going against the promise of using the centrally defined version.
 
 NuGet recommends you use automation like [Dependabot](https://docs.github.com/code-security/dependabot/working-with-dependabot) to keep package versions up-to-date which provides
-a streamlined way of keeping packages updated while integrating into your existing developer workflow of a pull request, automated build validation, and testing all backed by a
-commit in your repository.
+a streamlined way of updating package versions while integrating into your existing developer workflow of a pull request, automated build validation, and testing all backed by a commit in your repository.
 
+## Solution
 
-### Solution
+- It is recommended to change the floating version to a [non floating version range](../../concepts/Package-Versioning.md#version-ranges):
+```xml
+<ItemGroup>
+  <PackageVersion Include="PackageName" Version="1.0.0" />
+</ItemGroup>
+```
 
-It is recommended to change the floating version to a [non floating version range](../../concepts/Package-Versioning.md#version-ranges).  If that is not possible, you can enable
-floating versions with CPM by setting an MSBuild property:
+- If that is not possible, or you wish to use floating versions with Central Package Management, you can do so by setting an MSBuild property:
 
 ```xml
 <PropertyGroup>

--- a/docs/reference/errors-and-warnings/NU1011.md
+++ b/docs/reference/errors-and-warnings/NU1011.md
@@ -15,7 +15,7 @@ f1_keywords:
 
 ## Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageVersion />` item is defined which specifies a [floating version](..\..\concepts\Package-Versioning.md#version-ranges) value for the `Version` attribute:
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and a `<PackageVersion />` item is defined which specifies a [floating version](../../concepts/Package-Versioning.md#version-ranges) value for the `Version` attribute:
 
 ```xml
 <ItemGroup>
@@ -23,12 +23,12 @@ A project is configured to use NuGet [Central Package Management](..\..\consume-
 </ItemGroup>
 ```
 By default, `<PackageVersion />` items cannot specify floating versions.
-NuGet's [Central Package Management](..\..\consume-packages\Central-Package-Management.md) provides users the ability to manage package versions in a single location as well as deterministic and secure restores.
+NuGet's [Central Package Management](../../consume-packages/Central-Package-Management.md) provides users the ability to manage package versions in a single location as well as deterministic and secure restores.
 The use of floating versions introduces the possibility for a bad package to be introduced into your build after it has been pushed to a feed.
 This can lead to a situation where you made no changes in your repository but suddenly something is broken due to a problem in a new package and there is no way for you to get back into a good state without removing the floating version or pushing a newer version of the package which is fixed.
 Using non-floating versions means that every upgrade to a package is backed by a commit in your repository, making it easy to determine what change caused the break and allows you to revert a commit to get back into a good state.
 
-Also, when using the [transitive pinning](../../consume-packages/Central-Package-Management.md#transitive-pinning) feature of [Central Package Management](..\..\consume-packages\Central-Package-Management.md), using a floating version as an override could make restores of different projects end up with different versions for the package that what is supposed to be pinned, thus going against the promise of using the centrally defined version.
+Also, when using the [transitive pinning](../../consume-packages/Central-Package-Management.md#transitive-pinning) feature of [Central Package Management](../../consume-packages/Central-Package-Management.md), using a floating version as an override could make restores of different projects end up with different versions for the package that what is supposed to be pinned, thus going against the promise of using the centrally defined version.
 
 NuGet recommends you use automation like [Dependabot](https://docs.github.com/code-security/dependabot/working-with-dependabot) to keep package versions up-to-date which provides
 a streamlined way of updating package versions while integrating into your existing developer workflow of a pull request, automated build validation, and testing all backed by a commit in your repository.

--- a/docs/reference/errors-and-warnings/NU1013.md
+++ b/docs/reference/errors-and-warnings/NU1013.md
@@ -1,6 +1,6 @@
 ---
 title: NuGet Error NU1013
-description: NU1012 error code
+description: NU1013 error code
 author: jeffkl
 ms.author: jeffkl
 ms.date: 03/24/2025
@@ -15,7 +15,7 @@ f1_keywords:
 
 ### Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageReference />` item is defined which specifies a value for the `VersionOverride` attribute but this functionality has been disabled:
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and a `<PackageReference />` item is defined which specifies a value for the `VersionOverride` attribute but this functionality has been disabled:
 
 ```xml
 <PropertyGroup>
@@ -35,4 +35,4 @@ A project is configured to use NuGet [Central Package Management](..\..\consume-
 </ItemGroup>
 ```
 
-- You can configure [Central Package Management](..\..\consume-packages\Central-Package-Management.md) to allow or disallow `VersionOverride` with the MSBuild property `CentralPackageVersionOverrideEnabled`. See [Overriding Package Versions](..\..\consume-packages\Central-Package-Management.md#overriding-package-versions) for more information.
+- You can configure [Central Package Management](../../consume-packages/Central-Package-Management.md) to allow or disallow `VersionOverride` with the MSBuild property `CentralPackageVersionOverrideEnabled`. See [Overriding Package Versions](../../consume-packages/Central-Package-Management.md#overriding-package-versions) for more information.

--- a/docs/reference/errors-and-warnings/NU1013.md
+++ b/docs/reference/errors-and-warnings/NU1013.md
@@ -1,0 +1,38 @@
+---
+title: NuGet Error NU1013
+description: NU1012 error code
+author: jeffkl
+ms.author: jeffkl
+ms.date: 03/24/2025
+ms.topic: reference
+f1_keywords:
+  - "NU1013"
+---
+
+# NuGet Error NU1013
+
+> The PackageReference items 'PackageName' cannot specify a value for VersionOverride.  Projects using Central Package Management are currently configured to disable this functionality.
+
+### Issue
+
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a `<PackageReference />` item is defined which specifies a value for the `VersionOverride` attribute but this functionality has been disabled:
+
+```xml
+<PropertyGroup>
+  <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="PackageName" VersionOverride="9.0.0" />
+</ItemGroup>
+```
+
+### Solution
+- Remove the `VersionOverride` attribute from the `<PackageReference />` item:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="PackageName" />
+</ItemGroup>
+```
+
+- You can configure [Central Package Management](..\..\consume-packages\Central-Package-Management.md) to allow or disallow `VersionOverride` with the MSBuild property `CentralPackageVersionOverrideEnabled`. See [Overriding Package Versions](..\..\consume-packages\Central-Package-Management.md#overriding-package-versions) for more information.

--- a/docs/reference/errors-and-warnings/NU1013.md
+++ b/docs/reference/errors-and-warnings/NU1013.md
@@ -11,7 +11,7 @@ f1_keywords:
 
 # NuGet Error NU1013
 
-> The PackageReference items 'PackageName' cannot specify a value for VersionOverride.  Projects using Central Package Management are currently configured to disable this functionality.
+> The following PackageReference items cannot specify a value for VersionOverride: PackageName.  Projects using Central Package Management are currently configured to disable this functionality.
 
 ### Issue
 

--- a/docs/reference/errors-and-warnings/NU1109.md
+++ b/docs/reference/errors-and-warnings/NU1109.md
@@ -17,7 +17,7 @@ f1_keywords:
 
 ## Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a transitive package dependency is pinned to a version lower than is specified by the dependency package.
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and a transitive package dependency is pinned to a version lower than is specified by the dependency package.
 When resolving packages, NuGet respects the [direct-dependency-wins](../../concepts/dependency-resolution.md#direct-dependency-wins) rule and the pinned package version overrides the version specified by the dependency package which results in a lower version of the package being resolved which could result in issues at runtime.
 
 ```xml

--- a/docs/reference/errors-and-warnings/NU1109.md
+++ b/docs/reference/errors-and-warnings/NU1109.md
@@ -11,15 +11,37 @@ f1_keywords:
 
 # NuGet Error NU1109
 
-> NU1109: Detected package downgrade: B from 2.0.0 to centrally defined 1.0.0. Update the centrally managed package version to a higher version.<br/>
-> &nbsp;&nbsp;'Project' -> 'A' 1.0.0 -> 'B' (>= 2.0.0)<br/>
-> &nbsp;&nbsp;'Project' -> 'B' (>= 1.0.0)
+> NU1109: Detected package downgrade: PackageB from 2.0.0 to centrally defined 1.0.0. Update the centrally managed package version to a higher version.<br/>
+> &nbsp;&nbsp;'Project' -> 'PackageA' 1.0.0 -> 'PackageB' (>= 2.0.0)<br/>
+> &nbsp;&nbsp;'Project' -> 'PackageB' (>= 1.0.0)
 
-### Issue
+## Issue
 
-A dependency package specified a version constraint on a higher version of a package than restore ultimately resolved. That is because of the [direct-dependency-wins](../../concepts/dependency-resolution.md#direct-dependency-wins) rule - when resolving packages, the direct package version in the subgraph will override that of the distant packages with the same ID.
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and a transitive package dependency is pinned to a version lower than is specified by the dependency package.
+When resolving packages, NuGet respects the [direct-dependency-wins](../../concepts/dependency-resolution.md#direct-dependency-wins) rule and the pinned package version overrides the version specified by the dependency package which results in a lower version of the package being resolved which could result in issues at runtime.
 
-### Solution
+```xml
+<PropertyGroup>
+  <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+</PropertyGroup>
+<ItemGroup>
+  <PackageVersion Include="PackageA" Version="1.0.0" />
+  <PackageVersion Include="PackageB" Version="1.0.0" />
+</ItemGroup>
+```
 
-Update the PackageVersion of B to to the higher version of the package.
-In the example above, you would change the package reference to `B` 2.0.0.
+## Solution
+- Update the `PackageVersion` of `PackageB` to the higher version of the package.
+
+```xml
+<ItemGroup>
+  <PackageVersion Include="PackageB" Version="2.0.0" />
+</ItemGroup>
+```
+
+- Disable Central Package Management transitive pinning to allow the package version specified by the dependency package to be used.
+```xml
+<PropertyGroup>
+  <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+</PropertyGroup>
+```

--- a/docs/reference/errors-and-warnings/NU1507.md
+++ b/docs/reference/errors-and-warnings/NU1507.md
@@ -25,7 +25,7 @@ It is highly recommended to enable [Package Source Mapping](../../consume-packag
 
 ```xml
 <PropertyGroup>
-  <!-- Suppress Nu1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. -->
+  <!-- Suppress NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. -->
   <NoWarn>$(NoWarn);NU1507</NoWarn>
 </PropertyGroup>
 ```

--- a/docs/reference/errors-and-warnings/NU1507.md
+++ b/docs/reference/errors-and-warnings/NU1507.md
@@ -11,22 +11,21 @@ f1_keywords:
 
 # NuGet Warning NU1507
 
-## Scenario 1
+> There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. The following sources are defined: https://api.nuget.org/v3/index.json,  https://contoso.myget.org/F/development/.
 
-> There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: https://api.nuget.org/v3/index.json,  https://contoso.myget.org/F/development/.
+## Issue
 
-### Issue
+A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and is not configured to use [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md).
+It is highly recommended to enable [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md) because it safeguards your software supply chain when your project is consuming packages from multiple package sources by allowing you specify the source for each package.
 
-When using NuGet's central package management (CPM), it is highly recommended that you also use Package Source Mapping.  This can help safeguard your software supply chain is crucial if you use a mix of public and private package sources.  Visit https://aka.ms/nuget-package-source-mapping to learn more about how package source mapping works.
+## Solution
 
-### Solution
-
-Onboard to Package Source Mapping if you have more than one NuGet feed configured when using central package management.  You can visit https://aka.ms/nuget-package-source-mapping for more details.
-
-If you are unable to onboard to Package Source Mapping but want to use central package management, can suppress the warning:
+- Onboard to [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md) if you have more than one HTTP-based NuGet package source configured when using Central Package Management.
+- If you are unable to onboard to [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md) but want to use Central Package Management, you can suppress the warning:
 
 ```xml
 <PropertyGroup>
+  <!-- Suppress Nu1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. -->
   <NoWarn>$(NoWarn);NU1507</NoWarn>
 </PropertyGroup>
 ```

--- a/docs/reference/errors-and-warnings/NU1507.md
+++ b/docs/reference/errors-and-warnings/NU1507.md
@@ -15,13 +15,13 @@ f1_keywords:
 
 ## Issue
 
-A project is configured to use NuGet [Central Package Management](..\..\consume-packages\Central-Package-Management.md) and is not configured to use [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md).
-It is highly recommended to enable [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md) because it safeguards your software supply chain when your project is consuming packages from multiple package sources by allowing you specify the source for each package.
+A project is configured to use NuGet [Central Package Management](../../consume-packages/Central-Package-Management.md) and is not configured to use [Package Source Mapping](../../consume-packages/Package-Source-Mapping.md).
+It is highly recommended to enable [Package Source Mapping](../../consume-packages/Package-Source-Mapping.md) because it safeguards your software supply chain when your project is consuming packages from multiple package sources by allowing you specify the source for each package.
 
 ## Solution
 
-- Onboard to [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md) if you have more than one HTTP-based NuGet package source configured when using Central Package Management.
-- If you are unable to onboard to [Package Source Mapping](..\..\consume-packages\Package-Source-Mapping.md) but want to use Central Package Management, you can suppress the warning:
+- Onboard to [Package Source Mapping](../../consume-packages/Package-Source-Mapping.md) if you have more than one HTTP-based NuGet package source configured when using Central Package Management.
+- If you are unable to onboard to [Package Source Mapping](../../consume-packages/Package-Source-Mapping.md) but want to use Central Package Management, you can suppress the warning:
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/13482
Fixes: https://github.com/NuGet/Home/issues/14205

Update errors and warnings based on new text in their messages and any other cleanup that I felt would help based on feedback over the years.  Also documents NU1013.

This depends on changes being accepted in https://github.com/NuGet/NuGet.Client/pull/6345