### PR TITLE
Remove blog callout in package readme doc

### DIFF
--- a/docs/nuget-org/package-readme-on-nuget-org.md
+++ b/docs/nuget-org/package-readme-on-nuget-org.md
@@ -62,9 +62,6 @@ Where and how users can leave feedback?
 
 Keep in mind, high quality readmes can come in a wide variety of formats, shapes, and sizes! If you already have a package available on NuGet.org, chances are that you already have a `readme.md` or other documentation file in your repository that would be a great addition to your NuGet.org details page.
 
-> [!Note]
-> Read through our [blog on writing a high-quality README](https://devblogs.microsoft.com/nuget/write-a-high-quality-readme-for-nuget-packages/) for some best practices.
-
 ## Preview your readme
 
 To preview your readme file before it's live on NuGet.org, upload your package using the [Upload Package web portal on NuGet.org](/nuget/nuget-org/publish-a-package#web-portal-use-the-upload-package-tab-on-nugetorg) and scroll down to the "Readme File" section of the metadata preview. It should look something like this:


### PR DESCRIPTION
Removed the callout to blog post titled 'Write a high-quality README for NuGet packages' from doc titled 'Package readme on NuGet.org' as per best practice recommendation in https://github.com/NuGet/NuGetGallery/issues/10622.