### PR TITLE
Clarify that Package Source Mapping applies only to restore/install/update

### DIFF
--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -190,7 +190,7 @@ To ensure your build is predictable and secure from known attacks such as [Depen
 You can use a single feed or private feed with upstreaming capabilities for protection.
 
 When you configure both a public and a private source, client commands that query package metadata (for example, `dotnet package add` and `dotnet list package --outdated/--deprecated/--vulnerable`) send the requested package IDs to every configured source, including public ones.
-[Package Source Mapping](../consume-packages/package-source-mapping.md) doesn't prevent this, because it filters only the package download path used by restore, install, and update.
+[Package Source Mapping](../consume-packages/package-source-mapping.md) doesn't prevent this, because it applies only when NuGet downloads packages during restore, install, and update.
 For the current status of these feature gaps, see the following tracking issues:
 
 * dotnet.exe package commands (`add`, `list package`): [NuGet/Home#12766](https://github.com/NuGet/Home/issues/12766) and [NuGet/Home#11380](https://github.com/NuGet/Home/issues/11380).
@@ -225,8 +225,8 @@ To enable lock files, [see the following documentation](../consume-packages/pack
 
 Package Source Mapping allows you to centrally declare which source each package in your solution should restore from in your nuget.config file.
 
-Package Source Mapping applies to the package download path used by restore, install, and update.
-It doesn't filter the sources that other client commands query for package metadata, so it isn't a complete privacy control on its own.
+Package Source Mapping currently applies only when NuGet downloads packages during restore, install, and update.
+A current limitation is that it doesn't yet filter the sources that other client commands query for package metadata.
 For more information, see [NuGet feeds](#nuget-feeds).
 
 To enable package source mapping, [see the following documentation](../consume-packages/package-source-mapping.md).

--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -188,6 +188,14 @@ When using multiple public & private NuGet source feeds, a package can be downlo
 To ensure your build is predictable and secure from known attacks such as [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610), knowing what specific feed(s) your packages are coming from is a best practice.
 You can use a single feed or private feed with upstreaming capabilities for protection.
 
+When you configure both a public and a private source, client commands that query package metadata (for example, `dotnet package add` and `dotnet list package --outdated/--deprecated/--vulnerable`) send the requested package IDs to every configured source, including public ones.
+[Package Source Mapping](../consume-packages/package-source-mapping.md) doesn't prevent this, because it filters only the package download path used by restore, install, and update.
+For the current status of these feature gaps, see the following tracking issues:
+
+* dotnet.exe package commands (`add`, `list package`): [NuGet/Home#12766](https://github.com/NuGet/Home/issues/12766) and [NuGet/Home#11380](https://github.com/NuGet/Home/issues/11380).
+* Package Manager Console (PMC): [NuGet/Home#11384](https://github.com/NuGet/Home/issues/11384).
+* Package Manager UI (PMUI) in Visual Studio: [NuGet/Home#12783](https://github.com/NuGet/Home/issues/12783).
+
 For more information to secure your package feeds, see [3 Ways to Mitigate Risk When Using Private Package Feeds](https://azure.microsoft.com/resources/3-ways-to-mitigate-risk-using-private-package-feeds/en-us/).
 
 When using a private feed, refer to the [security best practices for managing credentials](../consume-packages/consuming-packages-authenticated-feeds.md#security-best-practices-for-managing-credentials).
@@ -215,6 +223,10 @@ To enable lock files, [see the following documentation](../consume-packages/pack
 **📦 Package Consumer**
 
 Package Source Mapping allows you to centrally declare which source each package in your solution should restore from in your nuget.config file.
+
+Package Source Mapping applies to the package download path used by restore, install, and update.
+It doesn't filter the sources that other client commands query for package metadata, so it isn't a complete privacy control on its own.
+For more information, see [NuGet feeds](#nuget-feeds).
 
 To enable package source mapping, [see the following documentation](../consume-packages/package-source-mapping.md).
 

--- a/docs/concepts/Security-Best-Practices.md
+++ b/docs/concepts/Security-Best-Practices.md
@@ -3,6 +3,7 @@ title: Best practices for a secure software supply chain
 description: Best practices for securing your software supply chain using NuGet & GitHub.
 author: JonDouglas
 ms.author: jodou
+ms.date: 07/16/2026
 ms.topic: best-practice
 ---
 

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -18,23 +18,24 @@ With Package Source Mapping, you can filter, per package, which source(s) NuGet 
 
 We also have suggestions for other [best practices](..\concepts\Security-Best-Practices.md) to help you fortify your supply chain against attacks.
 
-> [!IMPORTANT]
-> Package Source Mapping currently applies only when NuGet downloads packages during restore, install, and update operations.
-> It doesn't yet filter the sources that other client commands query for package metadata.
-> Commands such as [`dotnet package add`](/dotnet/core/tools/dotnet-package-add) and [`dotnet list package`](/dotnet/core/tools/dotnet-list-package) (including `--outdated`, `--deprecated`, and `--vulnerable`) and the Package Manager UI's browse and update metadata lookups send the requested package IDs to *all* configured sources, including public ones.
-> For the current status of these feature gaps, see the following tracking issues:
->
-> * dotnet.exe package commands (`add`, `list package`): [NuGet/Home#12766](https://github.com/NuGet/Home/issues/12766) and [NuGet/Home#11380](https://github.com/NuGet/Home/issues/11380).
-> * Package Manager Console (PMC): [NuGet/Home#11384](https://github.com/NuGet/Home/issues/11384).
-> * Package Manager UI (PMUI) in Visual Studio: [NuGet/Home#12783](https://github.com/NuGet/Home/issues/12783).
->
-> See [Security best practices](..\concepts\Security-Best-Practices.md#nuget-feeds) for more information.
-
 Package Source Mapping was added in [NuGet 6.0](..\release-notes\NuGet-6.0.md).
 Starting with Visual Studio 17.5, you can add and remove Package Source Mappings with the Visual Studio Options Dialog.
 For detailed information on all Visual Studio NuGet options, see [NuGet Options in Visual Studio](nuget-visual-studio-options.md).
 
-### Visual Studio support
+## Scope and limitations
+
+Package Source Mapping currently applies only when NuGet downloads packages during restore, install, and update operations.
+It doesn't yet filter the sources that other client commands query for package metadata.
+Commands such as [`dotnet package add`](/dotnet/core/tools/dotnet-package-add) and [`dotnet list package`](/dotnet/core/tools/dotnet-list-package) (including `--outdated`, `--deprecated`, and `--vulnerable`) and the Package Manager UI's browse and update metadata lookups send the requested package IDs to all configured sources, including public ones.
+For the current status of these feature gaps, see the following tracking issues:
+
+* dotnet.exe package commands (`add`, `list package`): [NuGet/Home#12766](https://github.com/NuGet/Home/issues/12766) and [NuGet/Home#11380](https://github.com/NuGet/Home/issues/11380).
+* Package Manager Console (PMC): [NuGet/Home#11384](https://github.com/NuGet/Home/issues/11384).
+* Package Manager UI (PM UI) in Visual Studio: [NuGet/Home#12783](https://github.com/NuGet/Home/issues/12783).
+
+See [Security best practices](..\concepts\Security-Best-Practices.md#nuget-feeds) for more information.
+
+## Visual Studio support
 
 | Visual Studio | Package Source Mapping | Support in Tools -> Options | Support in Package Manager UI |
 |-----|---------------------|---------------------|---------------------|

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -19,10 +19,9 @@ With Package Source Mapping, you can filter, per package, which source(s) NuGet 
 We also have suggestions for other [best practices](..\concepts\Security-Best-Practices.md) to help you fortify your supply chain against attacks.
 
 > [!IMPORTANT]
-> Package Source Mapping currently applies only to the package download path used by restore, install, and update operations.
+> Package Source Mapping currently applies only when NuGet downloads packages during restore, install, and update operations.
 > It doesn't yet filter the sources that other client commands query for package metadata.
 > Commands such as [`dotnet package add`](/dotnet/core/tools/dotnet-package-add) and [`dotnet list package`](/dotnet/core/tools/dotnet-list-package) (including `--outdated`, `--deprecated`, and `--vulnerable`) and the Package Manager UI's browse and update metadata lookups send the requested package IDs to *all* configured sources, including public ones.
-> If you use a mix of public and private sources, the names of your private packages can reach a public source through these metadata operations even when Package Source Mapping is configured.
 > For the current status of these feature gaps, see the following tracking issues:
 >
 > * dotnet.exe package commands (`add`, `list package`): [NuGet/Home#12766](https://github.com/NuGet/Home/issues/12766) and [NuGet/Home#11380](https://github.com/NuGet/Home/issues/11380).
@@ -217,5 +216,5 @@ For an idea of how your source mappings may look like, refer to our [samples rep
 >
 > * There are no nuget.exe or dotnet.exe commands for managing the package source mapping configuration, see [NuGet/Home#10735](https://github.com/NuGet/Home/issues/10735).
 > * There are no means of mapping packages at package installation time, see [NuGet/Home#10730](https://github.com/NuGet/Home/issues/10730).
-> * Package Source Mapping applies only to the package download path used by restore, install, and update. It doesn't apply to commands that query source metadata, such as `dotnet package add` and `dotnet list package --outdated/--deprecated/--vulnerable`. Those commands send package IDs to all configured sources.
+> * Package Source Mapping applies only when NuGet downloads packages during restore, install, and update. It doesn't apply to commands that query source metadata, such as `dotnet package add` and `dotnet list package --outdated/--deprecated/--vulnerable`. Those commands send package IDs to all configured sources.
 > * There is a limitation when using the `DotNetCoreCLI@2` Azure Pipelines task which can be worked around by using `feed-` prefixes in your source mapping configuration. It is recommended however to use `NuGetAuthenticate` for your authentication needs and call the dotnet cli directly from a script task. See [microsoft/azure-pipelines-tasks#15542](https://github.com/microsoft/azure-pipelines-tasks/issues/15542).

--- a/docs/consume-packages/Package-Source-Mapping.md
+++ b/docs/consume-packages/Package-Source-Mapping.md
@@ -3,7 +3,7 @@ title: Package Source Mapping
 description: Describes package source mapping functionality and how to onboard
 author: nkolev92
 ms.author: nikolev
-ms.date: 12/29/2025
+ms.date: 07/16/2026
 ms.update-cycle: 1095-days
 ms.topic: how-to
 ---
@@ -17,6 +17,19 @@ When a package exists on multiple sources, it may not be deterministic which sou
 With Package Source Mapping, you can filter, per package, which source(s) NuGet will search.
 
 We also have suggestions for other [best practices](..\concepts\Security-Best-Practices.md) to help you fortify your supply chain against attacks.
+
+> [!IMPORTANT]
+> Package Source Mapping currently applies only to the package download path used by restore, install, and update operations.
+> It doesn't yet filter the sources that other client commands query for package metadata.
+> Commands such as [`dotnet package add`](/dotnet/core/tools/dotnet-package-add) and [`dotnet list package`](/dotnet/core/tools/dotnet-list-package) (including `--outdated`, `--deprecated`, and `--vulnerable`) and the Package Manager UI's browse and update metadata lookups send the requested package IDs to *all* configured sources, including public ones.
+> If you use a mix of public and private sources, the names of your private packages can reach a public source through these metadata operations even when Package Source Mapping is configured.
+> For the current status of these feature gaps, see the following tracking issues:
+>
+> * dotnet.exe package commands (`add`, `list package`): [NuGet/Home#12766](https://github.com/NuGet/Home/issues/12766) and [NuGet/Home#11380](https://github.com/NuGet/Home/issues/11380).
+> * Package Manager Console (PMC): [NuGet/Home#11384](https://github.com/NuGet/Home/issues/11384).
+> * Package Manager UI (PMUI) in Visual Studio: [NuGet/Home#12783](https://github.com/NuGet/Home/issues/12783).
+>
+> See [Security best practices](..\concepts\Security-Best-Practices.md#nuget-feeds) for more information.
 
 Package Source Mapping was added in [NuGet 6.0](..\release-notes\NuGet-6.0.md).
 Starting with Visual Studio 17.5, you can add and remove Package Source Mappings with the Visual Studio Options Dialog.
@@ -204,4 +217,5 @@ For an idea of how your source mappings may look like, refer to our [samples rep
 >
 > * There are no nuget.exe or dotnet.exe commands for managing the package source mapping configuration, see [NuGet/Home#10735](https://github.com/NuGet/Home/issues/10735).
 > * There are no means of mapping packages at package installation time, see [NuGet/Home#10730](https://github.com/NuGet/Home/issues/10730).
+> * Package Source Mapping applies only to the package download path used by restore, install, and update. It doesn't apply to commands that query source metadata, such as `dotnet package add` and `dotnet list package --outdated/--deprecated/--vulnerable`. Those commands send package IDs to all configured sources.
 > * There is a limitation when using the `DotNetCoreCLI@2` Azure Pipelines task which can be worked around by using `feed-` prefixes in your source mapping configuration. It is recommended however to use `NuGetAuthenticate` for your authentication needs and call the dotnet cli directly from a script task. See [microsoft/azure-pipelines-tasks#15542](https://github.com/microsoft/azure-pipelines-tasks/issues/15542).

--- a/docs/nuget-org/Deprecate-packages.md
+++ b/docs/nuget-org/Deprecate-packages.md
@@ -1,9 +1,9 @@
 ---
 title: Deprecating packages on nuget.org
 description: Detailed description on the process of deprecating packages and how the clients shows this information
-author: anangaur
-ms.author: anangaur
-ms.date: 09/23/2019
+author: donnie-msft
+ms.author: eagoodso
+ms.date: 07/16/2026
 ms.topic: how-to
 ms.reviewer: karann-msft
 ---

--- a/docs/nuget-org/Deprecate-packages.md
+++ b/docs/nuget-org/Deprecate-packages.md
@@ -62,6 +62,10 @@ Project `My.Test.Project` has the following deprecated packages
 
 ```
 
+> [!NOTE]
+> [Package Source Mapping](../consume-packages/package-source-mapping.md) doesn't apply to `dotnet list package --deprecated`.
+> The command queries all configured sources for deprecation metadata, sending your package IDs to every source, including public ones.
+
 ## Transfer popularity to a newer package
 
 Package authors who have deprecated a legacy package can choose to transfer its "popularity" to a newer package to boost the newer package's search ranking. This helps customers discover the newer package instead of the deprecated package.

--- a/docs/reference/nuget-config-file.md
+++ b/docs/reference/nuget-config-file.md
@@ -382,6 +382,11 @@ The `packageSourceMapping` section contains the details that help the NuGet pack
 
 This section can only be managed manually right now.
 
+> [!NOTE]
+> `packageSourceMapping` filters only the package download path used by restore, install, and update.
+> It doesn't apply to commands that query source metadata, such as `dotnet package add` and `dotnet list package --outdated/--deprecated/--vulnerable`, which send package IDs to all configured sources.
+> For more information, see [Package Source Mapping](../consume-packages/package-source-mapping.md).
+
 A `packageSourceMapping` section can only contain `packageSource` sections.
 
 ### packageSource


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/15001

- **`Package-Source-Mapping.md`** — Added a scope note (and expanded the limitations list) stating PSM only affects the restore/install/update download path. Sets clear expectations up front so users know metadata commands aren't covered.
- **`Security-Best-Practices.md`** — Clarified in the **NuGet feeds** and **Package Source mapping** sections that metadata commands send package IDs to all sources, with tracking issues grouped by tool. Gives security-minded readers informed consent about the privacy implication where they'd look for it.
- **`nuget-config-file.md`** — Added a scope note to the `packageSourceMapping` section. Warns users at the point of configuration that PSM doesn't cover metadata operations.
- **`Deprecate-packages.md`** — Noted that `dotnet list package --deprecated` queries all sources. 
- **Scope correctness** — Excluded non-leaking commands (`nuget search`/`nuget list`, `dotnet package search`, `dotnet nuget why`) and dropped `dotnet package update` (already honors PSM per https://github.com/NuGet/Home/issues/14307). 
