### PR TITLE
Update CLI reference for certificate fingerprint options (NU3043 promoted to error)

### DIFF
--- a/docs/reference/cli-reference/cli-ref-sign.md
+++ b/docs/reference/cli-reference/cli-ref-sign.md
@@ -33,7 +33,8 @@ where `<package(s)>` is one or more `.nupkg` files.
 
   Starting with NuGet.exe 6.12, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
-  In NuGet.exe 7.0 and later versions, the warning is elevated to an error. Only SHA-2 family fingerprints (SHA-256, SHA-384, and SHA-512) are supported.
+  In NuGet.exe 7.0 and later versions, the warning is elevated to an error.
+  Only SHA-2 family fingerprints (SHA-256, SHA-384, and SHA-512) are supported.
 
   All the previous versions of the NuGet.exe continue to accept only SHA-1 certificate fingerprint.
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/14569

NU3043 warning will be promoted to error in NuGet.exe 7.0 version. This breaking change has already been updated in other docs such as NU3043 doc, `dotnet nuget sign` doc and .NET SDK breaking change doc. In this PR, I have updated NuGet.exe Sign CLI docs.

[NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043): `This warning is promoted to an error in the .NET 10 SDK, and will be promoted to an error in NuGet.exe around .NET 10's release.`

[dotnet-nuget-sign](https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-sign):`In .NET 10 and later versions,` [the warning is elevated to an error](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/dotnet-nuget-sign-sha1-deprecated). `Only SHA-2 family fingerprints (SHA-256, SHA-384, and SHA-512) are supported.`

[.NET SDK breaking change doc](https://learn.microsoft.com/dotnet/core/compatibility/sdk/10.0/dotnet-nuget-sign-sha1-deprecated): `Starting in .NET 10, the [NU3043](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3043) warning is promoted to an error when using SHA-1 fingerprints with the` [dotnet nuget sign command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-sign). `This change enforces the use of only strong, approved hash algorithms (SHA-2 family) for signing operations.`