### PR TITLE
Add Package name limits section to publish-a-package

### DIFF
--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -87,7 +87,7 @@ To submit a signed package, you must first [register the certificate](../create-
 Packages published to nuget.org must adhere to the following package naming rules:
 
 - Must start with a letter (A-Z, a-z), number, or underscore.
-- Can only contain letters, numbers, dots (`.`), or dashes (`-`).
+- Can only contain letters A-Z or a-z, numbers, dots (`.`), or dashes (`-`).
 - Cannot contain consecutive `.` (dot) or `-` (dash) characters.
 - Must be 100 characters or less.
 

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -82,6 +82,15 @@ You can push packages to nuget.org with Azure Pipelines as part of your continuo
 
 To submit a signed package, you must first [register the certificate](../create-packages/Sign-a-Package.md#register-the-certificate-on-nugetorg) you used to sign the package. If you don't meet the [signed package requirements](../reference/Signed-Packages-Reference.md#signature-requirements-on-nugetorg), nuget.org rejects the package.
 
+### Package name limits
+
+NuGet derives URLs and file system paths from a normalized form of the package ID, and inconsistencies in normalization can cause two visibly different IDs to collide. To protect your package brand and the integrity of the ecosystem, nuget.org enforces the following package naming rules:
+
+- Must start with a letter or underscore.
+- Can only contain the characters A-Z, a-z, 0-9, `.` (dot), `-` (dash), or `_` (underscore).
+- Cannot contain consecutive `.` (dot), `-` (dash), or `_` (underscore) characters.
+- Must be 120 characters or less.
+
 ### Package size limits
 
 Nuget.org has a package size limit of about 250 MB. When a package exceeding that limit is uploaded the following error is displayed:

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -92,7 +92,7 @@ Packages published to nuget.org must adhere to the following package naming rule
 - Must be 128 characters or less.
 
 > [!NOTE]
-> We recommend starting your package name with a letter.
+> For readability and clarity, we recommend starting your package name with a letter.
 
 ### Package size limits
 

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -91,6 +91,9 @@ Packages published to nuget.org must adhere to the following package naming rule
 - Cannot contain consecutive `.` (dot) or `-` (dash) characters.
 - Must be 128 characters or less.
 
+> [!NOTE]
+> We recommend starting your package name with a letter.
+
 ### Package size limits
 
 Nuget.org has a package size limit of about 250 MB. When a package exceeding that limit is uploaded the following error is displayed:

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -86,7 +86,7 @@ To submit a signed package, you must first [register the certificate](../create-
 
 Packages published to nuget.org must adhere to the following package naming rules:
 
-- Must start with a letter, number, or underscore.
+- Must start with a letter (A-Z, a-z), number, or underscore.
 - Can only contain letters, numbers, dots (`.`), or dashes (`-`).
 - Cannot contain consecutive `.` (dot) or `-` (dash) characters.
 - Must be 100 characters or less.

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -89,7 +89,7 @@ Packages published to nuget.org must adhere to the following package naming rule
 - Must start with a letter or number.
 - Can only contain letters, numbers, dots (`.`), or dashes (`-`).
 - Cannot contain consecutive `.` (dot) or `-` (dash) characters.
-- Must be 128 characters or less.
+- Must be 100 characters or less.
 
 > [!NOTE]
 > For readability and clarity, we recommend starting your package name with a letter.

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -84,7 +84,7 @@ To submit a signed package, you must first [register the certificate](../create-
 
 ### Package name limits
 
-NuGet derives URLs and file system paths from a normalized form of the package ID, and inconsistencies in normalization can cause two visibly different IDs to collide. To protect your package brand and the integrity of the ecosystem, nuget.org enforces the following package naming rules:
+Packages published to nuget.org must adhere to the following package naming rules:
 
 - Must start with a letter or underscore.
 - Can only contain the characters A-Z, a-z, 0-9, `.` (dot), `-` (dash), or `_` (underscore).

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -86,10 +86,10 @@ To submit a signed package, you must first [register the certificate](../create-
 
 Packages published to nuget.org must adhere to the following package naming rules:
 
-- Must start with a letter or underscore.
-- Can only contain the characters A-Z, a-z, 0-9, `.` (dot), `-` (dash), or `_` (underscore).
-- Cannot contain consecutive `.` (dot), `-` (dash), or `_` (underscore) characters.
-- Must be 120 characters or less.
+- Must start with a letter or number.
+- Can only contain letters, numbers, dots (`.`), or dashes (`-`).
+- Cannot contain consecutive `.` (dot) or `-` (dash) characters.
+- Must be 128 characters or less.
 
 ### Package size limits
 

--- a/docs/nuget-org/Publish-a-package.md
+++ b/docs/nuget-org/Publish-a-package.md
@@ -86,7 +86,7 @@ To submit a signed package, you must first [register the certificate](../create-
 
 Packages published to nuget.org must adhere to the following package naming rules:
 
-- Must start with a letter or number.
+- Must start with a letter, number, or underscore.
 - Can only contain letters, numbers, dots (`.`), or dashes (`-`).
 - Cannot contain consecutive `.` (dot) or `-` (dash) characters.
 - Must be 100 characters or less.

--- a/docs/reference/errors-and-warnings/NU1017.md
+++ b/docs/reference/errors-and-warnings/NU1017.md
@@ -49,3 +49,6 @@ Invalid:
 ```xml
 <PackageReference Include="contoso../id" Version="1.0.0" />
 ```
+
+> [!NOTE]
+> Packages published to nuget.org must also satisfy stricter [nuget.org package naming rules](../../nuget-org/Publish-a-package.md#package-name-limits), including a 120 character limit and the requirement to start with a letter or underscore.

--- a/docs/reference/errors-and-warnings/NU1017.md
+++ b/docs/reference/errors-and-warnings/NU1017.md
@@ -49,6 +49,3 @@ Invalid:
 ```xml
 <PackageReference Include="contoso../id" Version="1.0.0" />
 ```
-
-> [!NOTE]
-> Packages published to nuget.org must also satisfy stricter [nuget.org package naming rules](../../nuget-org/Publish-a-package.md#package-name-limits), including a 120 character limit and the requirement to start with a letter or underscore.

--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -80,7 +80,7 @@ These elements must appear within a `<metadata>` element.
 #### id 
 The case-insensitive package identifier, which must be unique across nuget.org or whatever gallery the package resides in. IDs may not contain spaces or characters that are not valid for a URL, and generally follow .NET namespace rules. See [Choosing a unique package identifier](../create-packages/Creating-a-Package.md#choose-a-unique-package-identifier-and-set-the-version-number) for guidance.
 
-When uploading a package to nuget.org, the `id` field is limited to 128 characters.
+When uploading a package to nuget.org, the `id` field is limited to 120 characters and must follow the [nuget.org package naming rules](../nuget-org/Publish-a-package.md#package-name-limits).
 
 #### version
 The version of the package, following the *major.minor.patch* pattern. Version numbers may include a pre-release suffix as described in [Package versioning](../concepts/Package-Versioning.md#pre-release-versions). 

--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -80,7 +80,7 @@ These elements must appear within a `<metadata>` element.
 #### id 
 The case-insensitive package identifier, which must be unique across nuget.org or whatever gallery the package resides in. IDs may not contain spaces or characters that are not valid for a URL, and generally follow .NET namespace rules. See [Choosing a unique package identifier](../create-packages/Creating-a-Package.md#choose-a-unique-package-identifier-and-set-the-version-number) for guidance.
 
-When uploading a package to nuget.org, the `id` field is limited to 120 characters and must follow the [nuget.org package naming rules](../nuget-org/Publish-a-package.md#package-name-limits).
+When uploading a package to nuget.org, the `id` field is limited to 128 characters.
 
 #### version
 The version of the package, following the *major.minor.patch* pattern. Version numbers may include a pre-release suffix as described in [Package versioning](../concepts/Package-Versioning.md#pre-release-versions). 

--- a/docs/reference/nuspec.md
+++ b/docs/reference/nuspec.md
@@ -80,7 +80,7 @@ These elements must appear within a `<metadata>` element.
 #### id 
 The case-insensitive package identifier, which must be unique across nuget.org or whatever gallery the package resides in. IDs may not contain spaces or characters that are not valid for a URL, and generally follow .NET namespace rules. See [Choosing a unique package identifier](../create-packages/Creating-a-Package.md#choose-a-unique-package-identifier-and-set-the-version-number) for guidance.
 
-When uploading a package to nuget.org, the `id` field is limited to 128 characters.
+When uploading a package to nuget.org, the `id` field is limited to 100 characters.
 
 #### version
 The version of the package, following the *major.minor.patch* pattern. Version numbers may include a pre-release suffix as described in [Package versioning](../concepts/Package-Versioning.md#pre-release-versions). 


### PR DESCRIPTION
Adds a new **Package name limits** section above **Package size limits** in `docs/nuget-org/Publish-a-package.md`.

The section briefly sets context and lists the four naming rules enforced by nuget.org:
