### PR TITLE
Doc for package signing certificates on NuGet.org

### DIFF
--- a/docs/nuget-org/TOC.md
+++ b/docs/nuget-org/TOC.md
@@ -3,6 +3,7 @@
 ## [Individual accounts](individual-accounts.md)
 ## [Organizations](organizations-on-nuget-org.md)
 ## [API keys](scoped-api-keys.md)
+## [Signing certificates](package-signing-certificates.md)
 # Manage packages on NuGet.org
 ## [Publish a package](publish-a-package.md)
 ## [Package ID prefix reservation](id-prefix-reservation.md)

--- a/docs/nuget-org/package-signing-certificates.md
+++ b/docs/nuget-org/package-signing-certificates.md
@@ -9,11 +9,14 @@ ms.topic: how-to
 
 # Package signing certificates on NuGet.org
 
-NuGet.org lets you register one or more code signing certificates on your individual account or organization. You manage registered certificates in the **Certificates** section of the account or organization settings page.
+NuGet.org lets you register one or more code signing certificates on your individual account or organization.
+You manage registered certificates in the **Certificates** section of the account or organization settings page.
 
-Once you register at least one certificate, NuGet.org requires every package that account pushes to be author-signed with one of the registered certificates. This is referred to as **required author signing**.
+Once you register at least one certificate, NuGet.org requires every package that account pushes to be author-signed with one of the registered certificates.
+This is referred to as **required author signing**.
 
-This article describes the effect of registering a certificate and how to manage certificates on NuGet.org. For how package signatures work and the requirements NuGet.org enforces on each signature, see [Signed package reference](../reference/Signed-Packages-Reference.md).
+This article describes the effect of registering a certificate and how to manage certificates on NuGet.org.
+To learn how package signatures work and the requirements NuGet.org enforces on each signature, see [Signed package reference](../reference/Signed-Packages-Reference.md).
 
 ## What happens when you register a certificate
 
@@ -25,10 +28,14 @@ Once you register **one or more** certificates on an account:
 - NuGet.org **rejects packages author-signed with a certificate that isn't registered** to the account.
 - Packages author-signed with **any one** of the registered certificates are accepted, provided the signature also meets the [signature requirements on NuGet.org](#signature-requirements-on-nugetorg).
 
-This applies to **new versions** you push after enrollment. Package versions that were already published remain available and are not affected.
+This applies to **new versions** you push after enrollment.
+Package versions that were already published remain available and are not affected.
 
 > [!IMPORTANT]
-> After you register a certificate, you must author-sign every subsequent push from that account with a registered certificate. If you push an unsigned package, or a package signed with an unregistered certificate, the push is rejected. Author signing is produced with `nuget.exe sign`. For a walkthrough, see [Sign a package](../create-packages/Sign-a-Package.md).
+> After you register a certificate, you must author-sign every subsequent push from that account with a registered certificate.
+> If you push an unsigned package, or a package signed with an unregistered certificate, the push is rejected.
+> Author signing is produced with `nuget.exe sign`.
+> For a walkthrough, see [Sign a package](../create-packages/Sign-a-Package.md).
 
 ## Signature requirements on NuGet.org
 
@@ -43,7 +50,7 @@ NuGet.org has additional requirements for accepting a signed package:
   - Must be valid for its purpose:
     - The author signing certificate must be valid for code signing.
     - The timestamp certificate must be valid for timestamping.
-  - Must not be revoked at signing time. (This may not be knowable at submission time, so NuGet.org periodically rechecks revocation status.)
+  - Must not be revoked at signing time. (This might not be knowable at submission time, so NuGet.org periodically rechecks revocation status.)
 
 ## Register a certificate
 
@@ -54,26 +61,31 @@ To register a certificate, you must have a confirmed email address and be signed
 1. Expand the **Certificates** section.
 1. Select **Register new** and upload your public code signing certificate as a DER-encoded `.cer` file.
 
-Only the public certificate is uploaded. Never upload or share the private key associated with your signing certificate.
+Only the public certificate is uploaded.
+Never upload or share the private key associated with your signing certificate.
 
-You can register more than one certificate on an account. This is useful when rotating to a new certificate or when different build environments use different certificates: a package author-signed with any one of the registered certificates is accepted.
+You can register more than one certificate on an account.
+This is useful when rotating to a new certificate or when different build environments use different certificates: a package author-signed with any one of the registered certificates is accepted.
 
 ## Remove a certificate
 
 You can remove a registered certificate from the **Certificates** section of the account or organization settings page.
 
 - If the account still has **at least one** registered certificate after removal, required author signing remains in effect and packages must be signed with one of the remaining certificates.
-- If you remove the **last** registered certificate, the account is no longer enrolled in required author signing. It can once again push unsigned packages or packages signed with any valid certificate.
+- If you remove the **last** registered certificate, the account is no longer enrolled in required author signing. The account can once again push unsigned packages or packages signed with any valid certificate.
 
 ## Packages with multiple owners
 
-A package can have multiple owners, and each owner can independently register certificates. The signing requirement for a co-owned package depends on the owners' certificate state:
+A package can have multiple owners, and each owner can independently register certificates.
+The signing requirement for a co-owned package depends on the owners' certificate state:
 
 - If **all** owners have at least one registered certificate, future versions **must** be signed.
 - If **no** owner has a registered certificate, future versions **must** be unsigned.
-- If **some** owners have certificates and others don't, future versions **may** be unsigned or signed with a certificate registered to any owner.
+- If **some** owners have certificates and others don't, future versions **might** be unsigned or signed with a certificate registered to any owner.
 
-To make the requirement unambiguous for a co-owned package, you can designate a **required signer**. The required signer's certificate state alone determines whether that package's future versions must be signed, and only the required signer's registered certificates are accepted. You can set the required signer from the **Manage Packages** page.
+To make the requirement unambiguous for a co-owned package, you can designate a **required signer**.
+The required signer's certificate state alone determines whether that package's future versions must be signed, and only the required signer's registered certificates are accepted.
+You can set the required signer from the **Manage Packages** page.
 
 ## Related articles
 

--- a/docs/nuget-org/package-signing-certificates.md
+++ b/docs/nuget-org/package-signing-certificates.md
@@ -11,7 +11,7 @@ ms.topic: how-to
 
 NuGet.org lets you register one or more code signing certificates on your individual account or organization. You manage registered certificates in the **Certificates** section of the account or organization settings page.
 
-Registering a certificate changes what NuGet.org accepts from that account: once at least one certificate is registered, the account is required to author-sign the packages it pushes with a registered certificate. This is referred to as **required author signing**.
+Once you register at least one certificate, NuGet.org requires every package that account pushes to be author-signed with one of the registered certificates. This is referred to as **required author signing**.
 
 This article describes the effect of registering a certificate and how to manage certificates on NuGet.org. For how package signatures work and the requirements NuGet.org enforces on each signature, see [Signed package reference](../reference/Signed-Packages-Reference.md).
 

--- a/docs/nuget-org/package-signing-certificates.md
+++ b/docs/nuget-org/package-signing-certificates.md
@@ -1,0 +1,83 @@
+---
+title: Package signing certificates on NuGet.org
+description: Register signing certificates on your NuGet.org account or organization to require author-signed packages.
+author: pranathibora14
+ms.author: prabora
+ms.date: 07/23/2026
+ms.topic: how-to
+---
+
+# Package signing certificates on NuGet.org
+
+NuGet.org lets you register one or more code signing certificates on your individual account or organization. You manage registered certificates in the **Certificates** section of the account or organization settings page.
+
+Registering a certificate changes what NuGet.org accepts from that account: once at least one certificate is registered, the account is required to author-sign the packages it pushes with a registered certificate. This is referred to as **required author signing**.
+
+This article describes the effect of registering a certificate and how to manage certificates on NuGet.org. For how package signatures work and the requirements NuGet.org enforces on each signature, see [Signed package reference](../reference/Signed-Packages-Reference.md).
+
+## What happens when you register a certificate
+
+Before you register any certificate, the account can push both unsigned packages and packages signed with any (otherwise valid) certificate.
+
+Once you register **one or more** certificates on an account:
+
+- NuGet.org **rejects unsigned packages** pushed by that account.
+- NuGet.org **rejects packages author-signed with a certificate that isn't registered** to the account.
+- Packages author-signed with **any one** of the registered certificates are accepted, provided the signature also meets the [signature requirements on NuGet.org](#signature-requirements-on-nugetorg).
+
+This applies to **new versions** you push after enrollment. Package versions that were already published remain available and are not affected.
+
+> [!IMPORTANT]
+> After you register a certificate, you must author-sign every subsequent push from that account with a registered certificate. If you push an unsigned package, or a package signed with an unregistered certificate, the push is rejected. Author signing is produced with `nuget.exe sign`. For a walkthrough, see [Sign a package](../create-packages/Sign-a-Package.md).
+
+## Signature requirements on NuGet.org
+
+NuGet.org has additional requirements for accepting a signed package:
+
+- The primary signature must be an author signature.
+- The primary signature must have a single valid timestamp.
+- The X.509 certificates for both the author signature and its timestamp signature:
+  - Must have an RSA public key 2048 bits or greater.
+  - Must be within its validity period per current UTC time at time of package validation on NuGet.org.
+  - Must chain to a trusted root authority that is trusted by default on Windows. Packages signed with self-issued certificates are rejected.
+  - Must be valid for its purpose:
+    - The author signing certificate must be valid for code signing.
+    - The timestamp certificate must be valid for timestamping.
+  - Must not be revoked at signing time. (This may not be knowable at submission time, so NuGet.org periodically rechecks revocation status.)
+
+## Register a certificate
+
+To register a certificate, you must have a confirmed email address and be signed in with two-factor authentication (2FA).
+
+1. Sign in to [NuGet.org](https://www.nuget.org).
+1. Go to your [account settings](https://www.nuget.org/account) (for an individual account) or your [organization's settings](https://www.nuget.org/account/organizations) (for an organization).
+1. Expand the **Certificates** section.
+1. Select **Register new** and upload your public code signing certificate as a DER-encoded `.cer` file.
+
+Only the public certificate is uploaded. Never upload or share the private key associated with your signing certificate.
+
+You can register more than one certificate on an account. This is useful when rotating to a new certificate or when different build environments use different certificates: a package author-signed with any one of the registered certificates is accepted.
+
+## Remove a certificate
+
+You can remove a registered certificate from the **Certificates** section of the account or organization settings page.
+
+- If the account still has **at least one** registered certificate after removal, required author signing remains in effect and packages must be signed with one of the remaining certificates.
+- If you remove the **last** registered certificate, the account is no longer enrolled in required author signing. It can once again push unsigned packages or packages signed with any valid certificate.
+
+## Packages with multiple owners
+
+A package can have multiple owners, and each owner can independently register certificates. The signing requirement for a co-owned package depends on the owners' certificate state:
+
+- If **all** owners have at least one registered certificate, future versions **must** be signed.
+- If **no** owner has a registered certificate, future versions **must** be unsigned.
+- If **some** owners have certificates and others don't, future versions **may** be unsigned or signed with a certificate registered to any owner.
+
+To make the requirement unambiguous for a co-owned package, you can designate a **required signer**. The required signer's certificate state alone determines whether that package's future versions must be signed, and only the required signer's registered certificates are accepted. You can set the required signer from the **Manage Packages** page.
+
+## Related articles
+
+- [Signed package reference](../reference/Signed-Packages-Reference.md)
+- [Sign a package](../create-packages/Sign-a-Package.md)
+- [Individual accounts on NuGet.org](individual-accounts.md)
+- [Organizations on NuGet.org](organizations-on-nuget-org.md)

--- a/docs/nuget-org/package-signing-certificates.md
+++ b/docs/nuget-org/package-signing-certificates.md
@@ -68,7 +68,7 @@ A package can have multiple owners, and each owner can independently register ce
 NuGet.org computes the author-signing policy per package ID from that package's owners and any configured required signer:
 
 - **No required signer:** signing is allowed when any owner has a registered certificate and required only when every owner has one. A signed package can use a certificate registered to any owner.
-- **A required signer is set:** only that account's certificate state matters for these signing calculations. If it has certificates, signing is required and only its certificates are accepted. If it has none, asynchronous signature validation rejects every author-signed submission, even when another owner has certificates.
+- **A required signer is set:** only that account's certificate state matters for these signing calculations. If it has certificates, signing is required, and only its certificates are accepted. If it has none, asynchronous signature validation rejects every author-signed submission, even when another owner has certificates.
 
 You can set the required signer from the **Manage Packages** page.
 

--- a/docs/nuget-org/package-signing-certificates.md
+++ b/docs/nuget-org/package-signing-certificates.md
@@ -12,54 +12,42 @@ ms.topic: how-to
 NuGet.org lets you register one or more code signing certificates on your individual account or organization.
 You manage registered certificates in the **Certificates** section of the account or organization settings page.
 
-Once you register at least one certificate, NuGet.org requires every package that account pushes to be author-signed with one of the registered certificates.
-This is referred to as **required author signing**.
+Registering a certificate can change the author-signing requirements for the package IDs associated with that account.
+NuGet.org determines these requirements separately for each package ID, based on its owners and any configured required signer.
+When future versions of a package must be author-signed, this is referred to as **required author signing**.
 
 This article describes the effect of registering a certificate and how to manage certificates on NuGet.org.
 To learn how package signatures work and the requirements NuGet.org enforces on each signature, see [Signed package reference](../reference/Signed-Packages-Reference.md).
 
 ## What happens when you register a certificate
 
-Before you register any certificate, the account can push both unsigned packages and packages signed with any (otherwise valid) certificate.
+For a package ID that you solely own and that has no other required signer:
 
-Once you register **one or more** certificates on an account:
+- Before you register any certificate, you can push both unsigned packages and packages signed with any (otherwise valid) certificate.
+- After you register **one or more** certificates, new versions must be author-signed with one of your registered certificates. Unsigned packages, and packages signed with a certificate that isn't registered, aren't accepted.
 
-- NuGet.org **rejects unsigned packages** pushed by that account.
-- NuGet.org **rejects packages author-signed with a certificate that isn't registered** to the account.
-- Packages author-signed with **any one** of the registered certificates are accepted, provided the signature also meets the [signature requirements on NuGet.org](#signature-requirements-on-nugetorg).
+For packages with more than one owner, see [Packages with multiple owners](#packages-with-multiple-owners).
 
-This applies to **new versions** you push after enrollment.
-Package versions that were already published remain available and are not affected.
+These requirements apply to **new versions** you push after registering a certificate.
+Versions that were already published remain available and are not affected.
+
+NuGet.org enforces the signing requirement during asynchronous validation after a package is uploaded.
+A submission that doesn't meet the requirement fails validation and isn't published, rather than being rejected when the push is first received.
 
 > [!IMPORTANT]
-> After you register a certificate, you must author-sign every subsequent push from that account with a registered certificate.
-> If you push an unsigned package, or a package signed with an unregistered certificate, the push is rejected.
-> Author signing is produced with `nuget.exe sign`.
+> After you register a certificate, you must author-sign every subsequent version you publish for the affected package IDs with a registered certificate.
+> If you submit an unsigned package, or a package signed with an unregistered certificate, the version fails validation and isn't published.
 > For a walkthrough, see [Sign a package](../create-packages/Sign-a-Package.md).
 
 ## Signature requirements on NuGet.org
 
-NuGet.org has additional requirements for accepting a signed package:
-
-- The primary signature must be an author signature.
-- The primary signature must have a single valid timestamp.
-- The X.509 certificates for both the author signature and its timestamp signature:
-  - Must have an RSA public key 2048 bits or greater.
-  - Must be within its validity period per current UTC time at time of package validation on NuGet.org.
-  - Must chain to a trusted root authority that is trusted by default on Windows. Packages signed with self-issued certificates are rejected.
-  - Must be valid for its purpose:
-    - The author signing certificate must be valid for code signing.
-    - The timestamp certificate must be valid for timestamping.
-  - Must not be revoked at signing time. (This might not be knowable at submission time, so NuGet.org periodically rechecks revocation status.)
+Registering a certificate doesn't change the requirements NuGet.org enforces on each signature.
+For the full list of signature and certificate requirements, see [Signature requirements on NuGet.org](../reference/Signed-Packages-Reference.md#signature-requirements-on-nugetorg).
 
 ## Register a certificate
 
-To register a certificate, you must have a confirmed email address and be signed in with two-factor authentication (2FA).
-
-1. Sign in to [NuGet.org](https://www.nuget.org).
-1. Go to your [account settings](https://www.nuget.org/account) (for an individual account) or your [organization's settings](https://www.nuget.org/account/organizations) (for an organization).
-1. Expand the **Certificates** section.
-1. Select **Register new** and upload your public code signing certificate as a DER-encoded `.cer` file.
+You register a certificate from the **Certificates** section of your account or organization settings page, uploading your public code signing certificate as a DER-encoded `.cer` file.
+For the step-by-step walkthrough, see [Register the certificate on NuGet.org](../create-packages/Sign-a-Package.md#register-the-certificate-on-nugetorg).
 
 Only the public certificate is uploaded.
 Never upload or share the private key associated with your signing certificate.
@@ -77,15 +65,15 @@ You can remove a registered certificate from the **Certificates** section of the
 ## Packages with multiple owners
 
 A package can have multiple owners, and each owner can independently register certificates.
-The signing requirement for a co-owned package depends on the owners' certificate state:
+NuGet.org computes the author-signing policy per package ID from that package's owners and any configured required signer:
 
-- If **all** owners have at least one registered certificate, future versions **must** be signed.
-- If **no** owner has a registered certificate, future versions **must** be unsigned.
-- If **some** owners have certificates and others don't, future versions **might** be unsigned or signed with a certificate registered to any owner.
+- **No required signer:** signing is allowed when any owner has a registered certificate and required only when every owner has one. A signed package can use a certificate registered to any owner.
+- **A required signer is set:** only that account's certificate state matters for these signing calculations. If it has certificates, signing is required and only its certificates are accepted. If it has none, asynchronous signature validation rejects every author-signed submission, even when another owner has certificates.
 
-To make the requirement unambiguous for a co-owned package, you can designate a **required signer**.
-The required signer's certificate state alone determines whether that package's future versions must be signed, and only the required signer's registered certificates are accepted.
 You can set the required signer from the **Manage Packages** page.
+
+> [!NOTE]
+> A publisher can also push on behalf of multiple organizations, each with independent certificate registrations, while each package ID retains its own policy.
 
 ## Related articles
 


### PR DESCRIPTION
Adds a new server-side doc page describing the account certificates feature and its enrollment consequence, addressing https://github.com/NuGet/NuGetGallery/issues/10910.