### PR TITLE
Clarify that SdkAnalysisLevel impacts more than just this warning

### DIFF
--- a/docs/reference/errors-and-warnings/NU1302.md
+++ b/docs/reference/errors-and-warnings/NU1302.md
@@ -51,5 +51,5 @@ Here's how it functions:
 - For SDK Analysis Level value **below 9.0.100**, using HTTP sources triggers a warning ([NU1803](NU1803.md)).
 - Starting with SDK Analysis Level **9.0.100 or higher**, HTTP sources result in an error (NU1302) unless `AllowInsecureConnections` is explicitly enabled.
 
-> [!NOTE]
+> [!WARNING]
 > Changing SdkAnalysisLevel has other side-effects. Refer to the [`SdkAnalysisLevel`](/dotnet/core/project-sdk/msbuild-props#sdkanalysislevel) for a summary of the full scope of .NET SDK features affected.


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/14369. 

The idea is that we'd be adding this disclaimer to every place we recommend SDKAnalysisLevel. 

My plan is to update https://github.com/NuGet/NuGet.Client/blob/dev/docs/feature-guide.md#warnings-and-defaults once the wording here has been approved.