### PR TITLE
Add NU1512 warning documentation

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -198,6 +198,7 @@
 ### [NU1509](reference/errors-and-warnings/NU1509.md)
 ### [NU1510](reference/errors-and-warnings/NU1510.md)
 ### [NU1511](reference/errors-and-warnings/NU1511.md)
+### [NU1512](reference/errors-and-warnings/NU1512.md)
 ### [NU1601](reference/errors-and-warnings/NU1601.md)
 ### [NU1602](reference/errors-and-warnings/NU1602.md)
 ### [NU1603](reference/errors-and-warnings/NU1603.md)

--- a/docs/reference/Errors-and-Warnings.md
+++ b/docs/reference/Errors-and-Warnings.md
@@ -43,7 +43,7 @@ NuGet supports the following configuration properties.
 
 | Group | Warning numbers |
 | --- | --- |
-| Invalid input warnings | [NU1501](./errors-and-warnings/NU1501.md), [NU1502](./errors-and-warnings/NU1502.md), [NU1503](./errors-and-warnings/NU1503.md), [NU1504](./errors-and-warnings/NU1504.md), [NU1505](./errors-and-warnings/NU1505.md), [NU1506](./errors-and-warnings/NU1506.md), [NU1507](./errors-and-warnings/NU1507.md), [NU1508](./errors-and-warnings/NU1508.md), [NU1509](./errors-and-warnings/NU1509.md), [NU1510](./errors-and-warnings/NU1510.md), [NU1511](./errors-and-warnings/NU1511.md) |
+| Invalid input warnings | [NU1501](./errors-and-warnings/NU1501.md), [NU1502](./errors-and-warnings/NU1502.md), [NU1503](./errors-and-warnings/NU1503.md), [NU1504](./errors-and-warnings/NU1504.md), [NU1505](./errors-and-warnings/NU1505.md), [NU1506](./errors-and-warnings/NU1506.md), [NU1507](./errors-and-warnings/NU1507.md), [NU1508](./errors-and-warnings/NU1508.md), [NU1509](./errors-and-warnings/NU1509.md), [NU1510](./errors-and-warnings/NU1510.md), [NU1511](./errors-and-warnings/NU1511.md), [NU1512](./errors-and-warnings/NU1512.md) |
 | Unexpected package version warnings | [NU1601](./errors-and-warnings/NU1601.md), [NU1602](./errors-and-warnings/NU1602.md), [NU1603](./errors-and-warnings/NU1603.md), [NU1604](./errors-and-warnings/NU1604.md), [NU1605](./errors-and-warnings/NU1605.md), [NU1606](./errors-and-warnings/NU1108.md), [NU1607](./errors-and-warnings/NU1107.md) |
 | Resolver conflict warnings | [NU1608](./errors-and-warnings/NU1608.md) |
 | Package fallback warnings | [NU1701](./errors-and-warnings/NU1701.md), [NU1702](./errors-and-warnings/NU1702.md), [NU1703](./errors-and-warnings/NU1703.md) |

--- a/docs/reference/errors-and-warnings/NU1512.md
+++ b/docs/reference/errors-and-warnings/NU1512.md
@@ -1,0 +1,42 @@
+---
+title: NuGet Warning NU1512
+description: NU1512 warning code
+author: martinrrm
+ms.author: mruizmares
+ms.date: 06/15/2026
+ms.topic: reference
+f1_keywords: 
+  - "NU1512"
+---
+
+# NuGet Warning NU1512
+
+> RestoreForceEvaluate overrides RestoreLockedMode; the packages lock file will be re-evaluated and regenerated, and locked mode is ignored.
+
+## Issue
+
+Both [`RestoreLockedMode`](../../consume-packages/Package-References-in-Project-Files.md#lock-file-extensibility) and [`RestoreForceEvaluate`](../../consume-packages/Package-References-in-Project-Files.md#lock-file-extensibility) are enabled for the restore, but these options are contradictory:
+
+- `RestoreLockedMode` requires the `packages.lock.json` file to remain unchanged, and fails the restore if the resolved package dependencies differ from the lock file.
+- `RestoreForceEvaluate` forces NuGet to re-evaluate the package dependencies and regenerate the lock file on every restore.
+
+When both are set, `RestoreForceEvaluate` takes precedence: the lock file is re-evaluated and regenerated, and the requested locked mode is ignored. This warning is raised so that the ignored locked mode is not silent.
+
+## Solution
+
+Enable only one of these properties, based on your intent:
+
+- To guarantee repeatable restores (for example, in CI/CD scenarios), keep `RestoreLockedMode` enabled and stop setting `RestoreForceEvaluate`. For example, remove the `--force-evaluate` option (or `-p:RestoreForceEvaluate=true`) from your restore command:
+
+  ```dotnetcli
+  dotnet restore --locked-mode
+  ```
+
+- To intentionally re-evaluate floating versions and regenerate the lock file, keep `RestoreForceEvaluate` enabled and stop setting `RestoreLockedMode`:
+
+  ```dotnetcli
+  dotnet restore --force-evaluate
+  ```
+
+> [!NOTE]
+> This warning is raised by default starting with the .NET 11 SDK (`SdkAnalysisLevel` value `11.0.100` or higher). You can change the [`SdkAnalysisLevel`](/dotnet/core/project-sdk/msbuild-props#sdkanalysislevel) property to control this behavior.

--- a/docs/reference/errors-and-warnings/NU1512.md
+++ b/docs/reference/errors-and-warnings/NU1512.md
@@ -26,7 +26,8 @@ When both are set, `RestoreForceEvaluate` takes precedence: the lock file is re-
 
 Enable only one of these properties, based on your intent:
 
-- To guarantee repeatable restores (for example, in CI/CD scenarios), keep `RestoreLockedMode` enabled and stop setting `RestoreForceEvaluate`. For example, remove the `--force-evaluate` option (or `-p:RestoreForceEvaluate=true`) from your restore command:
+- To guarantee repeatable restores (for example, in CI/CD scenarios), keep `RestoreLockedMode` enabled and stop setting `RestoreForceEvaluate`.
+  For example, remove the `--force-evaluate` option (or `-p:RestoreForceEvaluate=true`) from your restore command:
 
   ```dotnetcli
   dotnet restore --locked-mode

--- a/docs/reference/errors-and-warnings/NU1512.md
+++ b/docs/reference/errors-and-warnings/NU1512.md
@@ -20,7 +20,8 @@ Both [`RestoreLockedMode`](../../consume-packages/Package-References-in-Project-
 - `RestoreLockedMode` requires the `packages.lock.json` file to remain unchanged, and fails the restore if the resolved package dependencies differ from the lock file.
 - `RestoreForceEvaluate` forces NuGet to re-evaluate the package dependencies and regenerate the lock file on every restore.
 
-When both are set, `RestoreForceEvaluate` takes precedence: the lock file is re-evaluated and regenerated, and the requested locked mode is ignored. This warning is raised so that the ignored locked mode is not silent.
+When both are set, `RestoreForceEvaluate` takes precedence: the lock file is re-evaluated and regenerated, and the requested locked mode is ignored.
+This warning is raised so that the ignored locked mode is not silent.
 
 ## Solution
 

--- a/docs/reference/errors-and-warnings/NU1512.md
+++ b/docs/reference/errors-and-warnings/NU1512.md
@@ -39,4 +39,5 @@ Enable only one of these properties, based on your intent:
   ```
 
 > [!NOTE]
-> This warning is raised by default starting with the .NET 11 SDK (`SdkAnalysisLevel` value `11.0.100` or higher). You can change the [`SdkAnalysisLevel`](/dotnet/core/project-sdk/msbuild-props#sdkanalysislevel) property to control this behavior.
+> This warning is raised by default starting with the .NET 11 SDK (`SdkAnalysisLevel` value `11.0.100` or higher).
+> You can change the [`SdkAnalysisLevel`](/dotnet/core/project-sdk/msbuild-props#sdkanalysislevel) property to control this behavior.


### PR DESCRIPTION
Document the NU1512 restore warning, raised when RestoreLockedMode and RestoreForceEvaluate are both set during restore. RestoreForceEvaluate takes precedence and locked mode is ignored. Add the new reference page and link it from the TOC and the errors-and-warnings index.