### PR TITLE
Fix links to `IsPackable` property from "Create a NuGet package [...]"

### DIFF
--- a/docs/create-packages/creating-a-package-dotnet-cli.md
+++ b/docs/create-packages/creating-a-package-dotnet-cli.md
@@ -99,7 +99,7 @@ To automatically run `dotnet pack` whenever you run `dotnet build`, add the foll
 > [!NOTE]
 > When you automatically generate the package, packing increases the build time for your project.
 
-Running `dotnet pack` on a solution packs all the projects in the solution that are packable, that is, have the `IsPackable` property set to `true`.
+Running `dotnet pack` on a solution packs all the projects in the solution that are packable, that is, have the [`IsPackable`](/nuget/reference/msbuild-targets#pack-target-inputs) property set to `true`.
 
 ### Test package installation
 

--- a/docs/create-packages/creating-a-package-msbuild.md
+++ b/docs/create-packages/creating-a-package-msbuild.md
@@ -175,7 +175,7 @@ To automatically run `msbuild -t:pack` when you build or restore the project, ad
 <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 ```
 
-When you run `msbuild -t:pack` on a solution, this packs all the projects in the solution that are packable ([`<IsPackable>`](/dotnet/core/tools/csproj#nuget-metadata-properties) property is set to `true`).
+When you run `msbuild -t:pack` on a solution, this packs all the projects in the solution that are packable ([`<IsPackable>`](/nuget/reference/msbuild-targets#pack-target-inputs) property is set to `true`).
 
 > [!NOTE]
 > When you automatically generate the package, the time to pack increases the build time for your project.


### PR DESCRIPTION
The link from `<IsPackable>` is broken in the [Create a NuGet package using MSBuild](https://learn.microsoft.com/en-us/nuget/create-packages/creating-a-package-msbuild) page.  It points to <https://learn.microsoft.com/dotnet/core/tools/csproj#nuget-metadata-properties>, which was removed in <https://github.com/dotnet/docs/pull/22277>.  Although  <https://learn.microsoft.com/dotnet/core/tools/csproj#nuget-metadata-properties> now redirects to <https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#nuget-metadata-properties>, this page does not mention "IsPackable".

Update the link to point to <https://learn.microsoft.com/nuget/reference/msbuild-targets#pack-target-inputs>, which does describe "IsPackable".

Also make `IsPackable` in [Create a NuGet package with the dotnet CLI](https://learn.microsoft.com/en-us/nuget/create-packages/creating-a-package-dotnet-cli) a link to the same page for consistency.
