### PR TITLE
Add NuGet 7.7 release notes

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -362,6 +362,7 @@
 ## Release notes
 ### [Known Issues](release-notes/Known-Issues.md)
 ### NuGet 7.x
+#### [NuGet 7.7](release-notes/NuGet-7.7.md)
 #### [NuGet 7.6](release-notes/NuGet-7.6.md)
 #### [NuGet 7.5](release-notes/NuGet-7.5.md)
 #### [NuGet 7.4](release-notes/NuGet-7.4.md)

--- a/docs/release-notes/Index.md
+++ b/docs/release-notes/Index.md
@@ -11,6 +11,8 @@ ms.topic: release-notes
 
 [Known Issues](../release-notes/Known-Issues.md)
 
+[NuGet 7.7](../release-notes/NuGet-7.7.md)
+
 [NuGet 7.6](../release-notes/NuGet-7.6.md)
 
 [NuGet 7.5](../release-notes/NuGet-7.5.md)

--- a/docs/release-notes/NuGet-7.7.md
+++ b/docs/release-notes/NuGet-7.7.md
@@ -30,7 +30,7 @@ NuGet distribution vehicles:
 
 * SourceRepositoryDependencyProvider.GetInstalledVersions returns null when packages may be available. - [#14837](https://github.com/NuGet/Home/issues/14837)
 
-* [Bug Bash][Unstable] The ‘Installed’ tab was not refreshed after fixing the NuGet package vulnerabilities with GitHub Copilot - [#14761](https://github.com/NuGet/Home/issues/14761)
+* [Bug Bash] [Unstable] The ‘Installed’ tab was not refreshed after fixing the NuGet package vulnerabilities with GitHub Copilot - [#14761](https://github.com/NuGet/Home/issues/14761)
 
 [List of commits in this release](https://github.com/NuGet/NuGet.Client/compare/7.6.0.59...7.7.0.44)
 

--- a/docs/release-notes/NuGet-7.7.md
+++ b/docs/release-notes/NuGet-7.7.md
@@ -1,0 +1,46 @@
+---
+title: NuGet 7.7 Release Notes
+description: Release notes for NuGet 7.7 including new features, bug fixes, and DCRs.
+author: kartheekp-ms
+ms.date: 06/04/2026
+ms.topic: release-notes
+---
+
+# NuGet 7.7 Release Notes
+
+NuGet distribution vehicles:
+
+| NuGet version | Available in Visual Studio version | Available in .NET SDK(s) |
+|:---|:---|:---|
+| [**7.7.0**](https://nuget.org/downloads) | [Visual Studio 2026 version 18.7.0](https://visualstudio.microsoft.com/downloads/) | N/A |
+
+> [!NOTE]
+> Visual Studio-only release.
+> NuGet SDK packages are published quarterly with .NET.
+
+## Summary: What's New in 7.7.0
+
+* Add option to not write out dependency graph spec - [#14114](https://github.com/NuGet/Home/issues/14114)
+
+### Issues fixed in this release
+
+* Pin System.Security.Crypography.Xml to 8.0.3 - [#14865](https://github.com/NuGet/Home/issues/14865)
+
+* nuget.exe restore `-MSBuildPath` crashes when pointing it to .NET SDK directory - [#14844](https://github.com/NuGet/Home/issues/14844)
+
+* Test TSTInfo structure generation is not DER-compliant. - [#14838](https://github.com/NuGet/Home/issues/14838)
+
+* SourceRepositoryDependencyProvider.GetInstalledVersions returns null when packages may be available. - [#14837](https://github.com/NuGet/Home/issues/14837)
+
+* [Bug Bash][Unstable] The ‘Installed’ tab was not refreshed after fixing the NuGet package vulnerabilities with GitHub Copilot - [#14761](https://github.com/NuGet/Home/issues/14761)
+
+[List of commits in this release](https://github.com/NuGet/NuGet.Client/compare/7.6.0.59...7.7.0.44)
+
+### Community contributions
+
+Thank you to all the contributors who helped make this NuGet release awesome!
+
+* [jjonescz](https://github.com/NuGet/NuGet.Client/pull/7316)
+  * [7316](https://github.com/NuGet/NuGet.Client/pull/7316) Switch file-based app integration tests to use dotnet.exe only
+* [nareshjo](https://github.com/NuGet/NuGet.Client/pull/7266)
+  * [7266](https://github.com/NuGet/NuGet.Client/pull/7266) Cache NUGET_DISABLE_PACKAGEID_VALIDATION env var read in PackageIdValidator.Validate to eliminate per-call allocations

--- a/docs/release-notes/NuGet-7.7.md
+++ b/docs/release-notes/NuGet-7.7.md
@@ -28,7 +28,7 @@ NuGet distribution vehicles:
 
 * Test TSTInfo structure generation is not DER-compliant - [#14838](https://github.com/NuGet/Home/issues/14838)
 
-* SourceRepositoryDependencyProvider.GetInstalledVersions returns null when packages may be available. - [#14837](https://github.com/NuGet/Home/issues/14837)
+* SourceRepositoryDependencyProvider.GetInstalledVersions returns null when packages may be available - [#14837](https://github.com/NuGet/Home/issues/14837)
 
 * [Bug Bash] [Unstable] The ‘Installed’ tab was not refreshed after fixing the NuGet package vulnerabilities with GitHub Copilot - [#14761](https://github.com/NuGet/Home/issues/14761)
 

--- a/docs/release-notes/NuGet-7.7.md
+++ b/docs/release-notes/NuGet-7.7.md
@@ -26,8 +26,6 @@ NuGet distribution vehicles:
 
 * Pin System.Security.Crypography.Xml to 8.0.3 - [#14865](https://github.com/NuGet/Home/issues/14865)
 
-* nuget.exe restore `-MSBuildPath` crashes when pointing it to .NET SDK directory - [#14844](https://github.com/NuGet/Home/issues/14844)
-
 * Test TSTInfo structure generation is not DER-compliant. - [#14838](https://github.com/NuGet/Home/issues/14838)
 
 * SourceRepositoryDependencyProvider.GetInstalledVersions returns null when packages may be available. - [#14837](https://github.com/NuGet/Home/issues/14837)

--- a/docs/release-notes/NuGet-7.7.md
+++ b/docs/release-notes/NuGet-7.7.md
@@ -24,7 +24,7 @@ NuGet distribution vehicles:
 
 ### Issues fixed in this release
 
-* Pin System.Security.Crypography.Xml to 8.0.3 - [#14865](https://github.com/NuGet/Home/issues/14865)
+* Pin System.Security.Cryptography.Xml to 8.0.3 - [#14865](https://github.com/NuGet/Home/issues/14865)
 
 * Test TSTInfo structure generation is not DER-compliant. - [#14838](https://github.com/NuGet/Home/issues/14838)
 

--- a/docs/release-notes/NuGet-7.7.md
+++ b/docs/release-notes/NuGet-7.7.md
@@ -26,7 +26,7 @@ NuGet distribution vehicles:
 
 * Pin System.Security.Cryptography.Xml to 8.0.3 - [#14865](https://github.com/NuGet/Home/issues/14865)
 
-* Test TSTInfo structure generation is not DER-compliant. - [#14838](https://github.com/NuGet/Home/issues/14838)
+* Test TSTInfo structure generation is not DER-compliant - [#14838](https://github.com/NuGet/Home/issues/14838)
 
 * SourceRepositoryDependencyProvider.GetInstalledVersions returns null when packages may be available. - [#14837](https://github.com/NuGet/Home/issues/14837)
 


### PR DESCRIPTION
Adds NuGet 7.7 release notes and updates the release notes index and TOC.

Notes:
- NuGet/Home#14601 was deferred because it is CLI-only and this is a Visual Studio-only release.
- NuGet/Home#12010 remains on the 7.6 milestone per release note review.