### PR TITLE
Fixing hosting-packages description

### DIFF
--- a/docs/hosting-packages/Overview.md
+++ b/docs/hosting-packages/Overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview of Hosting Your Own NuGet Feeds
-description: An overview of opens for hosting your own NuGet package feeds or galleries either locally or remotely.
+description: An overview of options for hosting your own NuGet package feeds or galleries either locally or remotely.
 author: JonDouglas
 ms.author: jodou
 ms.date: 3/2/2022


### PR DESCRIPTION
Fixing the typo in the description for the hosting-packages page