### PR TITLE
Clarify package pruning behavior in .NET SDK 10

### DIFF
--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -470,7 +470,7 @@ This can often lead to a `System.Text.Json 8.0.0` in a project targeting `.NET 9
 Starting in [NuGet version 6.13](..\release-notes\NuGet-6.13.md) and .NET SDK 9.0.200, `PrunePackageReference` enables the pruning of these packages at restore time for .NET SDK based projects.
 The first iteration of pruning affected transitive packages only, but starting with .NET SDK 10, package pruning affects direct packages as well.
 
-Package pruning is available as an opt-in feature with the .NET 9 SDK, and is enabled by default for `>= .NET 8.0` frameworks and `>= .NET Standard 2.0` starting with .NET 10 SDK.
+Package pruning is available as an opt-in feature with the .NET 9 SDK, and is enabled by default for for all frameworks of a project that targets `>= .NET 10.0` in the .NET 10 SDK.
 
 Package pruning is only available with the default dependency resolver as [released in 6.12](#nuget-dependency-resolver).
 

--- a/docs/consume-packages/Package-References-in-Project-Files.md
+++ b/docs/consume-packages/Package-References-in-Project-Files.md
@@ -470,7 +470,7 @@ This can often lead to a `System.Text.Json 8.0.0` in a project targeting `.NET 9
 Starting in [NuGet version 6.13](..\release-notes\NuGet-6.13.md) and .NET SDK 9.0.200, `PrunePackageReference` enables the pruning of these packages at restore time for .NET SDK based projects.
 The first iteration of pruning affected transitive packages only, but starting with .NET SDK 10, package pruning affects direct packages as well.
 
-Package pruning is available as an opt-in feature with the .NET 9 SDK, and is enabled by default for for all frameworks of a project that targets `>= .NET 10.0` in the .NET 10 SDK.
+Package pruning is available as an opt-in feature with the .NET 9 SDK, and is enabled by default for all frameworks of a project that targets `>= .NET 10.0` in the .NET 10 SDK.
 
 Package pruning is only available with the default dependency resolver as [released in 6.12](#nuget-dependency-resolver).
 


### PR DESCRIPTION
Updated the description of package pruning to clarify its behavior in .NET SDK 10.