### PR TITLE
Update audit docs for .net 10

### DIFF
--- a/docs/concepts/Auditing-Packages.md
+++ b/docs/concepts/Auditing-Packages.md
@@ -159,7 +159,7 @@ If security vulnerabilities are found and updates are available for the package,
 - Edit the `.csproj` or other package version location (`Directory.Packages.props`) with a newer version containing a security fix.
 - Use the NuGet package manager user interface in Visual Studio to update the individual package.
 - Run the `dotnet package update --vulnerable` command to update all vulnerable packages in a project to the first version without known vulnerabilities.
-- Run the `dotnet package update` or `dotnet package add` commands with the respective package ID to update to the latest version.
+- Run the `dotnet package update` or `dotnet package add` commands with the respective package ID to update to the latest version. Use [`dotnet add package` when using .NET 9 or earlier](/dotnet/core/whats-new/dotnet-10/sdk#more-consistent-command-order).
 
 #### Transitive Packages
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/14564

The docs were already updated to say that NuGetAuditMode has changed defaults when projects target .net 10 or higher.  This PR updates the table giving an overview of features per version and adds a mention of `dotnet package update --vulnerable`.