### PR TITLE
Update broken video link for NuGet package tutorial

### DIFF
--- a/docs/quickstart/create-and-publish-a-package-using-the-dotnet-cli.md
+++ b/docs/quickstart/create-and-publish-a-package-using-the-dotnet-cli.md
@@ -100,7 +100,7 @@ Congratulations on creating and publishing your first NuGet package!
 
 ## Related video
 
-> [!Video https://learn.microsoft.com/shows/dotnet-package-management-with-nuget-for-beginners/creating-and-publishing-a-nuget-package-nuget-for-beginners/player]
+> [!VIDEO https://learn-video.azurefd.net/vod/player?show=dotnet-package-management-with-nuget-for-beginners&ep=creating-and-publishing-a-nuget-package-nuget-for-beginners]
 
 Find more NuGet videos on [Channel 9](/shows/NuGet-101/) and [YouTube](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oVLvfkFk8O9h6v2Dcdh2bh_).
 


### PR DESCRIPTION
This pull request updates the related video link in the NuGet package creation quickstart documentation to point to a more relevant and beginner-friendly video.

Documentation update:

* Updated the video link in `docs/quickstart/create-and-publish-a-package-using-the-dotnet-cli.md` to reference "Creating and Publishing a NuGet Package - NuGet for Beginners" instead of the previous NuGet 101 video.