### PR TITLE
Fixing typo in the configuration example

### DIFF
--- a/docs/consume-packages/configuring-nuget-behavior.md
+++ b/docs/consume-packages/configuring-nuget-behavior.md
@@ -70,7 +70,7 @@ dotnet nuget config set repositoryPath "C:\packages" --configfile "C:\my.config"
 dotnet nuget config set repositoryPath "c:\packages" --configfile "..\..\my.config"
 
 # Set repositoryPath in the computer-level file (requires elevation)
-dotnet nuget config set repositoryPath "c:\packages" --configfile "%appdata%\NuGet\NuGet.Config"
+dotnet nuget config set repositoryPath "c:\packages" --configfile "%ProgramFiles(x86)%\NuGet\Config\NuGet.config"
 ```
 
 Mac/Linux:


### PR DESCRIPTION
* The system-wide NuGet.config should be in %ProgramFiles(x86)% as per the documentation
  - Also, %appdata% would not require any elevation

-----

Correct me, if I am wrong, but looking at the corresponding mac/Linux example the intent here is to use the global (not user-writable) `.config`.