### PR TITLE
Update NU1701.md

### DIFF
--- a/docs/reference/errors-and-warnings/NU1701.md
+++ b/docs/reference/errors-and-warnings/NU1701.md
@@ -15,7 +15,7 @@ f1_keywords:
 > Package 'packageId' was restored using 'TargetFrameworkA' instead the project target framework 'TargetFrameworkB'. This package may not be fully compatible with your project.
 
 ### Issue
-`PackageTargetFallback` / `AssetTargetFallback` was used to select assets from a package. The warning let users know that the assets may not be 100% compatible.
+`AssetTargetFallback` was used to select assets from a package. The warning let users know that the assets may not be 100% compatible.
 
 ### Solution
 Change the project's target framework to one that the package supports.


### PR DESCRIPTION
https://learn.microsoft.com/nuget/consume-packages/package-references-in-project-files#assettargetfallback

$(PackageTargetFallback) was an earlier feature that attempted to address this challenge, but it is fundamentally broken and should not be used. 