### PR TITLE
Add note about third-party pull requests for GitHub Actions

### DIFF
--- a/docs/nuget-org/trusted-publishing.md
+++ b/docs/nuget-org/trusted-publishing.md
@@ -56,7 +56,11 @@ To get started:
        > This corresponds to your workflow at `.github/workflows/build.yml`. Enter the **file name only** (`build.yml`)—do not include the `.github/workflows/` path.  
      - **Environment (optional):** `release` 
        > Enter environment if your workflow uses e.g. `environment: release` and you want to restrict this policy to that environment. Leave this empty if you do not use GitHub Actions environments.
-4. In your **GitHub repo**, update your workflow to request a short‑lived API key and push your package.  
+4. In your **GitHub repo**, update your workflow to request a short‑lived API key and push your package.
+
+> [!NOTE]
+> While pull requests by third parties will be able to change the workflow file, their requests will be stamped with their owner and repository name IDs and thus won't match the configured trust policy and will be rejected.
+
 Here’s a basic example:
 
 ```yaml


### PR DESCRIPTION
I think it's important to communicate to the user, that pull requests by strangers won't be able to circumvent the trust publishing policy.

Without such a hint, it's unclear whether an "approved" user (someone who has contributed before and won't need a manual approval for the GitHub Actions run), would be able to create a PR that changes the GitHub Actions step in such a way, that malicious code is released as new package, because the trust publishing policy is set up for the given repository.

Feel free to make suggestions on the words or change the wording directly.

Pinging @joelverhagen, given that I have more or less used his wording from the .NET Foundation Discord server.