### PR TITLE
Add NuGet 7.6 release notes

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -360,7 +360,7 @@
 ### [Ecosystem](policies/ecosystem.md)
 ### [NuGet.org policies](nuget-org/policies/data-requests.md)
 ## Release notes
-### [Known Issues](release-notes/known-issues.md)
+### [Known Issues](release-notes/Known-Issues.md)
 ### NuGet 7.x
 #### [NuGet 7.6](release-notes/NuGet-7.6.md)
 #### [NuGet 7.5](release-notes/NuGet-7.5.md)

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -362,6 +362,7 @@
 ## Release notes
 ### [Known Issues](release-notes/known-issues.md)
 ### NuGet 7.x
+#### [NuGet 7.6](release-notes/NuGet-7.6.md)
 #### [NuGet 7.5](release-notes/NuGet-7.5.md)
 #### [NuGet 7.4](release-notes/NuGet-7.4.md)
 #### [NuGet 7.3](release-notes/NuGet-7.3.md)

--- a/docs/release-notes/Index.md
+++ b/docs/release-notes/Index.md
@@ -11,6 +11,8 @@ ms.topic: release-notes
 
 [Known Issues](../release-notes/known-issues.md)
 
+[NuGet 7.6](../release-notes/NuGet-7.6.md)
+
 [NuGet 7.5](../release-notes/NuGet-7.5.md)
 
 [NuGet 7.4](../release-notes/NuGet-7.4.md)

--- a/docs/release-notes/Index.md
+++ b/docs/release-notes/Index.md
@@ -9,7 +9,7 @@ ms.topic: release-notes
 
 # Release Notes
 
-[Known Issues](../release-notes/known-issues.md)
+[Known Issues](../release-notes/Known-Issues.md)
 
 [NuGet 7.6](../release-notes/NuGet-7.6.md)
 

--- a/docs/release-notes/NuGet-7.6.md
+++ b/docs/release-notes/NuGet-7.6.md
@@ -18,21 +18,53 @@ NuGet distribution vehicles:
 
 ## Summary: What's New in 7.6.0
 
+* Pack with aliased frameworks should allow combining build outputs from the same framework into a single pack - [#14751](https://github.com/NuGet/Home/issues/14751)
+
+* [Design spec][OIDC] Enrich telemetry for nuget.exe push to include about where the push is from (Azure DevOps, GitHub Actions, etc) - [#14740](https://github.com/NuGet/Home/issues/14740)
+
+* APIs for package management of file-based apps - [#14390](https://github.com/NuGet/Home/issues/14390)
+
 * Get push API key from environment variable - [#12539](https://github.com/NuGet/Home/issues/12539)
 
 ### Issues fixed in this release
 
-* Show certificate CRL and OCSP URLs in `dotnet nuget verify` output - [#14780](https://github.com/NuGet/Home/issues/14780)
+* List package should use TargetFramework property as a key it its output instead of the effective TargetFramework; Introduce a V2 version of the list package output - [#14762](https://github.com/NuGet/Home/issues/14762)
+
+* Block aliases with path separator - [#14752](https://github.com/NuGet/Home/issues/14752)
 
 * Add package and update package treat framework as an alias - [#14540](https://github.com/NuGet/Home/issues/14540)
 
+* [CPM] dotnet add package with --no-restore causes NU1008 - [#12552](https://github.com/NuGet/Home/issues/12552)
+
 * Treat TargetFramework(s) values as aliases - [#5154](https://github.com/NuGet/Home/issues/5154)
+
+* Error while using Add-Migration in  nuget console in Visual Studio Insiders 18.6 - [#14862](https://github.com/NuGet/Home/issues/14862)
+
+* `&lt;NuGetAuditSuppress&gt;` with packages.config projects doesn&#39;t work for more than one suppression - [#14825](https://github.com/NuGet/Home/issues/14825)
+
+* GetReferenceFrameworkNearestTask does not use aliases for disambiguation when using AssetTargetFallback - [#14807](https://github.com/NuGet/Home/issues/14807)
+
+* Aliasing opt-in is broken due to a versioning change in .NET 10.0.3xx - [#14805](https://github.com/NuGet/Home/issues/14805)
 
 * Context menu on Search control in PM UI is missing VS color theming - [#14799](https://github.com/NuGet/Home/issues/14799)
 
+* When using aliased frameworks, package conditions are not generated correctly - [#14796](https://github.com/NuGet/Home/issues/14796)
+
 * NugetProjectServiceV1 brokered service is not usable from out-of-proc consumers - [#14732](https://github.com/NuGet/Home/issues/14732)
 
+* Context menus to Copy text from PM UI are missing VS color theming - [#14704](https://github.com/NuGet/Home/issues/14704)
+
+* Ensure seamless experience with aliasing when packing - [#14535](https://github.com/NuGet/Home/issues/14535)
+
 * No vulns shown for vulnerable &amp; deprecated package version when using dotnet list package --vulnerable - [#14477](https://github.com/NuGet/Home/issues/14477)
+
+* `dotnet list package` invalid TFM resolution; does not work when TargetFramework property matches real framework. - [#14339](https://github.com/NuGet/Home/issues/14339)
+
+* NU1107 message provides poor guidance when CPVM + transitive pinning is enabled - [#12277](https://github.com/NuGet/Home/issues/12277)
+
+* [Bug]: NU1004: The project Xxx has no compatible target framework for .NET vs .NET Framework cross reference with -LockedMode - [#12010](https://github.com/NuGet/Home/issues/12010)
+
+* Random error: Failed to resolve SDK &#39;package/version&#39;. Package restore was successful but a package with the ID of &quot;package&quot; was not installed. - [#10935](https://github.com/NuGet/Home/issues/10935)
 
 [List of commits in this release](https://github.com/NuGet/NuGet.Client/compare/7.5.0.55...7.6.0.59)
 
@@ -52,4 +84,3 @@ Thank you to all the contributors who helped make this NuGet release awesome!
   * [7201](https://github.com/NuGet/NuGet.Client/pull/7201) Add --allow-untrusted-root flag to nuget sign and dotnet nuget sign
 * [slang25](https://github.com/NuGet/NuGet.Client/pull/7148)
   * [7148](https://github.com/NuGet/NuGet.Client/pull/7148) Fix `dotnet add package --no-restore` ignoring Central Package Management
-

--- a/docs/release-notes/NuGet-7.6.md
+++ b/docs/release-notes/NuGet-7.6.md
@@ -40,8 +40,6 @@ NuGet distribution vehicles:
 
 * [CPM] dotnet add package with --no-restore causes NU1008 - [#12552](https://github.com/NuGet/Home/issues/12552)
 
-* Treat TargetFramework(s) values as aliases - [#5154](https://github.com/NuGet/Home/issues/5154)
-
 * Error while using Add-Migration in  nuget console in Visual Studio Insiders 18.6 - [#14862](https://github.com/NuGet/Home/issues/14862)
 
 * `&lt;NuGetAuditSuppress&gt;` with packages.config projects doesn&#39;t work for more than one suppression - [#14825](https://github.com/NuGet/Home/issues/14825)

--- a/docs/release-notes/NuGet-7.6.md
+++ b/docs/release-notes/NuGet-7.6.md
@@ -20,6 +20,10 @@ NuGet distribution vehicles:
 
 * Pack with aliased frameworks should allow combining build outputs from the same framework into a single pack - [#14751](https://github.com/NuGet/Home/issues/14751)
 
+* Treat TargetFramework(s) values as aliases - [#5154](https://github.com/NuGet/Home/issues/5154)
+  * This feature enables building for the same framework multiple times, enabling scenarios such as generating runtime specific assemblies for the same target framework, as well as making running benchmarks on different versions of the same package easier.
+  * [Learn more about TargetFramework aliases](/nuget/reference/target-frameworks#targetframework-values-are-aliases)
+
 * [Design spec][OIDC] Enrich telemetry for nuget.exe push to include about where the push is from (Azure DevOps, GitHub Actions, etc) - [#14740](https://github.com/NuGet/Home/issues/14740)
 
 * APIs for package management of file-based apps - [#14390](https://github.com/NuGet/Home/issues/14390)
@@ -56,7 +60,7 @@ NuGet distribution vehicles:
 
 * Ensure seamless experience with aliasing when packing - [#14535](https://github.com/NuGet/Home/issues/14535)
 
-* No vulns shown for vulnerable &amp; deprecated package version when using dotnet list package --vulnerable - [#14477](https://github.com/NuGet/Home/issues/14477)
+* No vulnerabilities shown for vulnerable and deprecated package version when using `dotnet list package --vulnerable` - [#14477](https://github.com/NuGet/Home/issues/14477)
 
 * `dotnet list package` invalid TFM resolution; does not work when TargetFramework property matches real framework. - [#14339](https://github.com/NuGet/Home/issues/14339)
 

--- a/docs/release-notes/NuGet-7.6.md
+++ b/docs/release-notes/NuGet-7.6.md
@@ -22,11 +22,8 @@ NuGet distribution vehicles:
   * This feature enables building for the same framework multiple times, enabling scenarios such as generating runtime specific assemblies for the same target framework, as well as making running benchmarks on different versions of the same package easier.
   * [Learn more about TargetFramework aliases](/nuget/reference/target-frameworks#targetframework-values-are-aliases)
 
-* Pack aliased frameworks into a single package - [#14751](https://github.com/NuGet/Home/issues/14751)
-  * When multiple TargetFramework aliases resolve to the same framework, `dotnet pack` now combines their build outputs into a single package instead of producing errors.
-
-* Push telemetry includes CI environment context - [#14740](https://github.com/NuGet/Home/issues/14740)
-  * `nuget.exe push` now includes telemetry about the CI environment (Azure DevOps, GitHub Actions, and others) to help diagnose push failures.
+* Pack is aliased-framework-aware - [#14751](https://github.com/NuGet/Home/issues/14751)
+  * When a project has multiple TargetFramework aliases that resolve to the same framework, `dotnet pack` now detects the ambiguity and raises NU5051 with an actionable error message instead of producing unexpected output.
 
 * Package management APIs for file-based apps - [#14390](https://github.com/NuGet/Home/issues/14390)
   * NuGet now exposes APIs that `dotnet package add`, `list`, `remove`, and `update` use for file-based apps that reference packages with `#:package` directives in C# source files.
@@ -36,14 +33,8 @@ NuGet distribution vehicles:
 
 ### Issues fixed in this release
 
-* `dotnet list package` now displays the TargetFramework alias instead of the resolved framework - [#14762](https://github.com/NuGet/Home/issues/14762)
-  * Output now shows the alias you authored (for example, `apple`) rather than the resolved framework (for example, `net10.0`), making it easier to identify which target framework each package belongs to.
-
-* Block path separators in TargetFramework aliases - [#14752](https://github.com/NuGet/Home/issues/14752)
-  * NuGet now rejects TargetFramework alias values that contain path separator characters to prevent file system issues during restore and pack.
-
-* `dotnet package add` and `dotnet package update` recognize framework aliases - [#14540](https://github.com/NuGet/Home/issues/14540)
-  * The `add` and `update` commands now treat TargetFramework values as aliases, correctly matching packages to aliased framework entries in the project file.
+* `nuget push` sends CI platform in user-agent header - [#14740](https://github.com/NuGet/Home/issues/14740)
+  * `nuget.exe push` now includes the CI platform (Azure DevOps, GitHub Actions, and others) in the HTTP user-agent header, allowing package sources to identify where pushes originate.
 
 * `dotnet add package --no-restore` with Central Package Management no longer produces NU1008 - [#12552](https://github.com/NuGet/Home/issues/12552)
   * When using Central Package Management, `dotnet add package --no-restore` now correctly adds the `PackageReference` without a `Version` attribute instead of producing a restore error.
@@ -54,26 +45,14 @@ NuGet distribution vehicles:
 * `NuGetAuditSuppress` with packages.config now supports multiple suppressions - [#14825](https://github.com/NuGet/Home/issues/14825)
   * Previously, only the first `NuGetAuditSuppress` entry was honored in packages.config projects. All suppressions are now applied correctly.
 
-* Framework alias disambiguation with AssetTargetFallback - [#14807](https://github.com/NuGet/Home/issues/14807)
-  * `GetReferenceNearestTargetFrameworkTask` now uses framework aliases for disambiguation when `AssetTargetFallback` is enabled, matching the behavior of the restore dependency resolver.
-
-* Fix framework aliasing opt-in for .NET 10.0.3xx SDK - [#14805](https://github.com/NuGet/Home/issues/14805)
-  * A versioning change in the .NET 10.0.3xx SDK broke the framework aliasing opt-in check. The detection logic is now corrected.
-
 * Fix context menu theming on Package Manager UI search box - [#14799](https://github.com/NuGet/Home/issues/14799)
   * The right-click context menu on the search control in the NuGet Package Manager UI now follows the Visual Studio color theme.
-
-* Correct package conditions for aliased frameworks - [#14796](https://github.com/NuGet/Home/issues/14796)
-  * When using aliased frameworks that resolve to the same underlying framework, NuGet now generates the correct MSBuild conditions in the project file so that each alias gets its own package references.
 
 * Fix NuGetProjectServiceV1 for out-of-process consumers - [#14732](https://github.com/NuGet/Home/issues/14732)
   * The `NuGetProjectServiceV1` brokered service now uses the correct serialization settings, making it usable from out-of-process Visual Studio extensions.
 
 * Fix context menu theming on Package Manager UI copy menus - [#14704](https://github.com/NuGet/Home/issues/14704)
   * The right-click copy context menus in the Package Manager UI Package Details tab now follow the Visual Studio color theme.
-
-* Consistent aliasing behavior during pack - [#14535](https://github.com/NuGet/Home/issues/14535)
-  * Packing now correctly handles projects with TargetFramework aliases, producing consistent package output regardless of alias usage.
 
 * `dotnet list package --vulnerable` now shows vulnerabilities for deprecated packages - [#14477](https://github.com/NuGet/Home/issues/14477)
   * Previously, vulnerability information was not displayed for package versions that were both vulnerable and deprecated. Both statuses are now reported.

--- a/docs/release-notes/NuGet-7.6.md
+++ b/docs/release-notes/NuGet-7.6.md
@@ -1,27 +1,55 @@
 ---
 title: NuGet 7.6 Release Notes
 description: Release notes for NuGet 7.6 including new features, bug fixes, and DCRs.
-author: nikolev
+author: jeffkl
+ms.date: 4/28/2026
 ms.topic: release-notes
-ms.date: 03/26/2026
 ---
-# NuGet 7.6 Release Notes
 
-<!--
-    This is intentionally not yet added to TOC.md.
-    When this version is ready for release:
-    1. Rename this file to the next version
-    2. Change the version strings in this file to the next version
-    3. Use the release tool to create the real release notes for the version ready for release
-    4. Add the release notes to TOC.yml
--->
+# NuGet 7.6 Release Notes
 
 NuGet distribution vehicles:
 
 | NuGet version | Available in Visual Studio version | Available in .NET SDK(s) |
 |:---|:---|:---|
-| [**7.6**](https://nuget.org/downloads) | TBD | TBD |
+| [**7.6.0**](https://nuget.org/downloads) | [Visual Studio 2026 version 18.6.0](https://visualstudio.microsoft.com/downloads/) | [10.0.300](https://dotnet.microsoft.com/download/dotnet/10.0)<sup>1</sup> |
 
-## Not yet released
+<sup>1</sup> Installed with Visual Studio 2026 with any .NET workload
 
-This version of NuGet is in preview and these release notes will be updated when it is released.
+## Summary: What's New in 7.6.0
+
+* Get push API key from environment variable - [#12539](https://github.com/NuGet/Home/issues/12539)
+
+### Issues fixed in this release
+
+* Show certificate CRL and OCSP URLs in `dotnet nuget verify` output - [#14780](https://github.com/NuGet/Home/issues/14780)
+
+* Add package and update package treat framework as an alias - [#14540](https://github.com/NuGet/Home/issues/14540)
+
+* Treat TargetFramework(s) values as aliases - [#5154](https://github.com/NuGet/Home/issues/5154)
+
+* Context menu on Search control in PM UI is missing VS color theming - [#14799](https://github.com/NuGet/Home/issues/14799)
+
+* NugetProjectServiceV1 brokered service is not usable from out-of-proc consumers - [#14732](https://github.com/NuGet/Home/issues/14732)
+
+* No vulns shown for vulnerable &amp; deprecated package version when using dotnet list package --vulnerable - [#14477](https://github.com/NuGet/Home/issues/14477)
+
+[List of commits in this release](https://github.com/NuGet/NuGet.Client/compare/7.5.0.55...7.6.0.59)
+
+### Community contributions
+
+Thank you to all the contributors who helped make this NuGet release awesome!
+
+* [nareshjo](https://github.com/NuGet/NuGet.Client/pull/7237)
+  * [7237](https://github.com/NuGet/NuGet.Client/pull/7237) Reduce allocations in LicenseExpressionTokenizer.HasValidCharacters by caching Regex instance
+  * [7174](https://github.com/NuGet/NuGet.Client/pull/7174) Resolve dependency graph items reduce allocation size
+* [jjonescz](https://github.com/NuGet/NuGet.Client/pull/7233)
+  * [7233](https://github.com/NuGet/NuGet.Client/pull/7233) Make virtual project builder parameter required in MSBuildAPIUtility
+  * [7169](https://github.com/NuGet/NuGet.Client/pull/7169) Add support for file-based apps to the XPlat CLI
+* [SimonCropp](https://github.com/NuGet/NuGet.Client/pull/7224)
+  * [7224](https://github.com/NuGet/NuGet.Client/pull/7224) Use Ordinal string comparison for TargetAlias
+* [elantiguamsft](https://github.com/NuGet/NuGet.Client/pull/7201)
+  * [7201](https://github.com/NuGet/NuGet.Client/pull/7201) Add --allow-untrusted-root flag to nuget sign and dotnet nuget sign
+* [slang25](https://github.com/NuGet/NuGet.Client/pull/7148)
+  * [7148](https://github.com/NuGet/NuGet.Client/pull/7148) Fix `dotnet add package --no-restore` ignoring Central Package Management
+

--- a/docs/release-notes/NuGet-7.6.md
+++ b/docs/release-notes/NuGet-7.6.md
@@ -18,55 +18,77 @@ NuGet distribution vehicles:
 
 ## Summary: What's New in 7.6.0
 
-* Pack with aliased frameworks should allow combining build outputs from the same framework into a single pack - [#14751](https://github.com/NuGet/Home/issues/14751)
-
 * Treat TargetFramework(s) values as aliases - [#5154](https://github.com/NuGet/Home/issues/5154)
   * This feature enables building for the same framework multiple times, enabling scenarios such as generating runtime specific assemblies for the same target framework, as well as making running benchmarks on different versions of the same package easier.
   * [Learn more about TargetFramework aliases](/nuget/reference/target-frameworks#targetframework-values-are-aliases)
 
-* [Design spec][OIDC] Enrich telemetry for nuget.exe push to include about where the push is from (Azure DevOps, GitHub Actions, etc) - [#14740](https://github.com/NuGet/Home/issues/14740)
+* Pack aliased frameworks into a single package - [#14751](https://github.com/NuGet/Home/issues/14751)
+  * When multiple TargetFramework aliases resolve to the same framework, `dotnet pack` now combines their build outputs into a single package instead of producing errors.
 
-* APIs for package management of file-based apps - [#14390](https://github.com/NuGet/Home/issues/14390)
+* Push telemetry includes CI environment context - [#14740](https://github.com/NuGet/Home/issues/14740)
+  * `nuget.exe push` now includes telemetry about the CI environment (Azure DevOps, GitHub Actions, and others) to help diagnose push failures.
 
-* Get push API key from environment variable - [#12539](https://github.com/NuGet/Home/issues/12539)
+* Package management APIs for file-based apps - [#14390](https://github.com/NuGet/Home/issues/14390)
+  * NuGet now exposes APIs that `dotnet package add`, `list`, `remove`, and `update` use for file-based apps that reference packages with `#:package` directives in C# source files.
+
+* Read push API key from environment variable - [#12539](https://github.com/NuGet/Home/issues/12539)
+  * `dotnet nuget push` can now read the API key from an environment variable, avoiding the need to pass secrets on the command line or store them in configuration files.
 
 ### Issues fixed in this release
 
-* List package should use TargetFramework property as a key it its output instead of the effective TargetFramework; Introduce a V2 version of the list package output - [#14762](https://github.com/NuGet/Home/issues/14762)
+* `dotnet list package` now displays the TargetFramework alias instead of the resolved framework - [#14762](https://github.com/NuGet/Home/issues/14762)
+  * Output now shows the alias you authored (for example, `apple`) rather than the resolved framework (for example, `net10.0`), making it easier to identify which target framework each package belongs to.
 
-* Block aliases with path separator - [#14752](https://github.com/NuGet/Home/issues/14752)
+* Block path separators in TargetFramework aliases - [#14752](https://github.com/NuGet/Home/issues/14752)
+  * NuGet now rejects TargetFramework alias values that contain path separator characters to prevent file system issues during restore and pack.
 
-* Add package and update package treat framework as an alias - [#14540](https://github.com/NuGet/Home/issues/14540)
+* `dotnet package add` and `dotnet package update` recognize framework aliases - [#14540](https://github.com/NuGet/Home/issues/14540)
+  * The `add` and `update` commands now treat TargetFramework values as aliases, correctly matching packages to aliased framework entries in the project file.
 
-* [CPM] dotnet add package with --no-restore causes NU1008 - [#12552](https://github.com/NuGet/Home/issues/12552)
+* `dotnet add package --no-restore` with Central Package Management no longer produces NU1008 - [#12552](https://github.com/NuGet/Home/issues/12552)
+  * When using Central Package Management, `dotnet add package --no-restore` now correctly adds the `PackageReference` without a `Version` attribute instead of producing a restore error.
 
-* Error while using Add-Migration in  nuget console in Visual Studio Insiders 18.6 - [#14862](https://github.com/NuGet/Home/issues/14862)
+* Fix `Add-Migration` error in Package Manager Console - [#14862](https://github.com/NuGet/Home/issues/14862)
+  * Running `Add-Migration` in the NuGet Package Manager Console no longer throws a "GetProjectFromHierarchy must be called on the UI thread" error.
 
-* `&lt;NuGetAuditSuppress&gt;` with packages.config projects doesn&#39;t work for more than one suppression - [#14825](https://github.com/NuGet/Home/issues/14825)
+* `NuGetAuditSuppress` with packages.config now supports multiple suppressions - [#14825](https://github.com/NuGet/Home/issues/14825)
+  * Previously, only the first `NuGetAuditSuppress` entry was honored in packages.config projects. All suppressions are now applied correctly.
 
-* GetReferenceFrameworkNearestTask does not use aliases for disambiguation when using AssetTargetFallback - [#14807](https://github.com/NuGet/Home/issues/14807)
+* Framework alias disambiguation with AssetTargetFallback - [#14807](https://github.com/NuGet/Home/issues/14807)
+  * `GetReferenceNearestTargetFrameworkTask` now uses framework aliases for disambiguation when `AssetTargetFallback` is enabled, matching the behavior of the restore dependency resolver.
 
-* Aliasing opt-in is broken due to a versioning change in .NET 10.0.3xx - [#14805](https://github.com/NuGet/Home/issues/14805)
+* Fix framework aliasing opt-in for .NET 10.0.3xx SDK - [#14805](https://github.com/NuGet/Home/issues/14805)
+  * A versioning change in the .NET 10.0.3xx SDK broke the framework aliasing opt-in check. The detection logic is now corrected.
 
-* Context menu on Search control in PM UI is missing VS color theming - [#14799](https://github.com/NuGet/Home/issues/14799)
+* Fix context menu theming on Package Manager UI search box - [#14799](https://github.com/NuGet/Home/issues/14799)
+  * The right-click context menu on the search control in the NuGet Package Manager UI now follows the Visual Studio color theme.
 
-* When using aliased frameworks, package conditions are not generated correctly - [#14796](https://github.com/NuGet/Home/issues/14796)
+* Correct package conditions for aliased frameworks - [#14796](https://github.com/NuGet/Home/issues/14796)
+  * When using aliased frameworks that resolve to the same underlying framework, NuGet now generates the correct MSBuild conditions in the project file so that each alias gets its own package references.
 
-* NugetProjectServiceV1 brokered service is not usable from out-of-proc consumers - [#14732](https://github.com/NuGet/Home/issues/14732)
+* Fix NuGetProjectServiceV1 for out-of-process consumers - [#14732](https://github.com/NuGet/Home/issues/14732)
+  * The `NuGetProjectServiceV1` brokered service now uses the correct serialization settings, making it usable from out-of-process Visual Studio extensions.
 
-* Context menus to Copy text from PM UI are missing VS color theming - [#14704](https://github.com/NuGet/Home/issues/14704)
+* Fix context menu theming on Package Manager UI copy menus - [#14704](https://github.com/NuGet/Home/issues/14704)
+  * The right-click copy context menus in the Package Manager UI Package Details tab now follow the Visual Studio color theme.
 
-* Ensure seamless experience with aliasing when packing - [#14535](https://github.com/NuGet/Home/issues/14535)
+* Consistent aliasing behavior during pack - [#14535](https://github.com/NuGet/Home/issues/14535)
+  * Packing now correctly handles projects with TargetFramework aliases, producing consistent package output regardless of alias usage.
 
-* No vulnerabilities shown for vulnerable and deprecated package version when using `dotnet list package --vulnerable` - [#14477](https://github.com/NuGet/Home/issues/14477)
+* `dotnet list package --vulnerable` now shows vulnerabilities for deprecated packages - [#14477](https://github.com/NuGet/Home/issues/14477)
+  * Previously, vulnerability information was not displayed for package versions that were both vulnerable and deprecated. Both statuses are now reported.
 
-* `dotnet list package` invalid TFM resolution; does not work when TargetFramework property matches real framework. - [#14339](https://github.com/NuGet/Home/issues/14339)
+* `dotnet list package` resolves conditional TargetFramework values correctly - [#14339](https://github.com/NuGet/Home/issues/14339)
+  * `dotnet list package` no longer fails when a project uses a TargetFramework property value that matches a real framework moniker, such as `net9.0-windows` with conditional `PackageReference` elements.
 
-* NU1107 message provides poor guidance when CPVM + transitive pinning is enabled - [#12277](https://github.com/NuGet/Home/issues/12277)
+* Improved NU1107 error message with Central Package Management and transitive pinning - [#12277](https://github.com/NuGet/Home/issues/12277)
+  * The NU1107 version conflict error now provides relevant guidance when Central Package Management with transitive pinning is enabled, instead of suggesting actions that don't apply in that configuration.
 
-* [Bug]: NU1004: The project Xxx has no compatible target framework for .NET vs .NET Framework cross reference with -LockedMode - [#12010](https://github.com/NuGet/Home/issues/12010)
+* Fix NU1004 for cross-framework references with locked mode - [#12010](https://github.com/NuGet/Home/issues/12010)
+  * Restoring with `--locked-mode` no longer produces a false NU1004 error when a .NET project references a .NET Framework project.
 
-* Random error: Failed to resolve SDK &#39;package/version&#39;. Package restore was successful but a package with the ID of &quot;package&quot; was not installed. - [#10935](https://github.com/NuGet/Home/issues/10935)
+* Fix intermittent "Failed to resolve SDK" error during parallel restores - [#10935](https://github.com/NuGet/Home/issues/10935)
+  * Parallel `dotnet` restore processes no longer intermittently fail with "Failed to resolve SDK" when the package is already installed in the global packages folder.
 
 [List of commits in this release](https://github.com/NuGet/NuGet.Client/compare/7.5.0.55...7.6.0.59)
 


### PR DESCRIPTION
Release notes for NuGet 7.6 / VS 18.6 / .NET SDK 10.0.300.

- Added NuGet-7.6.md with features, bug fixes, and community contributions
- Updated Index.md and TOC.md

Tracking issue: https://github.com/NuGet/Client.Engineering/issues/3711